### PR TITLE
Add release automation, bump to v0.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,19 @@
-name: CI
+name: Build
 
 on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
+  release:
+    types: [created, published]
+
+permissions:
+  contents: write
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -34,3 +39,51 @@ jobs:
 
       - name: Run tests
         run: dotnet test tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj -c Release --no-build --verbosity normal
+
+      - name: Get version
+        id: version
+        shell: pwsh
+        run: |
+          $version = ([xml](Get-Content src/PlanViewer.App/PlanViewer.App.csproj)).Project.PropertyGroup.Version | Where-Object { $_ }
+          echo "VERSION=$version" >> $env:GITHUB_OUTPUT
+
+      - name: Publish App
+        run: dotnet publish src/PlanViewer.App/PlanViewer.App.csproj -c Release -o publish/App
+
+      - name: Publish CLI
+        run: dotnet publish src/PlanViewer.Cli/PlanViewer.Cli.csproj -c Release -o publish/Cli
+
+      - name: Package release artifacts
+        if: github.event_name == 'release'
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.VERSION }}"
+          New-Item -ItemType Directory -Force -Path releases
+
+          # App ZIP
+          if (Test-Path 'README.md') { Copy-Item 'README.md' 'publish/App/' }
+          if (Test-Path 'LICENSE') { Copy-Item 'LICENSE' 'publish/App/' }
+          Compress-Archive -Path 'publish/App/*' -DestinationPath "releases/PerformanceStudio-$version.zip" -Force
+
+          # CLI ZIP
+          if (Test-Path 'LICENSE') { Copy-Item 'LICENSE' 'publish/Cli/' }
+          Compress-Archive -Path 'publish/Cli/*' -DestinationPath "releases/PerformanceStudioCli-$version.zip" -Force
+
+      - name: Generate checksums
+        if: github.event_name == 'release'
+        shell: pwsh
+        run: |
+          $checksums = Get-ChildItem releases/*.zip | ForEach-Object {
+            $hash = (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLower()
+            "$hash  $($_.Name)"
+          }
+          $checksums | Out-File -FilePath releases/SHA256SUMS.txt -Encoding utf8
+          Write-Host "Checksums:"
+          $checksums | ForEach-Object { Write-Host $_ }
+
+      - name: Upload release assets
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} releases/*.zip releases/SHA256SUMS.txt --clobber

--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Cli/PlanViewer.Cli.csproj
+++ b/src/PlanViewer.Cli/PlanViewer.Cli.csproj
@@ -11,10 +11,10 @@
     <Nullable>enable</Nullable>
     <RootNamespace>PlanViewer.Cli</RootNamespace>
     <AssemblyName>planview</AssemblyName>
-    <Version>0.5.0</Version>
+    <Version>0.8.0</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
-    <Product>SQL Performance Studio</Product>
+    <Product>Performance Studio</Product>
     <Copyright>Copyright (c) 2026 Erik Darling, Darling Data LLC</Copyright>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- Update CI workflow to auto-package and upload release zips (matching PerformanceMonitor pattern)
- Produces `PerformanceStudio-{version}.zip` (App) and `PerformanceStudioCli-{version}.zip` (CLI) with SHA256 checksums
- Bump version to 0.8.0 across App and CLI
- Fix CLI product name to "Performance Studio"

## How it works
- CI triggers on PRs to dev/main (build + test only)
- On GitHub release creation, publishes both projects and uploads zips + checksums as release assets

## Test plan
- [x] Build passes locally (Release config, 0 errors)
- [ ] Create a release on GitHub → verify zips auto-attach

🤖 Generated with [Claude Code](https://claude.com/claude-code)