### PR TITLE
Add THIRD_PARTY_NOTICES.md, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A cross-platform SQL Server execution plan analyzer with built-in MCP server for
 
 Built for developers and DBAs who want fast, automated plan analysis without clicking through SSMS.
 
+## Screenshots
+
+*Screenshots coming soon — see the [screenshots/](screenshots/) folder.*
+
 ## What It Does
 
 Feed it a query plan and it tells you what's wrong:
@@ -260,7 +264,7 @@ A VSIX extension that adds **"Open in Performance Studio"** to the execution pla
 
 ### Installation
 
-1. Download both `PlanViewer.Ssms.vsix` and `InstallSsmsExtension.exe` from the [latest release](https://github.com/erikdarlingdata/PerformanceStudio/releases)
+1. Download `PlanViewer.Ssms.vsix` and `InstallSsmsExtension.exe` from the [v0.7.0 release](https://github.com/erikdarlingdata/PerformanceStudio/releases/tag/v0.7.0) (SSMS extension is not yet included in automated builds)
 2. Place them in the same folder
 3. Double-click `InstallSsmsExtension.exe` and approve the UAC prompt
 4. The installer auto-detects SSMS 21 and/or SSMS 22 and installs into both
@@ -433,4 +437,6 @@ Rules can be disabled or have their severity overridden via a `.planview.json` c
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).
+
+Execution plan operator icons are from Microsoft's [vscode-mssql](https://github.com/microsoft/vscode-mssql) extension (MIT). See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) for details.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,49 @@
+# Third-Party Notices
+
+Performance Studio includes the following third-party open-source components. Each component is subject to the license terms specified below.
+
+---
+
+## vscode-mssql (Execution Plan Icons)
+
+**Author**: Microsoft Corporation
+**Repository**: https://github.com/microsoft/vscode-mssql
+**License**: MIT License
+
+Execution plan operator icons (PNG) from the vscode-mssql extension are used to render graphical execution plans. Icons are located in `src/PlanViewer.Core/Resources/PlanIcons/`.
+
+### License Text
+
+MIT License
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Full license: https://github.com/microsoft/vscode-mssql/blob/main/LICENSE
+
+---
+
+## Acknowledgments
+
+Performance Studio uses execution plan operator icons from **Microsoft's vscode-mssql extension**, which provides SQL Server tooling for Visual Studio Code. We are grateful for their commitment to open-source software.
+
+---
+
+*Last Updated: March 5, 2026*


### PR DESCRIPTION
## Summary
- Add THIRD_PARTY_NOTICES.md crediting vscode-mssql for execution plan operator icons (MIT)
- Add screenshots placeholder section to README (will be populated with images)
- Fix SSMS extension download link — points to v0.7.0 since SSMS isn't in automated builds yet
- Link THIRD_PARTY_NOTICES from license section

🤖 Generated with [Claude Code](https://claude.com/claude-code)