### PR TITLE
Fix obsolete clipboard warnings

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
@@ -120,7 +121,7 @@ public partial class QuerySessionControl : UserControl
         {
             var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
             if (clipboard == null) return;
-            var text = await clipboard.GetTextAsync();
+            var text = await clipboard.TryGetTextAsync();
             if (string.IsNullOrEmpty(text)) return;
             QueryEditor.TextArea.PerformTextInput(text);
         };

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
@@ -370,7 +371,7 @@ public partial class MainWindow : Window
         var clipboard = this.Clipboard;
         if (clipboard == null) return;
 
-        var xml = await clipboard.GetTextAsync();
+        var xml = await clipboard.TryGetTextAsync();
         if (string.IsNullOrWhiteSpace(xml))
         {
             ShowError("The clipboard does not contain any text.");


### PR DESCRIPTION
## Summary
- Replace `IClipboard.GetTextAsync()` with `ClipboardExtensions.TryGetTextAsync()` in both paste handlers
- Adds `using Avalonia.Input.Platform` to resolve the extension method

Closes #3

## Test plan
- [ ] Build with zero warnings (`dotnet build -c Debug`)
- [ ] Paste from clipboard in query editor
- [ ] Paste XML from clipboard via File > Paste Plan XML

🤖 Generated with [Claude Code](https://claude.com/claude-code)