### PR TITLE
Bump version to 0.8.1

### DIFF
--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>0.8.0</Version>
+    <Version>0.8.1</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Cli/PlanViewer.Cli.csproj
+++ b/src/PlanViewer.Cli/PlanViewer.Cli.csproj
@@ -11,7 +11,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>PlanViewer.Cli</RootNamespace>
     <AssemblyName>planview</AssemblyName>
-    <Version>0.8.0</Version>
+    <Version>0.8.1</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>


### PR DESCRIPTION
Version bump for v0.8.1 release (docs, screenshots, workflows, transport fix).