### PR TITLE
Fix release workflow: build and upload in single workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,10 @@
-name: Build
+name: CI
 
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main, dev]
-  release:
-    types: [published]
-
-permissions:
-  contents: write
 
 jobs:
   build-and-test:
@@ -39,43 +34,3 @@ jobs:
 
       - name: Run tests
         run: dotnet test tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj -c Release --no-build --verbosity normal
-
-      - name: Publish App (all platforms)
-        if: github.event_name == 'release'
-        run: |
-          dotnet publish src/PlanViewer.App/PlanViewer.App.csproj -c Release -r win-x64 --self-contained -o publish/win-x64
-          dotnet publish src/PlanViewer.App/PlanViewer.App.csproj -c Release -r linux-x64 --self-contained -o publish/linux-x64
-          dotnet publish src/PlanViewer.App/PlanViewer.App.csproj -c Release -r osx-x64 --self-contained -o publish/osx-x64
-          dotnet publish src/PlanViewer.App/PlanViewer.App.csproj -c Release -r osx-arm64 --self-contained -o publish/osx-arm64
-
-      - name: Package release artifacts
-        if: github.event_name == 'release'
-        shell: pwsh
-        run: |
-          New-Item -ItemType Directory -Force -Path releases
-
-          $rids = @('win-x64', 'linux-x64', 'osx-x64', 'osx-arm64')
-          foreach ($rid in $rids) {
-            if (Test-Path 'README.md') { Copy-Item 'README.md' "publish/$rid/" }
-            if (Test-Path 'LICENSE') { Copy-Item 'LICENSE' "publish/$rid/" }
-            Compress-Archive -Path "publish/$rid/*" -DestinationPath "releases/PerformanceStudio-$rid.zip" -Force
-          }
-
-      - name: Generate checksums
-        if: github.event_name == 'release'
-        shell: pwsh
-        run: |
-          $checksums = Get-ChildItem releases/*.zip | ForEach-Object {
-            $hash = (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLower()
-            "$hash  $($_.Name)"
-          }
-          $checksums | Out-File -FilePath releases/SHA256SUMS.txt -Encoding utf8
-          Write-Host "Checksums:"
-          $checksums | ForEach-Object { Write-Host $_ }
-
-      - name: Upload release assets
-        if: github.event_name == 'release'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release upload ${{ github.event.release.tag_name }} releases/*.zip releases/SHA256SUMS.txt --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,9 @@ permissions:
   contents: write
 
 jobs:
-  create-release:
+  release:
     if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'dev'
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,53 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "v${{ steps.version.outputs.VERSION }}" \
-            --title "v${{ steps.version.outputs.VERSION }}" \
-            --generate-notes \
-            --target main
+          gh release create "v${{ steps.version.outputs.VERSION }}" --title "v${{ steps.version.outputs.VERSION }}" --generate-notes --target main
+
+      - name: Setup .NET 8.0
+        if: steps.check.outputs.EXISTS == 'false'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Build and test
+        if: steps.check.outputs.EXISTS == 'false'
+        run: |
+          dotnet restore
+          dotnet build -c Release
+          dotnet test tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj -c Release --no-build --verbosity normal
+
+      - name: Publish App (all platforms)
+        if: steps.check.outputs.EXISTS == 'false'
+        run: |
+          dotnet publish src/PlanViewer.App/PlanViewer.App.csproj -c Release -r win-x64 --self-contained -o publish/win-x64
+          dotnet publish src/PlanViewer.App/PlanViewer.App.csproj -c Release -r linux-x64 --self-contained -o publish/linux-x64
+          dotnet publish src/PlanViewer.App/PlanViewer.App.csproj -c Release -r osx-x64 --self-contained -o publish/osx-x64
+          dotnet publish src/PlanViewer.App/PlanViewer.App.csproj -c Release -r osx-arm64 --self-contained -o publish/osx-arm64
+
+      - name: Package and upload
+        if: steps.check.outputs.EXISTS == 'false'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          New-Item -ItemType Directory -Force -Path releases
+
+          $rids = @('win-x64', 'linux-x64', 'osx-x64', 'osx-arm64')
+          foreach ($rid in $rids) {
+            if (Test-Path 'README.md') { Copy-Item 'README.md' "publish/$rid/" }
+            if (Test-Path 'LICENSE') { Copy-Item 'LICENSE' "publish/$rid/" }
+            Compress-Archive -Path "publish/$rid/*" -DestinationPath "releases/PerformanceStudio-$rid.zip" -Force
+          }
+
+          # Checksums
+          $checksums = Get-ChildItem releases/*.zip | ForEach-Object {
+            $hash = (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLower()
+            "$hash  $($_.Name)"
+          }
+          $checksums | Out-File -FilePath releases/SHA256SUMS.txt -Encoding utf8
+          Write-Host "Checksums:"
+          $checksums | ForEach-Object { Write-Host $_ }
+
+          # Upload
+          gh release upload "v$env:VERSION" releases/*.zip releases/SHA256SUMS.txt --clobber


### PR DESCRIPTION
## Problem
GITHUB_TOKEN events don't trigger other workflows. The release workflow created the tag, but the build workflow's `on: release` event never fired — so zips were never attached.

## Fix
Merged both into a single release workflow: create release → build → publish → zip → upload. CI workflow is now just build+test for PRs/pushes.

## Test
v0.8.1 release exists but has no zips. After this fix, the next dev→main merge will work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)