### PR TITLE
Pass AnalysisResult through to AdviceContentBuilder

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -694,7 +694,7 @@ public partial class QuerySessionControl : UserControl
         if (analysis == null) { SetStatus("No plan to analyze", autoClear: false); return; }
 
         var text = TextFormatter.Format(analysis);
-        ShowAdviceWindow("Advice for Humans", text);
+        ShowAdviceWindow("Advice for Humans", text, analysis);
     }
 
     private void RobotAdvice_Click(object? sender, RoutedEventArgs e)
@@ -706,9 +706,9 @@ public partial class QuerySessionControl : UserControl
         ShowAdviceWindow("Advice for Robots", json);
     }
 
-    private void ShowAdviceWindow(string title, string content)
+    private void ShowAdviceWindow(string title, string content, AnalysisResult? analysis = null)
     {
-        var styledContent = AdviceContentBuilder.Build(content);
+        var styledContent = AdviceContentBuilder.Build(content, analysis);
 
         var scrollViewer = new ScrollViewer
         {

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -444,7 +444,7 @@ public partial class MainWindow : Window
         {
             if (viewer.CurrentPlan == null) return;
             var analysis = ResultMapper.Map(viewer.CurrentPlan, "file", viewer.Metadata);
-            ShowAdviceWindow("Advice for Humans", TextFormatter.Format(analysis));
+            ShowAdviceWindow("Advice for Humans", TextFormatter.Format(analysis), analysis);
         };
 
         robotBtn.Click += (_, _) =>
@@ -566,9 +566,9 @@ public partial class MainWindow : Window
         return panel;
     }
 
-    private void ShowAdviceWindow(string title, string content)
+    private void ShowAdviceWindow(string title, string content, AnalysisResult? analysis = null)
     {
-        var styledContent = AdviceContentBuilder.Build(content);
+        var styledContent = AdviceContentBuilder.Build(content, analysis);
 
         var scrollViewer = new ScrollViewer
         {


### PR DESCRIPTION
## Summary

Thread `AnalysisResult` through `ShowAdviceWindow` in both MainWindow and QuerySessionControl so triage cards have access to parsed statement data.

Without this, triage cards in the Advice for Humans window don't render (the `analysis` parameter is always null).

🤖 Generated with [Claude Code](https://claude.com/claude-code)