### PR TITLE
Format memory grants as KB/MB/GB

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -18,6 +18,7 @@ using Avalonia.Platform.Storage;
 using PlanViewer.App.Helpers;
 using PlanViewer.App.Mcp;
 using PlanViewer.Core.Models;
+using PlanViewer.Core.Output;
 using PlanViewer.Core.Services;
 
 using AvaloniaPath = Avalonia.Controls.Shapes.Path;
@@ -2622,7 +2623,7 @@ public partial class PlanViewerControl : UserControl
                 ? (double)mg.MaxUsedMemoryKB / mg.GrantedMemoryKB * 100 : 100;
             var grantColor = EfficiencyColor(grantPct);
             AddRow("Memory grant",
-                $"{mg.GrantedMemoryKB:N0} KB granted, {mg.MaxUsedMemoryKB:N0} KB used ({grantPct:N0}%)",
+                $"{TextFormatter.FormatMemoryGrantKB(mg.GrantedMemoryKB)} granted, {TextFormatter.FormatMemoryGrantKB(mg.MaxUsedMemoryKB)} used ({grantPct:N0}%)",
                 grantColor);
             if (mg.GrantWaitTimeMs > 0)
                 AddRow("Grant wait", $"{mg.GrantWaitTimeMs:N0}ms", "#E57373");

--- a/src/PlanViewer.Core/Output/TextFormatter.cs
+++ b/src/PlanViewer.Core/Output/TextFormatter.cs
@@ -62,13 +62,15 @@ public static class TextFormatter
                 writer.WriteLine($"Runtime: {stmt.QueryTime.ElapsedTimeMs:N0}ms elapsed, {stmt.QueryTime.CpuTimeMs:N0}ms CPU");
             if (stmt.MemoryGrant != null && stmt.MemoryGrant.GrantedKB > 0)
             {
-                var grantedMB = stmt.MemoryGrant.GrantedKB / 1024.0;
-                var usedMB = stmt.MemoryGrant.MaxUsedKB / 1024.0;
-                var pctUsed = grantedMB > 0 ? usedMB / grantedMB * 100 : 0;
+                var pctUsed = stmt.MemoryGrant.GrantedKB > 0
+                    ? (double)stmt.MemoryGrant.MaxUsedKB / stmt.MemoryGrant.GrantedKB * 100 : 0;
                 var pctContext = "";
                 if (result.ServerContext?.MaxServerMemoryMB > 0)
+                {
+                    var grantedMB = stmt.MemoryGrant.GrantedKB / 1024.0;
                     pctContext = $", {grantedMB / result.ServerContext.MaxServerMemoryMB * 100:N1}% of max server memory";
-                writer.WriteLine($"Memory grant: {grantedMB:N1} MB granted, {usedMB:N1} MB used ({pctUsed:N0}% utilized{pctContext})");
+                }
+                writer.WriteLine($"Memory grant: {FormatMemoryGrantKB(stmt.MemoryGrant.GrantedKB)} granted, {FormatMemoryGrantKB(stmt.MemoryGrant.MaxUsedKB)} used ({pctUsed:N0}% utilized{pctContext})");
             }
 
             // Expensive operators — promoted to right after memory grant.
@@ -321,6 +323,21 @@ public static class TextFormatter
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Formats a memory value given in KB to a human-readable string.
+    /// Under 1,024 KB: show KB (e.g., "512 KB").
+    /// 1,024 KB to 1,048,576 KB: show MB with 1 decimal (e.g., "533.3 MB").
+    /// Over 1,048,576 KB: show GB with 2 decimals (e.g., "2.14 GB").
+    /// </summary>
+    public static string FormatMemoryGrantKB(long kb)
+    {
+        if (kb < 1024)
+            return $"{kb:N0} KB";
+        if (kb < 1024 * 1024)
+            return $"{kb / 1024.0:N1} MB";
+        return $"{kb / (1024.0 * 1024.0):N2} GB";
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Add `FormatMemoryGrantKB` helper that picks human-readable units (KB/MB/GB)
- Applied in text output (TextFormatter) and runtime summary pane (PlanViewerControl)
- Reduces visual clutter for large grants (e.g., "2.14 GB" instead of "2,245,632 KB")

Closes #68

## Test plan
- [ ] Open a plan with a large memory grant — verify it shows MB or GB
- [ ] Open a plan with a small grant (<1 MB) — verify it shows KB
- [ ] Text output (Advice for Humans) also uses new format

🤖 Generated with [Claude Code](https://claude.com/claude-code)