### PR TITLE
Add MCP copy button to About screen (#26)

### DIFF
--- a/src/PlanViewer.App/AboutWindow.axaml
+++ b/src/PlanViewer.App/AboutWindow.axaml
@@ -2,7 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="PlanViewer.App.AboutWindow"
         Title="About Performance Studio"
-        Width="450" Height="420"
+        Width="450" Height="460"
         CanResize="False"
         WindowStartupLocation="CenterOwner"
         Icon="avares://PlanViewer.App/EDD.ico"
@@ -63,6 +63,12 @@
             <TextBlock Text="Restart the application after changing MCP settings."
                        FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}"
                        Margin="0,4,0,0"/>
+            <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
+                <Button x:Name="CopyMcpCommandButton" Content="Copy MCP Command"
+                        Click="CopyMcpCommand_Click" Padding="10,4" FontSize="12"/>
+                <TextBlock x:Name="McpCopyStatus" FontSize="11" VerticalAlignment="Center"
+                           Foreground="{DynamicResource ForegroundMutedBrush}"/>
+            </StackPanel>
         </StackPanel>
 
         <!-- Close -->

--- a/src/PlanViewer.App/AboutWindow.axaml.cs
+++ b/src/PlanViewer.App/AboutWindow.axaml.cs
@@ -12,6 +12,7 @@ using System.Runtime.InteropServices;
 using System.Text.Json;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using PlanViewer.App.Mcp;
 
@@ -59,6 +60,18 @@ public partial class AboutWindow : Window
     private void GitHubLink_Click(object? sender, PointerPressedEventArgs e) => OpenUrl(GitHubUrl);
     private void ReportIssueLink_Click(object? sender, PointerPressedEventArgs e) => OpenUrl(IssuesUrl);
     private void DarlingDataLink_Click(object? sender, PointerPressedEventArgs e) => OpenUrl(DarlingDataUrl);
+    private async void CopyMcpCommand_Click(object? sender, RoutedEventArgs e)
+    {
+        var port = int.TryParse(McpPortInput.Text, out var p) && p >= 1024 && p <= 65535 ? p : 5152;
+        var command = $"claude mcp add --transport streamable-http --scope user performance-studio http://localhost:{port}/";
+        var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+        if (clipboard != null)
+        {
+            await clipboard.SetTextAsync(command);
+            McpCopyStatus.Text = "Copied to clipboard!";
+        }
+    }
+
     private void CloseButton_Click(object? sender, RoutedEventArgs e) => Close();
 
     private static void OpenUrl(string url)


### PR DESCRIPTION
## Summary
- Adds a "Copy MCP Command" button below the MCP enable/port settings on the About screen
- Copies `claude mcp add --transport streamable-http --scope user performance-studio http://localhost:{port}/` to clipboard using the current port setting
- Shows "Copied to clipboard!" confirmation text

## Test plan
- [x] Open Help > About, click "Copy MCP Command" — command copied to clipboard
- [x] Change port, click again — command reflects updated port
- [x] Paste into terminal — correct registration command

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)