### PR TITLE
Fix taskbar icon when app is pinned

### DIFF
--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <ApplicationIcon>EDD.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <Version>1.1.0</Version>
     <Authors>Erik Darling</Authors>


### PR DESCRIPTION
## Summary
- Add `<ApplicationIcon>` to csproj to embed the icon in the exe's PE resources
- Without this, Windows shows the default app icon when pinned to the taskbar

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)