### PR TITLE
Fix MCP transport type: streamable-http → http

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ The desktop GUI includes an embedded [Model Context Protocol](https://modelconte
 2. Register with Claude Code:
 
 ```
-claude mcp add --transport streamable-http --scope user performance-studio http://localhost:5152/
+claude mcp add --transport http --scope user performance-studio http://localhost:5152/
 ```
 
 3. Open a new Claude Code session and ask questions like:

--- a/src/PlanViewer.App/Mcp/McpInstructions.cs
+++ b/src/PlanViewer.App/Mcp/McpInstructions.cs
@@ -105,7 +105,7 @@ internal static class McpInstructions
         {
           "mcpServers": {
             "performance-studio": {
-              "type": "streamable-http",
+              "type": "http",
               "url": "http://localhost:5152/"
             }
           }


### PR DESCRIPTION
Claude Code CLI uses `http` not `streamable-http`. Fixed in README and McpInstructions.