### PR TITLE
Fix RetrievedFromCache always showing False

### DIFF
--- a/src/PlanViewer.Core/Services/ShowPlanParser.cs
+++ b/src/PlanViewer.Core/Services/ShowPlanParser.cs
@@ -409,7 +409,7 @@ public static class ShowPlanParser
         stmt.CachedPlanSizeKB = ParseLong(queryPlanEl.Attribute("CachedPlanSize")?.Value);
         stmt.DegreeOfParallelism = (int)ParseDouble(queryPlanEl.Attribute("DegreeOfParallelism")?.Value);
         stmt.NonParallelPlanReason = queryPlanEl.Attribute("NonParallelPlanReason")?.Value;
-        stmt.RetrievedFromCache = queryPlanEl.Attribute("RetrievedFromCache")?.Value is "true" or "1";
+        stmt.RetrievedFromCache = stmtEl.Attribute("RetrievedFromCache")?.Value is "true" or "1";
         stmt.CompileTimeMs = ParseLong(queryPlanEl.Attribute("CompileTime")?.Value);
         stmt.CompileMemoryKB = ParseLong(queryPlanEl.Attribute("CompileMemory")?.Value);
         stmt.CompileCPUMs = ParseLong(queryPlanEl.Attribute("CompileCPU")?.Value);


### PR DESCRIPTION
## Summary
- Fixes #88
- `RetrievedFromCache` is an attribute on the `<StmtSimple>` XML element, but the parser was reading it from the child `<QueryPlan>` element where it never exists — so it always defaulted to `false`
- One-line fix: changed `queryPlanEl` to `stmtEl` in `ShowPlanParser.cs:412`

## Test plan
- [x] All 48 existing tests pass
- [x] Verified across 19 test `.sqlplan` files that `RetrievedFromCache` always appears on `StmtSimple`, never on `QueryPlan`
- [ ] Manual: open a Query Store plan and confirm "Retrieved From Cache" shows True when expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)