### PR TITLE
Fix Ctrl+scroll-down not zooming out

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -118,7 +118,8 @@ public partial class PlanViewerControl : UserControl
     public PlanViewerControl()
     {
         InitializeComponent();
-        PlanScrollViewer.PointerWheelChanged += PlanScrollViewer_PointerWheelChanged;
+        // Use Tunnel routing so Ctrl+wheel zoom fires before ScrollViewer consumes the event
+        PlanScrollViewer.AddHandler(PointerWheelChangedEvent, PlanScrollViewer_PointerWheelChanged, Avalonia.Interactivity.RoutingStrategies.Tunnel);
         // Use Tunnel routing so pan handlers fire before ScrollViewer consumes the events
         PlanScrollViewer.AddHandler(PointerPressedEvent, PlanScrollViewer_PointerPressed, Avalonia.Interactivity.RoutingStrategies.Tunnel);
         PlanScrollViewer.AddHandler(PointerMovedEvent, PlanScrollViewer_PointerMoved, Avalonia.Interactivity.RoutingStrategies.Tunnel);

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -60,8 +60,8 @@ public partial class QuerySessionControl : UserControl
         // Keybindings: F5/Ctrl+E for Execute, Ctrl+L for Estimated Plan
         KeyDown += OnKeyDown;
 
-        // Ctrl+mousewheel for font zoom
-        QueryEditor.PointerWheelChanged += OnEditorPointerWheel;
+        // Ctrl+mousewheel for font zoom — use Tunnel so it fires before ScrollViewer consumes scroll-down
+        QueryEditor.AddHandler(Avalonia.Input.InputElement.PointerWheelChangedEvent, OnEditorPointerWheel, Avalonia.Interactivity.RoutingStrategies.Tunnel);
 
         // Code completion
         QueryEditor.TextArea.TextEntering += OnTextEntering;


### PR DESCRIPTION
## Summary
- Switch `PointerWheelChanged` from bubble to tunnel routing so Ctrl+zoom fires before ScrollViewer consumes scroll-down
- Fixes both plan viewer and query editor

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)