### PR TITLE
Add PR branch check and version bump check

### DIFF
--- a/.github/workflows/check-pr-branch.yml
+++ b/.github/workflows/check-pr-branch.yml
@@ -1,0 +1,21 @@
+name: Check pull request target branch
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+jobs:
+  check-branches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branches
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ "$HEAD_REF" != "dev" ] && [ "$BASE_REF" == "main" ]; then
+            echo "::error::Pull requests to main are only allowed from dev. Please target the dev branch instead."
+            exit 1
+          fi

--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -1,0 +1,48 @@
+name: Check version bump
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-version:
+    if: github.head_ref == 'dev'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+
+      - name: Get PR version
+        id: pr
+        shell: pwsh
+        run: |
+          $version = ([xml](Get-Content src/PlanViewer.App/PlanViewer.App.csproj)).Project.PropertyGroup.Version | Where-Object { $_ }
+          echo "VERSION=$version" >> $env:GITHUB_OUTPUT
+          Write-Host "PR version: $version"
+
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: main-branch
+
+      - name: Get main version
+        id: main
+        shell: pwsh
+        run: |
+          $version = ([xml](Get-Content main-branch/src/PlanViewer.App/PlanViewer.App.csproj)).Project.PropertyGroup.Version | Where-Object { $_ }
+          echo "VERSION=$version" >> $env:GITHUB_OUTPUT
+          Write-Host "Main version: $version"
+
+      - name: Compare versions
+        env:
+          PR_VERSION: ${{ steps.pr.outputs.VERSION }}
+          MAIN_VERSION: ${{ steps.main.outputs.VERSION }}
+        run: |
+          echo "Main version: $MAIN_VERSION"
+          echo "PR version:   $PR_VERSION"
+          if [ "$PR_VERSION" == "$MAIN_VERSION" ]; then
+            echo "::error::Version in PlanViewer.App.csproj ($PR_VERSION) has not changed from main. Bump the version before merging to main."
+            exit 1
+          fi
+          echo "✅ Version bumped: $MAIN_VERSION → $PR_VERSION"


### PR DESCRIPTION
## Summary
Two new guard workflows:

### check-pr-branch.yml
Blocks PRs to main from anything other than dev. Feature branches must target dev.

### check-version-bump.yml
When dev PRs to main, compares the version in `PlanViewer.App.csproj` against main. Fails if the version hasn't been bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)