### PR TITLE
Fix release artifacts to match v0.7.0 format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main, dev]
   release:
-    types: [created, published]
+    types: [published]
 
 permissions:
   contents: write
@@ -40,34 +40,26 @@ jobs:
       - name: Run tests
         run: dotnet test tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj -c Release --no-build --verbosity normal
 
-      - name: Get version
-        id: version
-        shell: pwsh
+      - name: Publish App (all platforms)
+        if: github.event_name == 'release'
         run: |
-          $version = ([xml](Get-Content src/PlanViewer.App/PlanViewer.App.csproj)).Project.PropertyGroup.Version | Where-Object { $_ }
-          echo "VERSION=$version" >> $env:GITHUB_OUTPUT
-
-      - name: Publish App
-        run: dotnet publish src/PlanViewer.App/PlanViewer.App.csproj -c Release -o publish/App
-
-      - name: Publish CLI
-        run: dotnet publish src/PlanViewer.Cli/PlanViewer.Cli.csproj -c Release -o publish/Cli
+          dotnet publish src/PlanViewer.App/PlanViewer.App.csproj -c Release -r win-x64 --self-contained -o publish/win-x64
+          dotnet publish src/PlanViewer.App/PlanViewer.App.csproj -c Release -r linux-x64 --self-contained -o publish/linux-x64
+          dotnet publish src/PlanViewer.App/PlanViewer.App.csproj -c Release -r osx-x64 --self-contained -o publish/osx-x64
+          dotnet publish src/PlanViewer.App/PlanViewer.App.csproj -c Release -r osx-arm64 --self-contained -o publish/osx-arm64
 
       - name: Package release artifacts
         if: github.event_name == 'release'
         shell: pwsh
         run: |
-          $version = "${{ steps.version.outputs.VERSION }}"
           New-Item -ItemType Directory -Force -Path releases
 
-          # App ZIP
-          if (Test-Path 'README.md') { Copy-Item 'README.md' 'publish/App/' }
-          if (Test-Path 'LICENSE') { Copy-Item 'LICENSE' 'publish/App/' }
-          Compress-Archive -Path 'publish/App/*' -DestinationPath "releases/PerformanceStudio-$version.zip" -Force
-
-          # CLI ZIP
-          if (Test-Path 'LICENSE') { Copy-Item 'LICENSE' 'publish/Cli/' }
-          Compress-Archive -Path 'publish/Cli/*' -DestinationPath "releases/PerformanceStudioCli-$version.zip" -Force
+          $rids = @('win-x64', 'linux-x64', 'osx-x64', 'osx-arm64')
+          foreach ($rid in $rids) {
+            if (Test-Path 'README.md') { Copy-Item 'README.md' "publish/$rid/" }
+            if (Test-Path 'LICENSE') { Copy-Item 'LICENSE' "publish/$rid/" }
+            Compress-Archive -Path "publish/$rid/*" -DestinationPath "releases/PerformanceStudio-$rid.zip" -Force
+          }
 
       - name: Generate checksums
         if: github.event_name == 'release'


### PR DESCRIPTION
## Summary
- Publish self-contained per-platform builds (win-x64, linux-x64, osx-x64, osx-arm64)
- Name zips with platform suffix matching v0.7.0: `PerformanceStudio-win-x64.zip`, etc.
- Single `published` trigger (no duplicate workflow runs)

## v0.7.0 assets (target)
```
PerformanceStudio-win-x64.zip
PerformanceStudio-linux-x64.zip
PerformanceStudio-osx-x64.zip
PerformanceStudio-osx-arm64.zip
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)