### PR TITLE
Fix nullable databaseName in ActualPlanExecutor

### DIFF
--- a/src/PlanViewer.Core/Services/ActualPlanExecutor.cs
+++ b/src/PlanViewer.Core/Services/ActualPlanExecutor.cs
@@ -36,7 +36,7 @@ public static class ActualPlanExecutor
     /// <returns>The actual execution plan XML, or null if no plan was captured.</returns>
     public static async Task<string?> ExecuteForActualPlanAsync(
         string connectionString,
-        string databaseName,
+        string? databaseName,
         string queryText,
         string? planXml,
         string? isolationLevel,


### PR DESCRIPTION
## Summary
- Make `databaseName` parameter nullable (`string?`) in `ActualPlanExecutor.ExecuteForActualPlanAsync` — the method already handles null with `IsNullOrEmpty`, but the non-nullable type caused CS8604 at the MainWindow call site

## Test plan
- [ ] Build with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)