### PR TITLE
Fix macOS release packaging to use proper .app bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,11 +73,47 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path releases
 
-          $rids = @('win-x64', 'linux-x64', 'osx-x64', 'osx-arm64')
-          foreach ($rid in $rids) {
+          # Package Windows and Linux as flat zips
+          foreach ($rid in @('win-x64', 'linux-x64')) {
             if (Test-Path 'README.md') { Copy-Item 'README.md' "publish/$rid/" }
             if (Test-Path 'LICENSE') { Copy-Item 'LICENSE' "publish/$rid/" }
             Compress-Archive -Path "publish/$rid/*" -DestinationPath "releases/PerformanceStudio-$rid.zip" -Force
+          }
+
+          # Package macOS as proper .app bundles
+          foreach ($rid in @('osx-x64', 'osx-arm64')) {
+            $appName = "PerformanceStudio.app"
+            $bundleDir = "publish/$rid-bundle/$appName"
+
+            # Create .app bundle structure
+            New-Item -ItemType Directory -Force -Path "$bundleDir/Contents/MacOS"
+            New-Item -ItemType Directory -Force -Path "$bundleDir/Contents/Resources"
+
+            # Copy all published files into Contents/MacOS
+            Copy-Item -Path "publish/$rid/*" -Destination "$bundleDir/Contents/MacOS/" -Recurse
+
+            # Move Info.plist to Contents/ (it was copied to MacOS/ with the publish output)
+            if (Test-Path "$bundleDir/Contents/MacOS/Info.plist") {
+              Move-Item -Path "$bundleDir/Contents/MacOS/Info.plist" -Destination "$bundleDir/Contents/Info.plist" -Force
+            }
+
+            # Update version in Info.plist to match csproj
+            $plist = Get-Content "$bundleDir/Contents/Info.plist" -Raw
+            $plist = $plist -replace '(<key>CFBundleVersion</key>\s*<string>)[^<]*(</string>)', "`${1}$env:VERSION`${2}"
+            $plist = $plist -replace '(<key>CFBundleShortVersionString</key>\s*<string>)[^<]*(</string>)', "`${1}$env:VERSION`${2}"
+            Set-Content -Path "$bundleDir/Contents/Info.plist" -Value $plist -NoNewline
+
+            # Move icon to Contents/Resources
+            if (Test-Path "$bundleDir/Contents/MacOS/EDD.icns") {
+              Move-Item -Path "$bundleDir/Contents/MacOS/EDD.icns" -Destination "$bundleDir/Contents/Resources/EDD.icns" -Force
+            }
+
+            # Add README and LICENSE alongside the .app bundle
+            $wrapperDir = "publish/$rid-bundle"
+            if (Test-Path 'README.md') { Copy-Item 'README.md' "$wrapperDir/" }
+            if (Test-Path 'LICENSE') { Copy-Item 'LICENSE' "$wrapperDir/" }
+
+            Compress-Archive -Path "$wrapperDir/*" -DestinationPath "releases/PerformanceStudio-$rid.zip" -Force
           }
 
           # Checksums

--- a/src/PlanViewer.App/Info.plist
+++ b/src/PlanViewer.App/Info.plist
@@ -8,10 +8,12 @@
     <string>Performance Studio</string>
     <key>CFBundleIdentifier</key>
     <string>com.darlingdata.sqlperformancestudio</string>
+    <key>CFBundleExecutable</key>
+    <string>PlanViewer.App</string>
     <key>CFBundleVersion</key>
-    <string>0.7.0</string>
+    <string>0.9.0</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.7.0</string>
+    <string>0.9.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>NSHumanReadableCopyright</key>


### PR DESCRIPTION
## Summary
- macOS builds were shipping as flat folders of DLLs/binaries — not runnable on macOS
- Release workflow now creates proper `.app` bundle structure (`Contents/MacOS/`, `Contents/Resources/`, `Info.plist`)
- Added missing `CFBundleExecutable` key to Info.plist so macOS knows which binary to launch
- Info.plist version is now auto-synced from the csproj at build time, preventing version drift

## What users get now
```
PerformanceStudio.app/
└── Contents/
    ├── MacOS/          ← all published binaries
    ├── Resources/
    │   └── EDD.icns    ← app icon
    └── Info.plist      ← bundle metadata
```

## Test plan
- [ ] Merge to dev, then dev→main to trigger release workflow
- [ ] Download macOS zip from release, extract, and verify `.app` bundle launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)