### PR TITLE
Issue #48: Advice window styling, operator timing, rules, UI consistency

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml
@@ -64,10 +64,10 @@
                         <ColumnDefinition Width="Auto" MinWidth="180"/>
                         <ColumnDefinition Width="*" MinWidth="200"/>
                         <ColumnDefinition Width="*" MinWidth="200"/>
-                        <ColumnDefinition Width="*" MinWidth="200"/>
+                        <ColumnDefinition Width="2*" MinWidth="280"/>
                     </Grid.ColumnDefinitions>
 
-                    <!-- Server Context (first, only visible when connected) -->
+                    <!-- Server Context (first, placeholder when no metadata) -->
                     <Border x:Name="ServerContextBorder" Grid.Column="0" Padding="10,4,10,8"
                             Background="#1A1A2D"
                             BorderBrush="#3A3A5A" BorderThickness="0,0,1,0"
@@ -81,6 +81,10 @@
                                            Foreground="#9B9BFF"
                                            Margin="0,0,0,6"/>
                                 <StackPanel x:Name="ServerContextContent"/>
+                                <TextBlock x:Name="ServerContextEmpty"
+                                           Text="Run Repro Script to capture server context"
+                                           FontSize="12" IsVisible="False"
+                                           Foreground="{DynamicResource ForegroundBrush}"/>
                             </StackPanel>
                         </ScrollViewer>
                     </Border>
@@ -96,6 +100,10 @@
                                        Foreground="{DynamicResource ForegroundBrush}"
                                        Margin="0,0,0,4"/>
                             <StackPanel x:Name="RuntimeSummaryContent"/>
+                            <TextBlock x:Name="RuntimeSummaryEmpty"
+                                       Text="Estimated plan — no runtime stats"
+                                       FontSize="12" IsVisible="False"
+                                       Foreground="{DynamicResource ForegroundBrush}"/>
                         </StackPanel>
                     </Border>
 

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -2385,7 +2385,15 @@ public partial class PlanViewerControl : UserControl
         if (!string.IsNullOrEmpty(statement.StatementOptmEarlyAbortReason))
             AddRow("Early abort", statement.StatementOptmEarlyAbortReason);
 
-        RuntimeSummaryContent.Children.Add(grid);
+        if (grid.Children.Count > 0)
+        {
+            RuntimeSummaryContent.Children.Add(grid);
+            RuntimeSummaryEmpty.IsVisible = false;
+        }
+        else
+        {
+            RuntimeSummaryEmpty.IsVisible = true;
+        }
         ShowServerContext();
     }
 
@@ -2394,9 +2402,12 @@ public partial class PlanViewerControl : UserControl
         ServerContextContent.Children.Clear();
         if (_serverMetadata == null)
         {
-            ServerContextBorder.IsVisible = false;
+            ServerContextEmpty.IsVisible = true;
+            ServerContextBorder.IsVisible = true;
             return;
         }
+
+        ServerContextEmpty.IsVisible = false;
 
         var m = _serverMetadata;
         var fgColor = "#E4E6EB";

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml
@@ -33,12 +33,12 @@
                             ToolTip.Tip="Capture estimated plan without executing (Ctrl+L)"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
                                Foreground="{DynamicResource ForegroundBrush}" Margin="4,0"/>
-                    <Button x:Name="HumanAdviceButton" Content="&#x1F9D1; Advice for Humans"
+                    <Button x:Name="HumanAdviceButton" Content="&#x1F9D1; Human Advice"
                             Click="HumanAdvice_Click"
                             Height="28" Padding="10,0" FontSize="12" IsEnabled="False"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Human-readable plan analysis"/>
-                    <Button x:Name="RobotAdviceButton" Content="&#x1F916; Advice for Robots"
+                    <Button x:Name="RobotAdviceButton" Content="&#x1F916; Robot Advice"
                             Click="RobotAdvice_Click"
                             Height="28" Padding="10,0" FontSize="12" IsEnabled="False"
                             Theme="{StaticResource AppButton}"
@@ -59,12 +59,12 @@
                             ToolTip.Tip="Analyze top queries from Query Store"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
                                Foreground="{DynamicResource ForegroundBrush}" Margin="4,0"/>
-                    <Button x:Name="CopyReproButton" Content="&#x1F4CB; Copy Repro Script"
+                    <Button x:Name="CopyReproButton" Content="&#x1F4CB; Copy Repro"
                             Click="CopyRepro_Click"
                             Height="28" Padding="10,0" FontSize="12" IsEnabled="False"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Copy reproduction script to clipboard"/>
-                    <Button x:Name="GetActualPlanButton" Content="&#x25B6; Run Repro Script"
+                    <Button x:Name="GetActualPlanButton" Content="&#x25B6; Run Repro"
                             Click="GetActualPlan_Click"
                             Height="28" Padding="10,0" FontSize="12" IsEnabled="False"
                             Theme="{StaticResource AppButton}"

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -708,21 +708,11 @@ public partial class QuerySessionControl : UserControl
 
     private void ShowAdviceWindow(string title, string content)
     {
-        var textBox = new TextBox
-        {
-            Text = content,
-            IsReadOnly = true,
-            AcceptsReturn = true,
-            FontFamily = new FontFamily("Consolas, Menlo, monospace"),
-            FontSize = 12,
-            Background = Brushes.Transparent,
-            BorderThickness = new Avalonia.Thickness(0),
-            TextWrapping = TextWrapping.Wrap
-        };
+        var styledContent = AdviceContentBuilder.Build(content);
 
         var scrollViewer = new ScrollViewer
         {
-            Content = textBox,
+            Content = styledContent,
             HorizontalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Disabled,
             VerticalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Auto
         };

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -418,7 +418,7 @@ public partial class MainWindow : Window
     {
         var humanBtn = new Button
         {
-            Content = "\U0001f9d1 Advice for Humans",
+            Content = "\U0001f9d1 Human Advice",
             Height = 28,
             Padding = new Avalonia.Thickness(10, 0),
             FontSize = 12,
@@ -430,7 +430,7 @@ public partial class MainWindow : Window
 
         var robotBtn = new Button
         {
-            Content = "\U0001f916 Advice for Robots",
+            Content = "\U0001f916 Robot Advice",
             Height = 28,
             Padding = new Avalonia.Thickness(10, 0),
             FontSize = 12,
@@ -478,7 +478,7 @@ public partial class MainWindow : Window
 
         var copyReproBtn = new Button
         {
-            Content = "\U0001f4cb Copy Repro Script",
+            Content = "\U0001f4cb Copy Repro",
             Height = 28,
             Padding = new Avalonia.Thickness(10, 0),
             FontSize = 12,
@@ -508,7 +508,7 @@ public partial class MainWindow : Window
 
         var getActualPlanBtn = new Button
         {
-            Content = "\u25b6 Run Repro Script",
+            Content = "\u25b6 Run Repro",
             Height = 28,
             Padding = new Avalonia.Thickness(10, 0),
             FontSize = 12,
@@ -523,11 +523,33 @@ public partial class MainWindow : Window
             await GetActualPlanFromFile(viewer);
         };
 
+        var separator2 = new TextBlock
+        {
+            Text = "|",
+            VerticalAlignment = VerticalAlignment.Center,
+            Foreground = new SolidColorBrush(Color.Parse("#E4E6EB")),
+            Margin = new Avalonia.Thickness(4, 0)
+        };
+
+        var queryStoreBtn = new Button
+        {
+            Content = "\U0001f4ca Query Store",
+            Height = 28,
+            Padding = new Avalonia.Thickness(10, 0),
+            FontSize = 12,
+            Margin = new Avalonia.Thickness(6, 0, 0, 0),
+            VerticalContentAlignment = VerticalAlignment.Center,
+            HorizontalContentAlignment = HorizontalAlignment.Center,
+            IsEnabled = false,
+            Theme = (Avalonia.Styling.ControlTheme)this.FindResource("AppButton")!
+        };
+        ToolTip.SetTip(queryStoreBtn, "Connect to a server (Ctrl+N) to use Query Store");
+
         var toolbar = new StackPanel
         {
             Orientation = Orientation.Horizontal,
             Margin = new Avalonia.Thickness(8, 6),
-            Children = { humanBtn, robotBtn, compareBtn, separator1, copyReproBtn, getActualPlanBtn }
+            Children = { humanBtn, robotBtn, compareBtn, separator1, copyReproBtn, getActualPlanBtn, separator2, queryStoreBtn }
         };
 
         var panel = new DockPanel();
@@ -540,7 +562,7 @@ public partial class MainWindow : Window
 
     private void ShowAdviceWindow(string title, string content)
     {
-        var styledContent = BuildStyledAdviceContent(content);
+        var styledContent = AdviceContentBuilder.Build(content);
 
         var scrollViewer = new ScrollViewer
         {
@@ -1116,229 +1138,6 @@ public partial class MainWindow : Window
             statusText.Text = $"Error: {ex.Message}";
             progressBar.IsVisible = false;
         }
-    }
-
-    private static readonly SolidColorBrush AdviceHeaderBrush = new(Color.Parse("#4FA3FF"));
-    private static readonly SolidColorBrush AdviceCriticalBrush = new(Color.Parse("#E57373"));
-    private static readonly SolidColorBrush AdviceWarningBrush = new(Color.Parse("#FFB347"));
-    private static readonly SolidColorBrush AdviceInfoBrush = new(Color.Parse("#6BB5FF"));
-    private static readonly SolidColorBrush AdviceLabelBrush = new(Color.Parse("#9B9EC0"));
-    private static readonly SolidColorBrush AdviceValueBrush = new(Color.Parse("#E4E6EB"));
-    private static readonly SolidColorBrush AdviceCodeBrush = new(Color.Parse("#7BCF7B"));
-    private static readonly SolidColorBrush AdviceMutedBrush = new(Color.Parse("#8B8FA0"));
-    private static readonly FontFamily AdviceFont = new("Consolas, Menlo, monospace");
-
-    private StackPanel BuildStyledAdviceContent(string content)
-    {
-        var panel = new StackPanel { Margin = new Avalonia.Thickness(4, 0) };
-        var lines = content.Split('\n');
-        var inCodeBlock = false;
-        var codeBlockIndent = 0;
-
-        foreach (var rawLine in lines)
-        {
-            var line = rawLine.TrimEnd('\r');
-
-            // Empty lines — small spacer
-            if (string.IsNullOrWhiteSpace(line))
-            {
-                panel.Children.Add(new Border { Height = 6 });
-                inCodeBlock = false;
-                continue;
-            }
-
-            // Section headers: === ... ===
-            if (line.StartsWith("===") && line.EndsWith("==="))
-            {
-                inCodeBlock = false;
-                panel.Children.Add(new TextBlock
-                {
-                    Text = line,
-                    FontFamily = AdviceFont,
-                    FontSize = 12,
-                    FontWeight = FontWeight.SemiBold,
-                    Foreground = AdviceHeaderBrush,
-                    Margin = new Avalonia.Thickness(0, 4, 0, 2),
-                    TextWrapping = TextWrapping.Wrap
-                });
-                continue;
-            }
-
-            // Warning lines: [Critical], [Warning], [Info]
-            if (line.Contains("[Critical]"))
-            {
-                panel.Children.Add(CreateWarningLine(line, AdviceCriticalBrush));
-                continue;
-            }
-            if (line.Contains("[Warning]"))
-            {
-                panel.Children.Add(CreateWarningLine(line, AdviceWarningBrush));
-                continue;
-            }
-            if (line.Contains("[Info]"))
-            {
-                panel.Children.Add(CreateWarningLine(line, AdviceInfoBrush));
-                continue;
-            }
-
-            // SNIFFING marker
-            if (line.Contains("[SNIFFING]"))
-            {
-                var tb = new TextBlock
-                {
-                    FontFamily = AdviceFont,
-                    FontSize = 12,
-                    TextWrapping = TextWrapping.Wrap,
-                    Margin = new Avalonia.Thickness(0, 1)
-                };
-                var sniffIdx = line.IndexOf("[SNIFFING]");
-                tb.Inlines!.Add(new Avalonia.Controls.Documents.Run(line[..sniffIdx])
-                    { Foreground = AdviceValueBrush });
-                tb.Inlines.Add(new Avalonia.Controls.Documents.Run("[SNIFFING]")
-                    { Foreground = AdviceCriticalBrush, FontWeight = FontWeight.SemiBold });
-                panel.Children.Add(tb);
-                continue;
-            }
-
-            // CREATE INDEX lines (multi-line: CREATE..., ON..., INCLUDE..., WHERE...)
-            var trimmed = line.TrimStart();
-            if (trimmed.StartsWith("CREATE", StringComparison.OrdinalIgnoreCase))
-            {
-                inCodeBlock = true;
-                codeBlockIndent = line.Length - trimmed.Length;
-            }
-            else if (inCodeBlock)
-            {
-                // Continuation lines of a CREATE statement
-                if (trimmed.StartsWith("ON ", StringComparison.OrdinalIgnoreCase) ||
-                    trimmed.StartsWith("INCLUDE ", StringComparison.OrdinalIgnoreCase) ||
-                    trimmed.StartsWith("WHERE ", StringComparison.OrdinalIgnoreCase) ||
-                    trimmed.StartsWith("WITH ", StringComparison.OrdinalIgnoreCase))
-                { /* still in code block */ }
-                else
-                    inCodeBlock = false;
-            }
-
-            if (inCodeBlock)
-            {
-                // Normalize indentation: continuation lines match the CREATE line
-                var currentIndent = line.Length - trimmed.Length;
-                var displayLine = currentIndent < codeBlockIndent
-                    ? new string(' ', codeBlockIndent) + trimmed
-                    : line;
-
-                panel.Children.Add(new TextBlock
-                {
-                    Text = displayLine,
-                    FontFamily = AdviceFont,
-                    FontSize = 12,
-                    Foreground = AdviceCodeBrush,
-                    TextWrapping = TextWrapping.Wrap,
-                    Margin = new Avalonia.Thickness(0, 1)
-                });
-                continue;
-            }
-
-            // Section labels: "Warnings:", "Parameters:", "Wait stats:", etc.
-            if (trimmed.EndsWith(":") && !trimmed.Contains(' '))
-            {
-                panel.Children.Add(new TextBlock
-                {
-                    Text = line,
-                    FontFamily = AdviceFont,
-                    FontSize = 12,
-                    FontWeight = FontWeight.SemiBold,
-                    Foreground = AdviceLabelBrush,
-                    Margin = new Avalonia.Thickness(0, 4, 0, 1),
-                    TextWrapping = TextWrapping.Wrap
-                });
-                continue;
-            }
-
-            // Bullet lines: "   * ..."
-            if (trimmed.StartsWith("* "))
-            {
-                panel.Children.Add(new TextBlock
-                {
-                    Text = line,
-                    FontFamily = AdviceFont,
-                    FontSize = 12,
-                    Foreground = AdviceMutedBrush,
-                    Margin = new Avalonia.Thickness(0, 1),
-                    TextWrapping = TextWrapping.Wrap
-                });
-                continue;
-            }
-
-            // Key-value lines: "Label: value"
-            var colonIdx = line.IndexOf(':');
-            if (colonIdx > 0 && colonIdx < line.Length - 1)
-            {
-                // Check it's a label:value pattern (label is short text, not SQL)
-                var labelPart = line[..colonIdx].TrimStart();
-                if (labelPart.Length < 40 && !labelPart.Contains('(') && !labelPart.Contains('='))
-                {
-                    var tb = new TextBlock
-                    {
-                        FontFamily = AdviceFont,
-                        FontSize = 12,
-                        TextWrapping = TextWrapping.Wrap,
-                        Margin = new Avalonia.Thickness(0, 1)
-                    };
-                    tb.Inlines!.Add(new Avalonia.Controls.Documents.Run(line[..(colonIdx + 1)])
-                        { Foreground = AdviceLabelBrush });
-                    tb.Inlines.Add(new Avalonia.Controls.Documents.Run(line[(colonIdx + 1)..])
-                        { Foreground = AdviceValueBrush });
-                    panel.Children.Add(tb);
-                    continue;
-                }
-            }
-
-            // Default: regular text
-            panel.Children.Add(new TextBlock
-            {
-                Text = line,
-                FontFamily = AdviceFont,
-                FontSize = 12,
-                Foreground = AdviceValueBrush,
-                TextWrapping = TextWrapping.Wrap,
-                Margin = new Avalonia.Thickness(0, 1)
-            });
-        }
-
-        return panel;
-    }
-
-    private static TextBlock CreateWarningLine(string line, SolidColorBrush severityBrush)
-    {
-        var tb = new TextBlock
-        {
-            FontFamily = AdviceFont,
-            FontSize = 12,
-            TextWrapping = TextWrapping.Wrap,
-            Margin = new Avalonia.Thickness(0, 1)
-        };
-
-        // Find the severity tag and color it
-        foreach (var tag in new[] { "[Critical]", "[Warning]", "[Info]" })
-        {
-            var idx = line.IndexOf(tag);
-            if (idx >= 0)
-            {
-                if (idx > 0)
-                    tb.Inlines!.Add(new Avalonia.Controls.Documents.Run(line[..idx])
-                        { Foreground = AdviceMutedBrush });
-                tb.Inlines!.Add(new Avalonia.Controls.Documents.Run(tag)
-                    { Foreground = severityBrush, FontWeight = FontWeight.SemiBold });
-                tb.Inlines.Add(new Avalonia.Controls.Documents.Run(line[(idx + tag.Length)..])
-                    { Foreground = AdviceValueBrush });
-                return tb;
-            }
-        }
-
-        tb.Text = line;
-        tb.Foreground = severityBrush;
-        return tb;
     }
 
     private void ShowError(string message)

--- a/src/PlanViewer.App/Services/AdviceContentBuilder.cs
+++ b/src/PlanViewer.App/Services/AdviceContentBuilder.cs
@@ -1,0 +1,581 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Media;
+
+namespace PlanViewer.App.Services;
+
+/// <summary>
+/// Builds styled content for the Advice for Humans window.
+/// Shared between MainWindow (file mode) and QuerySessionControl (query mode).
+/// </summary>
+internal static class AdviceContentBuilder
+{
+    private static readonly SolidColorBrush HeaderBrush = new(Color.Parse("#4FA3FF"));
+    private static readonly SolidColorBrush CriticalBrush = new(Color.Parse("#E57373"));
+    private static readonly SolidColorBrush WarningBrush = new(Color.Parse("#FFB347"));
+    private static readonly SolidColorBrush InfoBrush = new(Color.Parse("#6BB5FF"));
+    private static readonly SolidColorBrush LabelBrush = new(Color.Parse("#9B9EC0"));
+    private static readonly SolidColorBrush ValueBrush = new(Color.Parse("#E4E6EB"));
+    private static readonly SolidColorBrush CodeBrush = new(Color.Parse("#7BCF7B"));
+    private static readonly SolidColorBrush MutedBrush = new(Color.Parse("#8B8FA0"));
+    private static readonly SolidColorBrush OperatorBrush = new(Color.Parse("#C792EA"));
+    private static readonly SolidColorBrush SqlKeywordBrush = new(Color.Parse("#569CD6"));
+    private static readonly SolidColorBrush SeparatorBrush = new(Color.Parse("#2A2D35"));
+    private static readonly SolidColorBrush WarningAccentBrush = new(Color.Parse("#332A1A"));
+    private static readonly FontFamily MonoFont = new("Consolas, Menlo, monospace");
+
+    private static readonly HashSet<string> PhysicalOperators = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Sort", "Filter", "Bitmap", "Hash Match", "Merge Join", "Nested Loops",
+        "Stream Aggregate", "Compute Scalar", "Table Scan", "Index Scan",
+        "Clustered Index Scan", "Table Spool", "Index Spool", "Constant Scan",
+        "Concatenation", "Assert", "Segment", "Sequence Project", "Window Aggregate",
+        "Adaptive Join", "Row Count Spool", "Lazy Spool", "Eager Spool",
+        "Columnstore Index Scan", "Batch Hash Table Build", "Parallelism",
+        "Top", "Index Seek", "Clustered Index Seek", "RID Lookup",
+        "Key Lookup", "Clustered Index Update", "Clustered Index Insert",
+        "Clustered Index Delete", "Table Insert", "Table Delete"
+    };
+
+    private static readonly HashSet<string> SqlKeywords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "SELECT", "FROM", "WHERE", "JOIN", "LEFT", "RIGHT", "INNER", "OUTER", "CROSS",
+        "ON", "AND", "OR", "NOT", "IN", "EXISTS", "BETWEEN", "LIKE", "IS", "NULL",
+        "INSERT", "INTO", "UPDATE", "SET", "DELETE", "MERGE", "USING", "MATCHED",
+        "GROUP", "BY", "ORDER", "HAVING", "UNION", "ALL", "EXCEPT", "INTERSECT",
+        "TOP", "DISTINCT", "AS", "WITH", "CTE", "OVER", "PARTITION", "ROW_NUMBER",
+        "CASE", "WHEN", "THEN", "ELSE", "END", "CAST", "CONVERT", "COALESCE",
+        "CREATE", "ALTER", "DROP", "INDEX", "TABLE", "VIEW", "PROCEDURE", "FUNCTION",
+        "EXEC", "EXECUTE", "DECLARE", "BEGIN", "RETURN", "IF", "WHILE",
+        "ASC", "DESC", "OFFSET", "FETCH", "NEXT", "ROWS", "ONLY",
+        "COUNT", "SUM", "AVG", "MIN", "MAX", "APPLY", "PIVOT", "UNPIVOT",
+        "NONCLUSTERED", "CLUSTERED", "INCLUDE", "OPTION", "RECOMPILE", "MAXDOP",
+        "NOLOCK", "READUNCOMMITTED", "READCOMMITTED", "SERIALIZABLE", "HOLDLOCK"
+    };
+
+    public static StackPanel Build(string content)
+    {
+        var panel = new StackPanel { Margin = new Avalonia.Thickness(4, 0) };
+        var lines = content.Split('\n');
+        var inCodeBlock = false;
+        var codeBlockIndent = 0;
+        var isStatementText = false;
+        var inSubSection = false; // tracks sub-sections within a statement
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i].TrimEnd('\r');
+
+            // Empty lines — small spacer
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                panel.Children.Add(new Border { Height = 6 });
+                inCodeBlock = false;
+                isStatementText = false;
+                continue;
+            }
+
+            // Section headers: === ... ===
+            if (line.StartsWith("===") && line.EndsWith("==="))
+            {
+                inCodeBlock = false;
+                isStatementText = false;
+                inSubSection = false;
+
+                // Strip === markers, just show the text
+                var headerText = line.Trim('=', ' ');
+
+                // Add separator before non-first headers
+                if (panel.Children.Count > 0)
+                {
+                    panel.Children.Add(new Border
+                    {
+                        Height = 1,
+                        Background = SeparatorBrush,
+                        Margin = new Avalonia.Thickness(0, 10, 0, 6)
+                    });
+                }
+
+                panel.Children.Add(new SelectableTextBlock
+                {
+                    Text = headerText,
+                    FontFamily = MonoFont,
+                    FontSize = 14,
+                    FontWeight = FontWeight.Bold,
+                    Foreground = HeaderBrush,
+                    Margin = new Avalonia.Thickness(0, 0, 0, 6),
+                    TextWrapping = TextWrapping.Wrap
+                });
+
+                // Statement text follows "Statement N:"
+                if (headerText.StartsWith("Statement"))
+                    isStatementText = true;
+
+                continue;
+            }
+
+            // Statement text (SQL) — highlight keywords
+            if (isStatementText)
+            {
+                isStatementText = false;
+                panel.Children.Add(BuildSqlHighlightedLine(line));
+                continue;
+            }
+
+            // Warning lines: [Critical], [Warning], [Info] — with left accent border
+            if (line.Contains("[Critical]"))
+            {
+                panel.Children.Add(CreateWarningBlock(line, CriticalBrush));
+                continue;
+            }
+            if (line.Contains("[Warning]"))
+            {
+                panel.Children.Add(CreateWarningBlock(line, WarningBrush));
+                continue;
+            }
+            if (line.Contains("[Info]"))
+            {
+                panel.Children.Add(CreateWarningBlock(line, InfoBrush));
+                continue;
+            }
+
+            var trimmed = line.TrimStart();
+
+            // Grouped explanation line: "  -> The overestimate may have..."
+            if (trimmed.StartsWith("-> "))
+            {
+                panel.Children.Add(new SelectableTextBlock
+                {
+                    Text = trimmed[3..],
+                    FontFamily = MonoFont,
+                    FontSize = 12,
+                    FontStyle = Avalonia.Media.FontStyle.Italic,
+                    Foreground = MutedBrush,
+                    Margin = new Avalonia.Thickness(16, 2, 0, 4),
+                    TextWrapping = TextWrapping.Wrap
+                });
+                continue;
+            }
+
+            // SNIFFING marker
+            if (line.Contains("[SNIFFING]"))
+            {
+                var tb = new SelectableTextBlock
+                {
+                    FontFamily = MonoFont,
+                    FontSize = 12,
+                    TextWrapping = TextWrapping.Wrap,
+                    Margin = new Avalonia.Thickness(8, 1, 0, 1)
+                };
+                var sniffIdx = line.IndexOf("[SNIFFING]");
+                tb.Inlines!.Add(new Run(line[..sniffIdx].TrimStart()) { Foreground = ValueBrush });
+                tb.Inlines.Add(new Run("[SNIFFING]")
+                    { Foreground = CriticalBrush, FontWeight = FontWeight.SemiBold });
+                panel.Children.Add(tb);
+                continue;
+            }
+
+            // CREATE INDEX lines (multi-line: CREATE..., ON..., INCLUDE..., WHERE...)
+            if (trimmed.StartsWith("CREATE", StringComparison.OrdinalIgnoreCase))
+            {
+                inCodeBlock = true;
+                codeBlockIndent = line.Length - trimmed.Length;
+            }
+            else if (inCodeBlock)
+            {
+                if (trimmed.StartsWith("ON ", StringComparison.OrdinalIgnoreCase) ||
+                    trimmed.StartsWith("INCLUDE ", StringComparison.OrdinalIgnoreCase) ||
+                    trimmed.StartsWith("WHERE ", StringComparison.OrdinalIgnoreCase) ||
+                    trimmed.StartsWith("WITH ", StringComparison.OrdinalIgnoreCase))
+                { /* still in code block */ }
+                else
+                    inCodeBlock = false;
+            }
+
+            if (inCodeBlock)
+            {
+                var currentIndent = line.Length - trimmed.Length;
+                var displayLine = currentIndent < codeBlockIndent
+                    ? new string(' ', codeBlockIndent) + trimmed
+                    : line;
+
+                panel.Children.Add(new SelectableTextBlock
+                {
+                    Text = displayLine,
+                    FontFamily = MonoFont,
+                    FontSize = 12,
+                    Foreground = CodeBrush,
+                    TextWrapping = TextWrapping.Wrap,
+                    Margin = new Avalonia.Thickness(8, 1, 0, 1)
+                });
+                continue;
+            }
+
+            // Expensive operator timing lines: "4,616ms CPU (61%), 586ms elapsed (62%)"
+            if (trimmed.Contains("ms CPU") || trimmed.Contains("ms elapsed"))
+            {
+                panel.Children.Add(CreateOperatorTimingLine(trimmed));
+                continue;
+            }
+
+            // Expensive operators section: highlight operator name
+            // Handles both "Operator (Object):" and bare "Sort:" forms
+            if (trimmed.EndsWith("):") ||
+                (trimmed.EndsWith(":") && PhysicalOperators.Contains(trimmed[..^1])))
+            {
+                panel.Children.Add(CreateOperatorLine(line));
+                continue;
+            }
+
+            // Sub-section labels within a statement: "Warnings:", "Parameters:", "Wait stats:", etc.
+            // These have a space or end with ":" after trimming
+            if (IsSubSectionLabel(trimmed))
+            {
+                inSubSection = true;
+                panel.Children.Add(new SelectableTextBlock
+                {
+                    Text = "  " + trimmed,
+                    FontFamily = MonoFont,
+                    FontSize = 12,
+                    FontWeight = FontWeight.SemiBold,
+                    Foreground = LabelBrush,
+                    Margin = new Avalonia.Thickness(0, 6, 0, 2),
+                    TextWrapping = TextWrapping.Wrap
+                });
+                continue;
+            }
+
+            // Bullet lines: "   * ..."
+            if (trimmed.StartsWith("* "))
+            {
+                panel.Children.Add(new SelectableTextBlock
+                {
+                    Text = line,
+                    FontFamily = MonoFont,
+                    FontSize = 12,
+                    Foreground = MutedBrush,
+                    Margin = new Avalonia.Thickness(8, 1, 0, 1),
+                    TextWrapping = TextWrapping.Wrap
+                });
+                continue;
+            }
+
+            // Wait stats lines: "  WAITTYPE: 1,234ms" — color by category
+            if (trimmed.Contains("ms") && trimmed.Contains(':'))
+            {
+                var waitColon = trimmed.IndexOf(':');
+                if (waitColon > 0 && waitColon < trimmed.Length - 1)
+                {
+                    var waitName = trimmed[..waitColon];
+                    var waitValue = trimmed[(waitColon + 1)..].Trim();
+                    if (waitValue.EndsWith("ms") && waitName == waitName.ToUpperInvariant() && !waitName.Contains(' '))
+                    {
+                        panel.Children.Add(CreateWaitStatLine(waitName, waitValue, inSubSection));
+                        continue;
+                    }
+                }
+            }
+
+            // Key-value lines: "Label: value"
+            var colonIdx = line.IndexOf(':');
+            if (colonIdx > 0 && colonIdx < line.Length - 1)
+            {
+                var labelPart = line[..colonIdx].TrimStart();
+                if (labelPart.Length < 40 && !labelPart.Contains('(') && !labelPart.Contains('='))
+                {
+                    var indent = inSubSection ? 8.0 : 0.0;
+                    var tb = new SelectableTextBlock
+                    {
+                        FontFamily = MonoFont,
+                        FontSize = 12,
+                        TextWrapping = TextWrapping.Wrap,
+                        Margin = new Avalonia.Thickness(indent, 1, 0, 1)
+                    };
+                    tb.Inlines!.Add(new Run(labelPart + ":") { Foreground = LabelBrush });
+                    tb.Inlines.Add(new Run(line[(colonIdx + 1)..]) { Foreground = ValueBrush });
+                    panel.Children.Add(tb);
+                    continue;
+                }
+            }
+
+            // Default: regular text
+            panel.Children.Add(new SelectableTextBlock
+            {
+                Text = line,
+                FontFamily = MonoFont,
+                FontSize = 12,
+                Foreground = ValueBrush,
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Avalonia.Thickness(0, 1)
+            });
+        }
+
+        return panel;
+    }
+
+    private static bool IsSubSectionLabel(string trimmed)
+    {
+        // "Warnings:", "Parameters:", "Wait stats:", "Operator warnings:",
+        // "Missing indexes:", "Expensive operators:"
+        if (!trimmed.EndsWith(":")) return false;
+        var label = trimmed[..^1];
+        // Sub-section labels are short, may contain spaces, and are all-alpha
+        return label.Length < 30 && !label.Contains('=') && !label.Contains('(');
+    }
+
+    private static SelectableTextBlock BuildSqlHighlightedLine(string line)
+    {
+        var tb = new SelectableTextBlock
+        {
+            FontFamily = MonoFont,
+            FontSize = 12,
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Avalonia.Thickness(4, 1, 0, 1)
+        };
+
+        int pos = 0;
+        var text = line.TrimStart();
+        while (pos < text.Length)
+        {
+            if (!char.IsLetterOrDigit(text[pos]) && text[pos] != '_')
+            {
+                int start = pos;
+                while (pos < text.Length && !char.IsLetterOrDigit(text[pos]) && text[pos] != '_')
+                    pos++;
+                tb.Inlines!.Add(new Run(text[start..pos]) { Foreground = ValueBrush });
+                continue;
+            }
+
+            int wordStart = pos;
+            while (pos < text.Length && (char.IsLetterOrDigit(text[pos]) || text[pos] == '_'))
+                pos++;
+            var word = text[wordStart..pos];
+
+            if (SqlKeywords.Contains(word))
+                tb.Inlines!.Add(new Run(word) { Foreground = SqlKeywordBrush, FontWeight = FontWeight.SemiBold });
+            else
+                tb.Inlines!.Add(new Run(word) { Foreground = ValueBrush });
+        }
+
+        return tb;
+    }
+
+    /// <summary>
+    /// Creates a warning line with a left accent border for better scannability.
+    /// </summary>
+    private static Border CreateWarningBlock(string line, SolidColorBrush severityBrush)
+    {
+        var tb = new SelectableTextBlock
+        {
+            FontFamily = MonoFont,
+            FontSize = 12,
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Avalonia.Thickness(8, 2, 0, 2)
+        };
+
+        foreach (var tag in new[] { "[Critical]", "[Warning]", "[Info]" })
+        {
+            var idx = line.IndexOf(tag);
+            if (idx >= 0)
+            {
+                var afterTag = line[(idx + tag.Length)..].TrimStart();
+                // Extract "Type: Message" — show type in severity color, message in value
+                var typeColon = afterTag.IndexOf(':');
+                if (typeColon > 0)
+                {
+                    var typeName = afterTag[..typeColon];
+                    var message = afterTag[(typeColon + 1)..].TrimStart();
+                    tb.Inlines!.Add(new Run(tag + " ")
+                        { Foreground = severityBrush, FontWeight = FontWeight.SemiBold });
+                    tb.Inlines.Add(new Run(typeName)
+                        { Foreground = severityBrush });
+
+                    // Split on unit separator (U+001F) — TextFormatter encodes \n as \x1F
+                    // so multi-line messages survive the top-level line split in Build().
+                    var messageParts = message.Split('\x1F');
+                    for (int p = 0; p < messageParts.Length; p++)
+                    {
+                        var part = messageParts[p].Trim();
+                        if (string.IsNullOrEmpty(part))
+                            continue;
+
+                        if (part.StartsWith("Predicate:"))
+                        {
+                            tb.Inlines.Add(new Run("\n" + part[..10])
+                                { Foreground = LabelBrush });
+                            tb.Inlines.Add(new Run(part[10..])
+                                { Foreground = CodeBrush });
+                        }
+                        else if (p == 0)
+                        {
+                            // First line: the main description
+                            tb.Inlines.Add(new Run("\n" + part)
+                                { Foreground = ValueBrush });
+                        }
+                        else if (part.StartsWith("• "))
+                        {
+                            // Bullet stats: bullet in muted, value in white
+                            tb.Inlines.Add(new Run("\n  • ")
+                                { Foreground = MutedBrush });
+                            tb.Inlines.Add(new Run(part[2..])
+                                { Foreground = ValueBrush });
+                        }
+                        else
+                        {
+                            // Other detail lines
+                            tb.Inlines.Add(new Run("\n" + part)
+                                { Foreground = MutedBrush });
+                        }
+                    }
+                }
+                else
+                {
+                    tb.Inlines!.Add(new Run(tag)
+                        { Foreground = severityBrush, FontWeight = FontWeight.SemiBold });
+                    tb.Inlines.Add(new Run(" " + afterTag)
+                        { Foreground = ValueBrush });
+                }
+
+                return new Border
+                {
+                    BorderBrush = severityBrush,
+                    BorderThickness = new Avalonia.Thickness(2, 0, 0, 0),
+                    Padding = new Avalonia.Thickness(0),
+                    Margin = new Avalonia.Thickness(4, 2, 0, 2),
+                    Child = tb
+                };
+            }
+        }
+
+        tb.Text = line.TrimStart();
+        tb.Foreground = severityBrush;
+        return new Border
+        {
+            BorderBrush = severityBrush,
+            BorderThickness = new Avalonia.Thickness(2, 0, 0, 0),
+            Padding = new Avalonia.Thickness(0),
+            Margin = new Avalonia.Thickness(4, 2, 0, 2),
+            Child = tb
+        };
+    }
+
+    private static SelectableTextBlock CreateOperatorLine(string line)
+    {
+        var tb = new SelectableTextBlock
+        {
+            FontFamily = MonoFont,
+            FontSize = 12,
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Avalonia.Thickness(8, 2, 0, 0)
+        };
+
+        var trimmed = line.TrimStart();
+        var parenIdx = trimmed.LastIndexOf('(');
+
+        if (parenIdx > 0)
+        {
+            var opName = trimmed[..parenIdx].TrimEnd();
+            var rest = trimmed[parenIdx..];
+            tb.Inlines!.Add(new Run(opName) { Foreground = OperatorBrush, FontWeight = FontWeight.SemiBold });
+            tb.Inlines.Add(new Run(" " + rest) { Foreground = MutedBrush });
+        }
+        else
+        {
+            tb.Text = trimmed;
+            tb.Foreground = OperatorBrush;
+            tb.FontWeight = FontWeight.SemiBold;
+        }
+
+        return tb;
+    }
+
+    /// <summary>
+    /// Renders timing line like "4,616ms CPU (61%), 586ms elapsed (62%)"
+    /// with ms values in white and percentages in amber.
+    /// </summary>
+    private static SelectableTextBlock CreateOperatorTimingLine(string trimmed)
+    {
+        var tb = new SelectableTextBlock
+        {
+            FontFamily = MonoFont,
+            FontSize = 12,
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Avalonia.Thickness(16, 1, 0, 1)
+        };
+
+        // Split by ", " to get timing parts like "4,616ms CPU (61%)" and "586ms elapsed (62%)"
+        var parts = trimmed.Split(new[] { ", " }, StringSplitOptions.RemoveEmptyEntries);
+        for (int i = 0; i < parts.Length; i++)
+        {
+            if (i > 0)
+                tb.Inlines!.Add(new Run(", ") { Foreground = MutedBrush });
+
+            var part = parts[i].Trim();
+            // Extract percentage in parentheses at the end
+            var pctStart = part.LastIndexOf('(');
+            if (pctStart > 0 && part.EndsWith(")"))
+            {
+                var timePart = part[..pctStart].TrimEnd();
+                var pctPart = part[pctStart..];
+                var brush = timePart.Contains("CPU") ? ValueBrush : MutedBrush;
+                tb.Inlines!.Add(new Run(timePart) { Foreground = brush });
+                tb.Inlines.Add(new Run(" " + pctPart) { Foreground = WarningBrush });
+            }
+            else
+            {
+                var brush = part.Contains("CPU") ? ValueBrush : MutedBrush;
+                tb.Inlines!.Add(new Run(part) { Foreground = brush });
+            }
+        }
+
+        return tb;
+    }
+
+    private static SelectableTextBlock CreateWaitStatLine(string waitName, string waitValue, bool indented)
+    {
+        var leftMargin = indented ? 16.0 : 8.0;
+        var tb = new SelectableTextBlock
+        {
+            FontFamily = MonoFont,
+            FontSize = 12,
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Avalonia.Thickness(leftMargin, 1, 0, 1)
+        };
+
+        var waitBrush = GetWaitCategoryBrush(waitName);
+        tb.Inlines!.Add(new Run(waitName) { Foreground = waitBrush });
+        tb.Inlines.Add(new Run(": " + waitValue) { Foreground = ValueBrush });
+
+        return tb;
+    }
+
+    private static SolidColorBrush GetWaitCategoryBrush(string waitType)
+    {
+        // CPU-related
+        if (waitType.StartsWith("SOS_SCHEDULER") || waitType.StartsWith("CXPACKET") ||
+            waitType.StartsWith("CXCONSUMER") || waitType == "THREADPOOL" ||
+            waitType.StartsWith("EXECSYNC"))
+            return new SolidColorBrush(Color.Parse("#FFB347")); // orange
+
+        // I/O-related
+        if (waitType.StartsWith("PAGEIOLATCH") || waitType.StartsWith("WRITELOG") ||
+            waitType.StartsWith("IO_COMPLETION") || waitType.StartsWith("ASYNC_IO"))
+            return new SolidColorBrush(Color.Parse("#E57373")); // red
+
+        // Lock/blocking
+        if (waitType.StartsWith("LCK_") || waitType.StartsWith("LOCK"))
+            return new SolidColorBrush(Color.Parse("#E57373")); // red
+
+        // Memory
+        if (waitType.StartsWith("RESOURCE_SEMAPHORE") || waitType.StartsWith("CMEMTHREAD"))
+            return new SolidColorBrush(Color.Parse("#C792EA")); // purple
+
+        // Network
+        if (waitType.StartsWith("ASYNC_NETWORK"))
+            return new SolidColorBrush(Color.Parse("#6BB5FF")); // blue
+
+        return LabelBrush; // default muted
+    }
+}

--- a/src/PlanViewer.Core/Output/TextFormatter.cs
+++ b/src/PlanViewer.Core/Output/TextFormatter.cs
@@ -18,21 +18,22 @@ public static class TextFormatter
         {
             WriteServerContext(result.ServerContext, writer);
         }
-        else if (result.SqlServerVersion != null)
+        else if (result.SqlServerBuild != null)
         {
-            writer.WriteLine($"SQL Server: {result.SqlServerVersion} (build {result.SqlServerBuild})");
+            writer.WriteLine($"SQL Server: {result.SqlServerBuild}");
         }
 
-        writer.WriteLine($"=== Statements: {result.Summary.TotalStatements} ===");
-        writer.WriteLine();
-
-        // Summary right after statement count
         writer.WriteLine("=== Summary ===");
+        writer.WriteLine($"Statements: {result.Summary.TotalStatements}");
         writer.WriteLine($"Warnings: {result.Summary.TotalWarnings} ({result.Summary.CriticalWarnings} critical)");
         writer.WriteLine($"Missing indexes: {result.Summary.MissingIndexes}");
         writer.WriteLine($"Actual stats: {(result.Summary.HasActualStats ? "yes" : "no (estimated plan)")}");
         if (result.Summary.WarningTypes.Count > 0)
-            writer.WriteLine($"Warning types: {string.Join(", ", result.Summary.WarningTypes)}");
+        {
+            writer.WriteLine("Warning types:");
+            foreach (var wt in result.Summary.WarningTypes)
+                writer.WriteLine($"  {wt}");
+        }
         writer.WriteLine();
 
         for (int i = 0; i < result.Statements.Count; i++)
@@ -44,7 +45,16 @@ public static class TextFormatter
             writer.WriteLine($"Estimated cost: {stmt.EstimatedCost:F4}");
 
             if (stmt.DegreeOfParallelism > 0)
-                writer.WriteLine($"DOP: {stmt.DegreeOfParallelism}");
+            {
+                var dopLine = $"DOP: {stmt.DegreeOfParallelism}";
+                if (stmt.QueryTime != null && stmt.QueryTime.ElapsedTimeMs > 0 && stmt.QueryTime.CpuTimeMs > 0)
+                {
+                    var idealCpu = stmt.QueryTime.ElapsedTimeMs * stmt.DegreeOfParallelism;
+                    var efficiency = Math.Min(100.0, stmt.QueryTime.CpuTimeMs * 100.0 / idealCpu);
+                    dopLine += $" ({efficiency:N0}% efficient)";
+                }
+                writer.WriteLine(dopLine);
+            }
             if (stmt.NonParallelReason != null)
                 writer.WriteLine($"Serial reason: {stmt.NonParallelReason}");
             if (stmt.QueryTime != null)
@@ -53,10 +63,66 @@ public static class TextFormatter
             {
                 var grantedMB = stmt.MemoryGrant.GrantedKB / 1024.0;
                 var usedMB = stmt.MemoryGrant.MaxUsedKB / 1024.0;
+                var pctUsed = grantedMB > 0 ? usedMB / grantedMB * 100 : 0;
                 var pctContext = "";
                 if (result.ServerContext?.MaxServerMemoryMB > 0)
-                    pctContext = $" ({grantedMB / result.ServerContext.MaxServerMemoryMB * 100:N1}% of max server memory)";
-                writer.WriteLine($"Memory grant: {grantedMB:N1} MB granted, {usedMB:N1} MB used{pctContext}");
+                    pctContext = $", {grantedMB / result.ServerContext.MaxServerMemoryMB * 100:N1}% of max server memory";
+                writer.WriteLine($"Memory grant: {grantedMB:N1} MB granted, {usedMB:N1} MB used ({pctUsed:N0}% utilized{pctContext})");
+            }
+
+            // Expensive operators — promoted to right after memory grant.
+            // Answers "where did the time go?" before drilling into waits/warnings.
+            if (stmt.OperatorTree != null)
+            {
+                var nodeTimings = new List<(OperatorResult Node, long OwnCpuMs, long OwnElapsedMs)>();
+                CollectNodeTimings(stmt.OperatorTree, nodeTimings);
+
+                var topNodes = nodeTimings
+                    .Where(t => t.OwnCpuMs > 0 || t.OwnElapsedMs > 0)
+                    .OrderByDescending(t => Math.Max(t.OwnCpuMs, t.OwnElapsedMs))
+                    .Take(5)
+                    .ToList();
+
+                if (topNodes.Count > 0)
+                {
+                    writer.WriteLine("Expensive operators:");
+                    var totalCpu = stmt.QueryTime?.CpuTimeMs > 0 ? stmt.QueryTime.CpuTimeMs : 0;
+                    var totalElapsed = stmt.QueryTime?.ElapsedTimeMs ?? 0;
+                    foreach (var (n, ownCpu, ownElapsed) in topNodes)
+                    {
+                        var label = n.ObjectName != null
+                            ? $"{n.PhysicalOp} ({n.ObjectName})"
+                            : n.PhysicalOp;
+                        var nodeId = $" (Node {n.NodeId})";
+
+                        writer.WriteLine($"  {label}{nodeId}:");
+
+                        // Timing on its own line
+                        var timeParts = new List<string>();
+                        if (ownCpu > 0)
+                        {
+                            var cpuPct = totalCpu > 0 ? $" ({ownCpu * 100.0 / totalCpu:N0}%)" : "";
+                            timeParts.Add($"{ownCpu:N0}ms CPU{cpuPct}");
+                        }
+                        if (ownElapsed > 0)
+                        {
+                            var elPct = totalElapsed > 0 ? $" ({ownElapsed * 100.0 / totalElapsed:N0}%)" : "";
+                            timeParts.Add($"{ownElapsed:N0}ms elapsed{elPct}");
+                        }
+                        if (timeParts.Count > 0)
+                            writer.WriteLine($"    {string.Join(", ", timeParts)}");
+
+                        var details = new List<string>();
+                        if (n.ActualRows > 0)
+                            details.Add($"{n.ActualRows:N0} rows");
+                        if (n.ActualLogicalReads > 0)
+                            details.Add($"{n.ActualLogicalReads:N0} logical reads");
+                        if (n.ActualPhysicalReads > 0)
+                            details.Add($"{n.ActualPhysicalReads:N0} physical reads");
+                        if (details.Count > 0)
+                            writer.WriteLine($"    {string.Join(", ", details)}");
+                    }
+                }
             }
 
             if (stmt.WaitStats.Count > 0)
@@ -79,9 +145,16 @@ public static class TextFormatter
             if (stmt.Warnings.Count > 0)
             {
                 writer.WriteLine();
-                writer.WriteLine("Warnings:");
+                writer.WriteLine("Plan warnings:");
+                var hasDetailedMemoryGrant = stmt.Warnings.Any(w =>
+                    w.Type == "Excessive Memory Grant" || w.Type == "Large Memory Grant");
                 foreach (var w in stmt.Warnings)
-                    writer.WriteLine($"  [{w.Severity}] {w.Type}: {w.Message}");
+                {
+                    // Skip raw XML "Memory Grant" when analyzer provides better context
+                    if (w.Type == "Memory Grant" && hasDetailedMemoryGrant)
+                        continue;
+                    writer.WriteLine($"  [{w.Severity}] {w.Type}: {EscapeNewlines(w.Message)}");
+                }
             }
 
             if (stmt.OperatorTree != null)
@@ -92,8 +165,7 @@ public static class TextFormatter
                 {
                     writer.WriteLine();
                     writer.WriteLine("Operator warnings:");
-                    foreach (var w in nodeWarnings)
-                        writer.WriteLine($"  [{w.Severity}] {w.Operator}: {w.Message}");
+                    WriteGroupedOperatorWarnings(nodeWarnings, writer);
                 }
             }
 
@@ -105,47 +177,6 @@ public static class TextFormatter
                 {
                     writer.WriteLine($"  {mi.Table} (impact: {mi.Impact:F0}%)");
                     writer.WriteLine($"    {mi.CreateStatement}");
-                }
-            }
-
-            // Expensive operators — actual plans only, ranked by actual elapsed time.
-            // Row mode: elapsed is cumulative (parent includes children), so subtract
-            // children's time to isolate each operator's own work.
-            // Batch mode: elapsed is already per-operator.
-            // Estimated plans: no actual stats, nothing to rank — skip entirely.
-            if (stmt.OperatorTree != null)
-            {
-                var nodeTimings = new List<(OperatorResult Node, long OwnElapsedMs)>();
-                CollectNodeTimings(stmt.OperatorTree, nodeTimings);
-
-                var topNodes = nodeTimings
-                    .Where(t => t.OwnElapsedMs > 0)
-                    .OrderByDescending(t => t.OwnElapsedMs)
-                    .Take(5)
-                    .ToList();
-
-                if (topNodes.Count > 0)
-                {
-                    writer.WriteLine();
-                    writer.WriteLine("Expensive operators (by actual duration):");
-                    foreach (var (n, ownMs) in topNodes)
-                    {
-                        var label = n.ObjectName != null
-                            ? $"{n.PhysicalOp} ({n.ObjectName})"
-                            : n.PhysicalOp;
-
-                        var pctStr = stmt.QueryTime != null && stmt.QueryTime.ElapsedTimeMs > 0
-                            ? $" ({ownMs * 100.0 / stmt.QueryTime.ElapsedTimeMs:N0}% of total)"
-                            : "";
-                        writer.WriteLine($"  {label}:");
-                        writer.WriteLine($"   * {ownMs:N0}ms{pctStr}");
-                        if (n.ActualRows > 0)
-                            writer.WriteLine($"   * {n.ActualRows:N0} rows");
-                        if (n.ActualLogicalReads > 0)
-                            writer.WriteLine($"   * {n.ActualLogicalReads:N0} logical reads");
-                        if (n.ActualPhysicalReads > 0)
-                            writer.WriteLine($"   * {n.ActualPhysicalReads:N0} physical reads");
-                    }
                 }
             }
 
@@ -236,35 +267,111 @@ public static class TextFormatter
             CollectNodeWarnings(child, warnings);
     }
 
-    private static void CollectNodeTimings(OperatorResult node, List<(OperatorResult Node, long OwnElapsedMs)> timings)
+    private static void WriteGroupedOperatorWarnings(List<WarningResult> warnings, TextWriter writer)
     {
-        if (node.ActualElapsedMs.HasValue)
+        // Split each message into "data | explanation" at the last sentence boundary
+        // that starts with "The " (the harm assessment). Group by shared explanation.
+        var entries = new List<(string Severity, string Operator, string Data, string? Explanation)>();
+        foreach (var w in warnings)
         {
-            var mode = node.ActualExecutionMode ?? node.ExecutionMode;
-            long ownMs;
-            if (mode == "Batch")
+            var msg = w.Message;
+            string data;
+            string? explanation = null;
+
+            // Find the harm sentence: ". The overestimate/underestimate..."
+            var splitIdx = msg.LastIndexOf(". The ", StringComparison.Ordinal);
+            if (splitIdx > 0)
             {
-                // Batch mode: elapsed is per-operator
-                ownMs = node.ActualElapsedMs.Value;
-            }
-            else if (node.PhysicalOp == "Parallelism")
-            {
-                // Parallel exchanges have misleading inflated times — skip them.
-                // Their own work is negligible; the time they report is mostly
-                // waiting on producers/consumers, not doing real work.
-                ownMs = -1; // sentinel: don't add to timings
+                data = msg[..splitIdx].TrimEnd('.');
+                explanation = msg[(splitIdx + 2)..];
             }
             else
             {
-                // Row mode: elapsed is cumulative, subtract ALL direct children.
-                // Exchange children have unreliable times — skip through to their
-                // real child for the elapsed value.
-                var childSum = GetChildElapsedSum(node);
-                ownMs = Math.Max(0, node.ActualElapsedMs.Value - childSum);
+                data = msg;
             }
 
-            if (ownMs >= 0)
-                timings.Add((node, ownMs));
+            entries.Add((w.Severity, w.Operator ?? "?", data, explanation));
+        }
+
+        // Group entries that share the same severity, type, and explanation
+        var grouped = entries
+            .GroupBy(e => (e.Severity, e.Explanation ?? ""))
+            .ToList();
+
+        foreach (var group in grouped)
+        {
+            var items = group.ToList();
+            if (items.Count > 1 && group.Key.Item2 != "")
+            {
+                // Multiple operators with the same explanation — list compactly
+                foreach (var item in items)
+                    writer.WriteLine($"  [{item.Severity}] {item.Operator}: {EscapeNewlines(item.Data)}");
+                writer.WriteLine($"  -> {group.Key.Item2}");
+            }
+            else
+            {
+                // Unique explanation or no explanation — write individually
+                foreach (var item in items)
+                {
+                    var full = item.Explanation != null ? $"{item.Data}. {item.Explanation}" : item.Data;
+                    writer.WriteLine($"  [{item.Severity}] {item.Operator}: {EscapeNewlines(full)}");
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Replaces newlines with unit separator (U+001F) so multi-line warning messages
+    /// survive the top-level line split in AdviceContentBuilder.Build().
+    /// CreateWarningBlock splits on U+001F to restore the internal structure.
+    /// </summary>
+    private static string EscapeNewlines(string text) => text.Replace('\n', '\x1F');
+
+    private static void CollectNodeTimings(OperatorResult node, List<(OperatorResult Node, long OwnCpuMs, long OwnElapsedMs)> timings)
+    {
+        // Skip exchanges — negligible own work, misleading elapsed times
+        if (node.PhysicalOp != "Parallelism")
+        {
+            var mode = node.ActualExecutionMode ?? node.ExecutionMode;
+
+            // Compute own CPU
+            long ownCpu = 0;
+            if (node.ActualCpuMs.HasValue)
+            {
+                if (mode == "Batch")
+                    ownCpu = node.ActualCpuMs.Value;
+                else
+                {
+                    var childCpuSum = GetChildCpuSum(node);
+                    ownCpu = Math.Max(0, node.ActualCpuMs.Value - childCpuSum);
+                }
+            }
+
+            // Compute own elapsed
+            long ownElapsed = 0;
+            if (node.ActualElapsedMs.HasValue)
+            {
+                if (mode == "Batch")
+                    ownElapsed = node.ActualElapsedMs.Value;
+                else
+                {
+                    var childSum = GetChildElapsedSum(node);
+                    ownElapsed = Math.Max(0, node.ActualElapsedMs.Value - childSum);
+                }
+            }
+
+            // When CPU data is available, only include operators that did real CPU work.
+            // Row-mode elapsed with 0 CPU is a cumulative timing artifact, not real work.
+            if (node.ActualCpuMs.HasValue)
+            {
+                if (ownCpu > 0)
+                    timings.Add((node, ownCpu, ownElapsed));
+            }
+            else if (ownElapsed > 0)
+            {
+                // No CPU data (estimated plans) — fall back to elapsed only
+                timings.Add((node, 0, ownElapsed));
+            }
         }
 
         foreach (var child in node.Children)
@@ -272,10 +379,30 @@ public static class TextFormatter
     }
 
     /// <summary>
+    /// Sums CPU time from all direct children, skipping through transparent
+    /// operators (Compute Scalar, etc.) that have no runtime stats.
+    /// </summary>
+    private static long GetChildCpuSum(OperatorResult node)
+    {
+        long sum = 0;
+        foreach (var child in node.Children)
+        {
+            if (child.ActualCpuMs.HasValue)
+            {
+                sum += child.ActualCpuMs.Value;
+            }
+            else
+            {
+                // Transparent operator (e.g. Compute Scalar) — skip through
+                sum += GetChildCpuSum(child);
+            }
+        }
+        return sum;
+    }
+
+    /// <summary>
     /// Sums elapsed time from all direct children, skipping through exchange
-    /// operators (their times are unreliable — they accumulate downstream wait
-    /// time from e.g. spilling sorts). For exchanges, uses the max elapsed of
-    /// the exchange's own children as the effective elapsed value.
+    /// and transparent operators.
     /// </summary>
     private static long GetChildElapsedSum(OperatorResult node)
     {
@@ -285,7 +412,6 @@ public static class TextFormatter
             long childTime;
             if (child.PhysicalOp == "Parallelism" && child.Children.Count > 0)
             {
-                // Exchange: skip through, use max of its children
                 childTime = child.Children
                     .Where(c => c.ActualElapsedMs.HasValue)
                     .Select(c => c.ActualElapsedMs!.Value)
@@ -298,7 +424,6 @@ public static class TextFormatter
             }
             else
             {
-                // No stats (e.g. Compute Scalar) — transparent, skip through
                 childTime = GetChildElapsedSum(child);
             }
             sum += childTime;

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.cs
@@ -61,7 +61,8 @@ public static class PlanAnalyzer
         [21] = "CTE Multiple References", [22] = "Table Variable", [23] = "Table-Valued Function",
         [24] = "Top Above Scan", [25] = "Ineffective Parallelism", [26] = "Row Goal",
         [27] = "Optimize For Unknown", [28] = "NOT IN with Nullable Column",
-        [29] = "Implicit Conversion", [30] = "Wide Index Suggestion"
+        [29] = "Implicit Conversion", [30] = "Wide Index Suggestion",
+        [31] = "Parallel Wait Bottleneck"
     };
 
     // Reverse lookup: WarningType → rule number
@@ -276,20 +277,16 @@ public static class PlanAnalyzer
         // Rule 25: Ineffective parallelism — parallel plan where CPU ≈ elapsed
         // In an effective parallel plan, CPU time should be significantly higher than
         // elapsed time because multiple threads are working simultaneously.
-        // When they're nearly equal, the work ran essentially serially despite the
-        // overhead of thread scheduling and exchanges.
+        // When they're nearly equal (ratio 0.8–1.3), the work ran essentially serially.
         if (!cfg.IsRuleDisabled(25) && stmt.DegreeOfParallelism > 1 && stmt.QueryTimeStats != null)
         {
             var cpu = stmt.QueryTimeStats.CpuTimeMs;
             var elapsed = stmt.QueryTimeStats.ElapsedTimeMs;
 
-            // Only flag if elapsed is meaningful (>= 1 second) to avoid noise
             if (elapsed >= 1000 && cpu > 0)
             {
                 var ratio = (double)cpu / elapsed;
-                // A well-parallelized query at DOP N should have CPU/Elapsed near N.
-                // If CPU/Elapsed is close to 1.0, work was essentially serial.
-                if (ratio <= 1.3)
+                if (ratio >= 0.8 && ratio <= 1.3)
                 {
                     stmt.PlanWarnings.Add(new PlanWarning
                     {
@@ -297,6 +294,33 @@ public static class PlanAnalyzer
                         Message = $"Parallel plan (DOP {stmt.DegreeOfParallelism}) but CPU time ({cpu:N0}ms) is nearly equal to elapsed time ({elapsed:N0}ms). " +
                                   $"The work ran essentially serially despite the overhead of parallelism. " +
                                   $"Look for parallel thread skew, blocking exchanges, or serial zones in the plan that prevent effective parallel execution.",
+                        Severity = PlanWarningSeverity.Warning
+                    });
+                }
+            }
+        }
+
+        // Rule 31: Parallel wait bottleneck — elapsed time significantly exceeds CPU time
+        // When elapsed >> CPU in a parallel plan, threads are spending time waiting rather
+        // than doing CPU work. Common causes: spills to tempdb, physical I/O, blocking,
+        // memory grant waits, or other resource contention.
+        if (!cfg.IsRuleDisabled(31) && stmt.DegreeOfParallelism > 1 && stmt.QueryTimeStats != null)
+        {
+            var cpu = stmt.QueryTimeStats.CpuTimeMs;
+            var elapsed = stmt.QueryTimeStats.ElapsedTimeMs;
+
+            if (elapsed >= 1000 && cpu > 0)
+            {
+                var ratio = (double)cpu / elapsed;
+                if (ratio < 0.8)
+                {
+                    var waitPct = (1.0 - ratio) * 100;
+                    stmt.PlanWarnings.Add(new PlanWarning
+                    {
+                        WarningType = "Parallel Wait Bottleneck",
+                        Message = $"Parallel plan (DOP {stmt.DegreeOfParallelism}) with elapsed time ({elapsed:N0}ms) significantly exceeding CPU time ({cpu:N0}ms). " +
+                                  $"Approximately {waitPct:N0}% of elapsed time was spent waiting rather than on CPU. " +
+                                  $"Common causes include spills to tempdb, physical I/O reads, lock or latch contention, and memory grant waits.",
                         Severity = PlanWarningSeverity.Warning
                     });
                 }
@@ -381,10 +405,16 @@ public static class PlanAnalyzer
         if (!cfg.IsRuleDisabled(1) && node.PhysicalOp == "Filter" && !string.IsNullOrEmpty(node.Predicate))
         {
             var impact = QuantifyFilterImpact(node);
+            var predicate = Truncate(node.Predicate, 200);
+            var message = "Filter operator discarding rows late in the plan.";
+            if (!string.IsNullOrEmpty(impact))
+                message += $"\n{impact}";
+            message += $"\nPredicate: {predicate}";
+
             node.Warnings.Add(new PlanWarning
             {
                 WarningType = "Filter Operator",
-                Message = $"Filter operator discarding rows late in the plan.{impact} Predicate: {Truncate(node.Predicate, 200)}",
+                Message = message,
                 Severity = PlanWarningSeverity.Warning
             });
         }
@@ -451,12 +481,12 @@ public static class PlanAnalyzer
                         var direction = ratio >= 10.0 ? "underestimated" : "overestimated";
                         var factor = ratio >= 10.0 ? ratio : 1.0 / ratio;
                         var actualDisplay = executions > 1
-                            ? $"actual {actualPerExec:N0}/exec ({node.ActualRows:N0} total across {executions:N0} executions)"
-                            : $"actual {node.ActualRows:N0}";
+                            ? $"Actual {node.ActualRows:N0} ({actualPerExec:N0} rows x {executions:N0} executions)"
+                            : $"Actual {node.ActualRows:N0}";
                         node.Warnings.Add(new PlanWarning
                         {
                             WarningType = "Row Estimate Mismatch",
-                            Message = $"Estimated {node.EstimateRows:N0} rows, {actualDisplay} ({factor:F0}x {direction}). {harm}",
+                            Message = $"Estimated {node.EstimateRows:N0} vs {actualDisplay} — {factor:F0}x {direction}. {harm}",
                             Severity = factor >= 100 ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning
                         });
                     }
@@ -572,7 +602,7 @@ public static class PlanAnalyzer
             node.Warnings.Add(new PlanWarning
             {
                 WarningType = "Key Lookup",
-                Message = $"Key Lookup — SQL Server found rows via a nonclustered index but had to go back to the clustered index for additional columns. Alter the nonclustered index to add the predicate column as a key column or as an INCLUDE column. Predicate: {Truncate(node.Predicate, 200)}",
+                Message = $"Key Lookup — SQL Server found rows via a nonclustered index but had to go back to the clustered index for additional columns. Alter the nonclustered index to add the predicate column as a key column or as an INCLUDE column.\nPredicate: {Truncate(node.Predicate, 200)}",
                 Severity = PlanWarningSeverity.Warning
             });
         }
@@ -600,7 +630,7 @@ public static class PlanAnalyzer
             node.Warnings.Add(new PlanWarning
             {
                 WarningType = "Non-SARGable Predicate",
-                Message = $"{nonSargableAdvice} Predicate: {Truncate(node.Predicate!, 200)}",
+                Message = $"{nonSargableAdvice}\nPredicate: {Truncate(node.Predicate!, 200)}",
                 Severity = PlanWarningSeverity.Warning
             });
         }
@@ -610,10 +640,11 @@ public static class PlanAnalyzer
         if (!cfg.IsRuleDisabled(11) && nonSargableReason == null && IsRowstoreScan(node) && !string.IsNullOrEmpty(node.Predicate) &&
             !IsProbeOnly(node.Predicate))
         {
+            var displayPredicate = StripProbeExpressions(node.Predicate);
             node.Warnings.Add(new PlanWarning
             {
                 WarningType = "Scan With Predicate",
-                Message = $"Scan with residual predicate — SQL Server is reading every row and filtering after the fact. Create an index on the predicate columns. Predicate: {Truncate(node.Predicate, 200)}",
+                Message = $"Scan with residual predicate — SQL Server is reading every row and filtering after the fact. Check that you have appropriate indexes.\nPredicate: {Truncate(displayPredicate, 200)}",
                 Severity = PlanWarningSeverity.Warning
             });
         }
@@ -822,7 +853,7 @@ public static class PlanAnalyzer
                     inner.Warnings.Add(new PlanWarning
                     {
                         WarningType = "Top Above Scan",
-                        Message = $"Top operator reads from {scanCandidate.PhysicalOp} (Node {scanCandidate.NodeId}) on the inner side of Nested Loops (Node {node.NodeId}).{predInfo} Create an index on the predicate columns to convert the scan into a seek.",
+                        Message = $"Top operator reads from {scanCandidate.PhysicalOp} (Node {scanCandidate.NodeId}) on the inner side of Nested Loops (Node {node.NodeId}).{predInfo} Check that you have appropriate indexes to convert the scan into a seek.",
                         Severity = PlanWarningSeverity.Warning
                     });
                 }
@@ -940,6 +971,21 @@ public static class PlanAnalyzer
 
         // If nothing meaningful remains, it was PROBE-only
         return stripped.Length == 0;
+    }
+
+    /// <summary>
+    /// Strips PROBE(...) bitmap filter expressions from a predicate for display,
+    /// leaving only the real residual predicate columns.
+    /// </summary>
+    private static string StripProbeExpressions(string predicate)
+    {
+        var stripped = Regex.Replace(predicate, @"\s*AND\s+PROBE\s*\([^()]*(?:\([^()]*\)[^()]*)*\)", "",
+            RegexOptions.IgnoreCase);
+        stripped = Regex.Replace(stripped, @"PROBE\s*\([^()]*(?:\([^()]*\)[^()]*)*\)\s*AND\s+", "",
+            RegexOptions.IgnoreCase);
+        stripped = Regex.Replace(stripped, @"PROBE\s*\([^()]*(?:\([^()]*\)[^()]*)*\)", "",
+            RegexOptions.IgnoreCase);
+        return stripped.Trim();
     }
 
     /// <summary>
@@ -1223,7 +1269,7 @@ public static class PlanAnalyzer
         if (parts.Count == 0)
             return "";
 
-        return $" Subtree cost to produce filtered rows: {string.Join(", ", parts)}.";
+        return string.Join("\n", parts.Select(p => "• " + p));
     }
 
     private static long SumSubtreeReads(PlanNode node)


### PR DESCRIPTION
## Summary
- **Expensive operators**: Multi-line format with both CPU and elapsed timing, node IDs for cross-referencing, fix for transparent operator CPU subtraction
- **New Rule 31**: Parallel Wait Bottleneck — fires when elapsed >> CPU in parallel plans
- **Rule 25**: Tightened Ineffective Parallelism threshold to 0.8–1.3
- **Warning formatting**: Structured multi-line format with bullet stats for filter/lookup/predicate warnings; U+001F encoding to preserve internal newlines through line splitter
- **Advice window**: SelectableTextBlock for copy/paste, color-coded timing lines, operator name detection
- **UI consistency**: Server Context pane always visible (placeholder when no metadata), Runtime Summary empty state, disabled Query Store button in file-mode toolbar
- **Toolbar**: Shortened button labels (Human Advice, Robot Advice, Copy Repro, Run Repro) to prevent overflow
- **Wait Stats**: Wider panel (2* column, MinWidth=280)

## Test plan
- [x] Open file-based .sqlplan — verify Server Context shows placeholder, Query Store button visible but disabled
- [x] Expensive operators show multi-line format with CPU/elapsed percentages and node IDs
- [x] Filter/lookup warnings render with bullet stats inside warning border (not escaping)
- [x] Toolbar buttons fit without overflow on standard 1080p+ display
- [x] All buttons visible in both Query Session and file-mode toolbars

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #48