### PR TITLE
Fix table variable warnings on modification operators

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -2187,7 +2187,7 @@ public partial class PlanViewerControl : UserControl
 
         if (parameters.Count == 0)
         {
-            var localVars = FindUnresolvedVariables(statement.StatementText, parameters);
+            var localVars = FindUnresolvedVariables(statement.StatementText, parameters, statement.RootNode);
             if (localVars.Count > 0)
             {
                 ParametersHeader.Text = "Parameters";
@@ -2303,7 +2303,7 @@ public partial class PlanViewerControl : UserControl
             }
         }
 
-        var unresolved = FindUnresolvedVariables(statement.StatementText, parameters);
+        var unresolved = FindUnresolvedVariables(statement.StatementText, parameters, statement.RootNode);
         if (unresolved.Count > 0)
         {
             AddParameterAnnotation(
@@ -2350,7 +2350,8 @@ public partial class PlanViewerControl : UserControl
         });
     }
 
-    private static List<string> FindUnresolvedVariables(string queryText, List<PlanParameter> parameters)
+    private static List<string> FindUnresolvedVariables(string queryText, List<PlanParameter> parameters,
+        PlanNode? rootNode = null)
     {
         var unresolved = new List<string>();
         if (string.IsNullOrEmpty(queryText))
@@ -2358,6 +2359,11 @@ public partial class PlanViewerControl : UserControl
 
         var extractedNames = new HashSet<string>(
             parameters.Select(p => p.Name), StringComparer.OrdinalIgnoreCase);
+
+        // Collect table variable names from the plan tree so we don't misreport them as local variables
+        var tableVarNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (rootNode != null)
+            CollectTableVariableNames(rootNode, tableVarNames);
 
         var matches = Regex.Matches(queryText, @"@\w+", RegexOptions.IgnoreCase);
         var seenVars = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -2369,12 +2375,27 @@ public partial class PlanViewerControl : UserControl
                 continue;
             if (varName.StartsWith("@@", StringComparison.OrdinalIgnoreCase))
                 continue;
+            if (tableVarNames.Contains(varName))
+                continue;
 
             seenVars.Add(varName);
             unresolved.Add(varName);
         }
 
         return unresolved;
+    }
+
+    private static void CollectTableVariableNames(PlanNode node, HashSet<string> names)
+    {
+        if (!string.IsNullOrEmpty(node.ObjectName) && node.ObjectName.StartsWith("@"))
+        {
+            // ObjectName is like "@t.c" — extract the table variable name "@t"
+            var dotIdx = node.ObjectName.IndexOf('.');
+            var tvName = dotIdx > 0 ? node.ObjectName[..dotIdx] : node.ObjectName;
+            names.Add(tvName);
+        }
+        foreach (var child in node.Children)
+            CollectTableVariableNames(child, names);
     }
 
     private static void CollectWarnings(PlanNode node, List<PlanWarning> warnings)

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.cs
@@ -388,7 +388,7 @@ public static class PlanAnalyzer
             var modifiesTableVar = false;
             CheckForTableVariables(stmt.RootNode, isModification, ref hasTableVar, ref modifiesTableVar);
 
-            if (hasTableVar)
+            if (hasTableVar && !modifiesTableVar)
             {
                 stmt.PlanWarnings.Add(new PlanWarning
                 {
@@ -865,11 +865,17 @@ public static class PlanAnalyzer
         if (!cfg.IsRuleDisabled(22) && !string.IsNullOrEmpty(node.ObjectName) &&
             node.ObjectName.StartsWith("@"))
         {
+            var isModificationOp = node.PhysicalOp.Contains("Insert", StringComparison.OrdinalIgnoreCase)
+                || node.PhysicalOp.Contains("Update", StringComparison.OrdinalIgnoreCase)
+                || node.PhysicalOp.Contains("Delete", StringComparison.OrdinalIgnoreCase);
+
             node.Warnings.Add(new PlanWarning
             {
                 WarningType = "Table Variable",
-                Message = "Table variable detected. Table variables lack column-level statistics, which causes bad row estimates, join choices, and memory grant decisions. Replace with a #temp table.",
-                Severity = PlanWarningSeverity.Warning
+                Message = isModificationOp
+                    ? "Modifying a table variable forces the entire plan to run single-threaded. Replace with a #temp table to allow parallel execution."
+                    : "Table variable detected. Table variables lack column-level statistics, which causes bad row estimates, join choices, and memory grant decisions. Replace with a #temp table.",
+                Severity = isModificationOp ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning
             });
         }
 


### PR DESCRIPTION
## Summary
- Node-level Rule 22: Insert/Update/Delete on table variables now shows Critical "forces serial" warning instead of generic "lacks statistics"
- Statement-level Rule 22: stats warning only fires when reading from a table variable, not modifying it
- Parameters pane: table variable names (e.g., `@t`) excluded from local variable detection

## Test plan
- [x] Open `table-variable-red-flags.sqlplan` — INSERT node shows Critical warning about forced serialization
- [x] SELECT statement still shows stats warning on table variable scan nodes
- [x] Parameters pane no longer shows false "Local variables detected (@t)"
- [x] 48 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)