### PR TITLE
Add Check for Updates to About window

### DIFF
--- a/src/PlanViewer.App/AboutWindow.axaml
+++ b/src/PlanViewer.App/AboutWindow.axaml
@@ -2,7 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="PlanViewer.App.AboutWindow"
         Title="About Performance Studio"
-        Width="450" Height="460"
+        Width="450" Height="500"
         CanResize="False"
         WindowStartupLocation="CenterOwner"
         Icon="avares://PlanViewer.App/EDD.ico"
@@ -44,6 +44,17 @@
                        Text="www.erikdarling.com"
                        PointerPressed="DarlingDataLink_Click"
                        TextDecorations="Underline"/>
+            <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,6,0,0">
+                <Button x:Name="CheckUpdateButton" Content="Check for Updates"
+                        Click="CheckUpdate_Click" Padding="10,4" FontSize="12"/>
+                <TextBlock x:Name="UpdateStatusText" FontSize="12" VerticalAlignment="Center"
+                           Foreground="{DynamicResource ForegroundBrush}"/>
+                <TextBlock x:Name="UpdateLink" FontSize="12" VerticalAlignment="Center"
+                           Foreground="{DynamicResource AccentBrush}"
+                           Cursor="Hand" IsVisible="False"
+                           TextDecorations="Underline"
+                           PointerPressed="UpdateLink_Click"/>
+            </StackPanel>
         </StackPanel>
 
         <!-- MCP Settings -->

--- a/src/PlanViewer.App/AboutWindow.axaml.cs
+++ b/src/PlanViewer.App/AboutWindow.axaml.cs
@@ -15,6 +15,7 @@ using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using PlanViewer.App.Mcp;
+using PlanViewer.App.Services;
 
 namespace PlanViewer.App;
 
@@ -70,6 +71,41 @@ public partial class AboutWindow : Window
             await clipboard.SetTextAsync(command);
             McpCopyStatus.Text = "Copied to clipboard!";
         }
+    }
+
+    private string? _updateUrl;
+
+    private async void CheckUpdate_Click(object? sender, RoutedEventArgs e)
+    {
+        CheckUpdateButton.IsEnabled = false;
+        UpdateStatusText.Text = "Checking...";
+        UpdateLink.IsVisible = false;
+
+        var currentVersion = Assembly.GetExecutingAssembly().GetName().Version ?? new Version(0, 0, 0);
+        var result = await UpdateChecker.CheckAsync(currentVersion);
+
+        if (result.Error != null)
+        {
+            UpdateStatusText.Text = $"Error: {result.Error}";
+        }
+        else if (result.UpdateAvailable)
+        {
+            UpdateStatusText.Text = $"New version available:";
+            UpdateLink.Text = result.LatestVersion;
+            UpdateLink.IsVisible = true;
+            _updateUrl = result.ReleaseUrl;
+        }
+        else
+        {
+            UpdateStatusText.Text = $"You're up to date ({result.LatestVersion})";
+        }
+
+        CheckUpdateButton.IsEnabled = true;
+    }
+
+    private void UpdateLink_Click(object? sender, PointerPressedEventArgs e)
+    {
+        if (_updateUrl != null) OpenUrl(_updateUrl);
     }
 
     private void CloseButton_Click(object? sender, RoutedEventArgs e) => Close();

--- a/src/PlanViewer.App/Services/UpdateChecker.cs
+++ b/src/PlanViewer.App/Services/UpdateChecker.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace PlanViewer.App.Services;
+
+public record UpdateCheckResult(bool UpdateAvailable, string? LatestVersion, string? ReleaseUrl, string? Error);
+
+public static class UpdateChecker
+{
+    private const string ReleasesApiUrl =
+        "https://api.github.com/repos/erikdarlingdata/PerformanceStudio/releases/latest";
+
+    private static readonly HttpClient Http = new()
+    {
+        DefaultRequestHeaders =
+        {
+            { "User-Agent", "PerformanceStudio-UpdateCheck" },
+            { "Accept", "application/vnd.github+json" }
+        },
+        Timeout = TimeSpan.FromSeconds(10)
+    };
+
+    public static async Task<UpdateCheckResult> CheckAsync(Version currentVersion)
+    {
+        try
+        {
+            var json = await Http.GetStringAsync(ReleasesApiUrl);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            var tagName = root.GetProperty("tag_name").GetString();
+            var htmlUrl = root.GetProperty("html_url").GetString();
+
+            if (string.IsNullOrEmpty(tagName))
+                return new UpdateCheckResult(false, null, null, "No release tag found");
+
+            // Strip leading 'v' from tag (e.g. "v0.9.0" -> "0.9.0")
+            var versionStr = tagName.StartsWith('v') ? tagName[1..] : tagName;
+
+            if (!Version.TryParse(versionStr, out var latestVersion))
+                return new UpdateCheckResult(false, tagName, htmlUrl, $"Could not parse version: {tagName}");
+
+            var updateAvailable = latestVersion > currentVersion;
+            return new UpdateCheckResult(updateAvailable, tagName, htmlUrl, null);
+        }
+        catch (Exception ex)
+        {
+            return new UpdateCheckResult(false, null, null, ex.Message);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New `UpdateChecker` service hits GitHub releases API to get latest version
- "Check for Updates" button in About window compares running version vs latest release
- Shows "up to date" confirmation or clickable link to the new release page

## Test plan
- [x] Click "Check for Updates" — shows "You're up to date (v0.9.0)" when current
- [x] Error handling works (network timeout, no releases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)