### PR TITLE
fix #81

### DIFF
--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -451,20 +451,23 @@ public partial class MainWindow : Window
             Theme = (Avalonia.Styling.ControlTheme)this.FindResource("AppButton")!
         };
 
-        humanBtn.Click += (_, _) =>
+        Action showHumanAdvice = () =>
         {
             if (viewer.CurrentPlan == null) return;
             var analysis = ResultMapper.Map(viewer.CurrentPlan, "file", viewer.Metadata);
             ShowAdviceWindow("Advice for Humans", TextFormatter.Format(analysis), analysis);
         };
 
-        robotBtn.Click += (_, _) =>
+        Action showRobotAdvice = () =>
         {
             if (viewer.CurrentPlan == null) return;
             var analysis = ResultMapper.Map(viewer.CurrentPlan, "file", viewer.Metadata);
             var json = JsonSerializer.Serialize(analysis, new JsonSerializerOptions { WriteIndented = true });
             ShowAdviceWindow("Advice for Robots", json);
         };
+
+        humanBtn.Click += (_, _) => showHumanAdvice();
+        robotBtn.Click += (_, _) => showRobotAdvice();
 
         var compareBtn = new Button
         {
@@ -500,7 +503,7 @@ public partial class MainWindow : Window
             Theme = (Avalonia.Styling.ControlTheme)this.FindResource("AppButton")!
         };
 
-        copyReproBtn.Click += async (_, _) =>
+        Func<System.Threading.Tasks.Task> copyRepro = async () =>
         {
             if (viewer.CurrentPlan == null) return;
             var queryText = GetQueryTextFromPlan(viewer);
@@ -518,10 +521,12 @@ public partial class MainWindow : Window
             }
         };
 
+        copyReproBtn.Click += async (_, _) => await copyRepro();
+
         // Wire up context menu events from PlanViewerControl
-        viewer.HumanAdviceRequested += (_, _) => humanBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
-        viewer.RobotAdviceRequested += (_, _) => robotBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
-        viewer.CopyReproRequested += async (_, _) => copyReproBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+        viewer.HumanAdviceRequested += (_, _) => showHumanAdvice();
+        viewer.RobotAdviceRequested += (_, _) => showRobotAdvice();
+        viewer.CopyReproRequested += async (_, _) => await copyRepro();
 
         var getActualPlanBtn = new Button
         {


### PR DESCRIPTION
## What does this PR do?

Fixes #81

## Which component(s) does this affect?

- [x] Desktop App (PlanViewer.App)
- [ ] Core Library (PlanViewer.Core)
- [ ] CLI Tool (PlanViewer.Cli)
- [ ] SSMS Extension (PlanViewer.Ssms)
- [ ] Tests
- [ ] Documentation

## How was this tested?

Same steps as #81 and confirmed it works.

## The problem

The RaiseEvent(new RoutedEventArgs(Button.ClickEvent)) approach is unreliable in Avalonia — Button.ClickEvent is a bubble-routing event that relies on the visual tree. Calling it programmatically on a button doesn't guarantee the Click handler fires in all scenarios.

The fix extracts the advice logic into showHumanAdvice and showRobotAdvice action delegates, then uses them from both the toolbar button click handlers and the context menu event subscriptions.

Previously, humanBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent)) was used as an indirect bridge — but Avalonia's Button.ClickEvent is a bubble-routed event tied to pointer interactions, and calling RaiseEvent programmatically on a button doesn't reliably trigger its Click handler outside of normal UI interaction. Calling the shared action directly avoids that indirection entirely.



## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceStudio/blob/main/CONTRIBUTING.md)
- [x] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] All tests pass (`dotnet test`)
- [x] I have not introduced any hardcoded credentials or server names
