### PR TITLE
Add Query Store search/filter by identifier (#90)

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -980,11 +980,17 @@ public partial class QuerySessionControl : UserControl
         return "Plan";
     }
 
+    private bool HasQueryStoreTab()
+    {
+        return SubTabControl.Items.OfType<TabItem>()
+            .Any(t => t.Content is QueryStoreGridControl);
+    }
+
     private async void QueryStore_Click(object? sender, RoutedEventArgs e)
     {
-        if (_connectionString == null || _selectedDatabase == null)
+        // If a QS tab already exists, always show connection dialog for a fresh tab
+        if (HasQueryStoreTab() || _connectionString == null || _selectedDatabase == null)
         {
-            // No connection — open the connection dialog and wait for it
             await ShowConnectionDialogAsync();
             if (_connectionString == null || _selectedDatabase == null)
                 return;
@@ -1009,7 +1015,11 @@ public partial class QuerySessionControl : UserControl
 
         SetStatus("");
 
-        var grid = new QueryStoreGridControl(_connectionString, _selectedDatabase!);
+        // Build database list from the current DatabaseBox
+        var databases = DatabaseBox.Items.OfType<string>().ToList();
+
+        var grid = new QueryStoreGridControl(_serverConnection!, _credentialService,
+            _selectedDatabase!, databases);
         grid.PlansSelected += OnQueryStorePlansSelected;
 
         var headerText = new TextBlock
@@ -1017,6 +1027,12 @@ public partial class QuerySessionControl : UserControl
             Text = $"Query Store — {_selectedDatabase}",
             VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
             FontSize = 12
+        };
+
+        // Update tab header when database is changed via the grid's picker
+        grid.DatabaseChanged += (_, db) =>
+        {
+            headerText.Text = $"Query Store — {db}";
         };
 
         var closeBtn = new Button

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
@@ -8,23 +8,19 @@
         <Border Grid.Row="0" Background="{DynamicResource BackgroundDarkBrush}" Padding="8,6"
                 BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,0,1">
             <StackPanel Orientation="Horizontal" Spacing="12">
-                <StackPanel Spacing="2" VerticalAlignment="Bottom">
-                    <Button x:Name="SelectAllButton" Content="Select All" Click="SelectAll_Click"
-                            Height="28" Padding="10,0" FontSize="12"
-                            Theme="{StaticResource AppButton}"/>
+                <StackPanel Spacing="4">
+                    <TextBlock Text="Database" Foreground="{DynamicResource ForegroundBrush}" FontSize="11"/>
+                    <ComboBox x:Name="QsDatabaseBox" Width="200" Height="36" FontSize="13"
+                              SelectionChanged="QsDatabase_SelectionChanged"/>
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <Button x:Name="SelectToggleButton" Content="Select All" Click="SelectToggle_Click"
+                                Height="24" Padding="8,0" FontSize="11"
+                                Theme="{StaticResource AppButton}"/>
+                        <Button x:Name="LoadButton" Content="Load Selected" Click="LoadSelected_Click"
+                                Height="24" Padding="8,0" FontSize="11" IsEnabled="False"
+                                Theme="{StaticResource AppButton}"/>
+                    </StackPanel>
                 </StackPanel>
-                <StackPanel Spacing="2" VerticalAlignment="Bottom">
-                    <Button x:Name="SelectNoneButton" Content="Select None" Click="SelectNone_Click"
-                            Height="28" Padding="10,0" FontSize="12"
-                            Theme="{StaticResource AppButton}"/>
-                </StackPanel>
-                <StackPanel Spacing="2" VerticalAlignment="Bottom">
-                    <Button x:Name="LoadButton" Content="Load Selected Plans" Click="LoadSelected_Click"
-                            Height="28" Padding="16,0" FontSize="12" IsEnabled="False"
-                            Theme="{StaticResource AppButton}"/>
-                </StackPanel>
-                <TextBlock Text="|" VerticalAlignment="Bottom" Margin="0,0,0,4"
-                           Foreground="{DynamicResource ForegroundBrush}"/>
                 <StackPanel Spacing="4">
                     <TextBlock Text="Top N" Foreground="{DynamicResource ForegroundBrush}" FontSize="11"/>
                     <NumericUpDown x:Name="TopNBox" Value="25" Minimum="1" Maximum="100"
@@ -39,7 +35,7 @@
                 </StackPanel>
                 <StackPanel Spacing="4">
                     <TextBlock Text="Order by" Foreground="{DynamicResource ForegroundBrush}" FontSize="11"/>
-                    <ComboBox x:Name="OrderByBox" Width="180" Height="36" FontSize="13"
+                    <ComboBox x:Name="OrderByBox" Width="160" Height="36" FontSize="13"
                               SelectedIndex="0">
                         <ComboBoxItem Content="Total CPU" Tag="cpu"/>
                         <ComboBoxItem Content="Avg CPU" Tag="avg-cpu"/>
@@ -56,12 +52,35 @@
                         <ComboBoxItem Content="Executions" Tag="executions"/>
                     </ComboBox>
                 </StackPanel>
-                <StackPanel Spacing="2" VerticalAlignment="Bottom">
+                <StackPanel Spacing="4">
+                    <TextBlock Text="Search by" Foreground="{DynamicResource ForegroundBrush}" FontSize="11"/>
+                    <ComboBox x:Name="SearchTypeBox" Width="120" Height="36" FontSize="13"
+                              SelectedIndex="0">
+                        <ComboBoxItem Content="(none)" Tag=""/>
+                        <ComboBoxItem Content="Query ID" Tag="query-id"/>
+                        <ComboBoxItem Content="Plan ID" Tag="plan-id"/>
+                        <ComboBoxItem Content="Query Hash" Tag="query-hash"/>
+                        <ComboBoxItem Content="Plan Hash" Tag="plan-hash"/>
+                        <ComboBoxItem Content="Module" Tag="module"/>
+                    </ComboBox>
+                </StackPanel>
+                <StackPanel Spacing="4">
+                    <TextBlock Text=" " FontSize="11"/>
+                    <TextBox x:Name="SearchValueBox" Width="200" Height="36" FontSize="13"
+                             Watermark="0x1AB2C3, dbo.MyProc"
+                             KeyDown="SearchValue_KeyDown"/>
+                </StackPanel>
+                <StackPanel Spacing="2" VerticalAlignment="Center">
                     <Button x:Name="FetchButton" Content="Fetch" Click="Fetch_Click"
                             Height="28" Padding="16,0" FontSize="12"
                             Theme="{StaticResource AppButton}"/>
                 </StackPanel>
-                <TextBlock x:Name="StatusText" VerticalAlignment="Bottom" Margin="0,0,0,4"
+                <StackPanel Spacing="2" VerticalAlignment="Center">
+                    <Button x:Name="ClearSearchButton" Content="Clear" Click="ClearSearch_Click"
+                            Height="28" Padding="10,0" FontSize="12"
+                            Theme="{StaticResource AppButton}"/>
+                </StackPanel>
+                <TextBlock x:Name="StatusText" VerticalAlignment="Center"
                            FontSize="12" Foreground="{DynamicResource ForegroundBrush}"/>
             </StackPanel>
         </Border>
@@ -95,6 +114,9 @@
                 </DataGridTemplateColumn>
                 <DataGridTextColumn Header="QueryId" Binding="{ReflectionBinding QueryId}" Width="90"/>
                 <DataGridTextColumn Header="PlanId" Binding="{ReflectionBinding PlanId}" Width="80"/>
+                <DataGridTextColumn Header="Query Hash" Binding="{ReflectionBinding QueryHash}" Width="150"/>
+                <DataGridTextColumn Header="Plan Hash" Binding="{ReflectionBinding QueryPlanHash}" Width="150"/>
+                <DataGridTextColumn Header="Module" Binding="{ReflectionBinding ModuleName}" Width="140"/>
                 <DataGridTextColumn Header="Last Executed (Local)" Binding="{ReflectionBinding LastExecutedLocal}" Width="160"/>
                 <DataGridTextColumn Header="Executions" Binding="{ReflectionBinding ExecsDisplay}" SortMemberPath="ExecsSort" Width="100"/>
                 <DataGridTextColumn Header="Total CPU (ms)" Binding="{ReflectionBinding TotalCpuDisplay}" SortMemberPath="TotalCpuSort" Width="120"/>

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
@@ -10,6 +10,8 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
 using Avalonia.Media;
+using Microsoft.Data.SqlClient;
+using PlanViewer.Core.Interfaces;
 using PlanViewer.Core.Models;
 using PlanViewer.Core.Services;
 
@@ -17,8 +19,10 @@ namespace PlanViewer.App.Controls;
 
 public partial class QueryStoreGridControl : UserControl
 {
-    private readonly string _connectionString;
-    private readonly string _database;
+    private readonly ServerConnection _serverConnection;
+    private readonly ICredentialService _credentialService;
+    private string _connectionString;
+    private string _database;
     private CancellationTokenSource? _fetchCts;
     private ObservableCollection<QueryStoreRow> _rows = new();
     private ObservableCollection<QueryStoreRow> _filteredRows = new();
@@ -27,15 +31,62 @@ public partial class QueryStoreGridControl : UserControl
     private ColumnFilterPopup? _filterPopupContent;
 
     public event EventHandler<List<QueryStorePlan>>? PlansSelected;
+    public event EventHandler<string>? DatabaseChanged;
 
-    public QueryStoreGridControl(string connectionString, string database)
+    public string Database => _database;
+
+    public QueryStoreGridControl(ServerConnection serverConnection, ICredentialService credentialService,
+        string initialDatabase, List<string> databases)
     {
-        _connectionString = connectionString;
-        _database = database;
+        _serverConnection = serverConnection;
+        _credentialService = credentialService;
+        _database = initialDatabase;
+        _connectionString = serverConnection.GetConnectionString(credentialService, initialDatabase);
         InitializeComponent();
         ResultsGrid.ItemsSource = _filteredRows;
         EnsureFilterPopup();
         SetupColumnHeaders();
+        PopulateDatabaseBox(databases, initialDatabase);
+    }
+
+    private void PopulateDatabaseBox(List<string> databases, string selectedDatabase)
+    {
+        QsDatabaseBox.ItemsSource = databases;
+        QsDatabaseBox.SelectedItem = selectedDatabase;
+    }
+
+    private async void QsDatabase_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (QsDatabaseBox.SelectedItem is not string db || db == _database) return;
+
+        // Check if Query Store is enabled on the new database
+        var newConnStr = _serverConnection.GetConnectionString(_credentialService, db);
+        StatusText.Text = "Checking Query Store...";
+
+        try
+        {
+            var (enabled, state) = await QueryStoreService.CheckEnabledAsync(newConnStr);
+            if (!enabled)
+            {
+                StatusText.Text = $"Query Store not enabled on {db} ({state ?? "unknown"})";
+                QsDatabaseBox.SelectedItem = _database; // revert
+                return;
+            }
+        }
+        catch (Exception ex)
+        {
+            StatusText.Text = ex.Message.Length > 60 ? ex.Message[..60] + "..." : ex.Message;
+            QsDatabaseBox.SelectedItem = _database; // revert
+            return;
+        }
+
+        _database = db;
+        _connectionString = newConnStr;
+        _rows.Clear();
+        _filteredRows.Clear();
+        LoadButton.IsEnabled = false;
+        StatusText.Text = "";
+        DatabaseChanged?.Invoke(this, db);
     }
 
     private async void Fetch_Click(object? sender, RoutedEventArgs e)
@@ -47,6 +98,7 @@ public partial class QueryStoreGridControl : UserControl
         var topN = (int)(TopNBox.Value ?? 25);
         var hoursBack = (int)(HoursBackBox.Value ?? 24);
         var orderBy = (OrderByBox.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "cpu";
+        var filter = BuildSearchFilter();
 
         FetchButton.IsEnabled = false;
         LoadButton.IsEnabled = false;
@@ -57,7 +109,7 @@ public partial class QueryStoreGridControl : UserControl
         try
         {
             var plans = await QueryStoreService.FetchTopPlansAsync(
-                _connectionString, topN, orderBy, hoursBack, ct);
+                _connectionString, topN, orderBy, hoursBack, filter, ct);
 
             if (plans.Count == 0)
             {
@@ -70,6 +122,7 @@ public partial class QueryStoreGridControl : UserControl
 
             ApplyFilters();
             LoadButton.IsEnabled = true;
+            SelectToggleButton.Content = "Select None";
         }
         catch (OperationCanceledException)
         {
@@ -85,16 +138,62 @@ public partial class QueryStoreGridControl : UserControl
         }
     }
 
-    private void SelectAll_Click(object? sender, RoutedEventArgs e)
+    private QueryStoreFilter? BuildSearchFilter()
     {
-        foreach (var row in _filteredRows)
-            row.IsSelected = true;
+        var searchType = (SearchTypeBox.SelectedItem as ComboBoxItem)?.Tag?.ToString();
+        var searchValue = SearchValueBox.Text?.Trim();
+
+        if (string.IsNullOrEmpty(searchType) || string.IsNullOrEmpty(searchValue))
+            return null;
+
+        var filter = new QueryStoreFilter();
+
+        switch (searchType)
+        {
+            case "query-id" when long.TryParse(searchValue, out var qid):
+                filter.QueryId = qid;
+                break;
+            case "plan-id" when long.TryParse(searchValue, out var pid):
+                filter.PlanId = pid;
+                break;
+            case "query-hash":
+                filter.QueryHash = searchValue;
+                break;
+            case "plan-hash":
+                filter.QueryPlanHash = searchValue;
+                break;
+            case "module":
+                // Default to dbo schema if no schema specified, following sp_QuickieStore pattern
+                filter.ModuleName = searchValue.Contains('.') ? searchValue : $"dbo.{searchValue}";
+                break;
+            default:
+                return null;
+        }
+
+        return filter;
     }
 
-    private void SelectNone_Click(object? sender, RoutedEventArgs e)
+    private void SearchValue_KeyDown(object? sender, Avalonia.Input.KeyEventArgs e)
     {
+        if (e.Key == Avalonia.Input.Key.Enter)
+        {
+            Fetch_Click(sender, e);
+            e.Handled = true;
+        }
+    }
+
+    private void ClearSearch_Click(object? sender, RoutedEventArgs e)
+    {
+        SearchTypeBox.SelectedIndex = 0;
+        SearchValueBox.Text = "";
+    }
+
+    private void SelectToggle_Click(object? sender, RoutedEventArgs e)
+    {
+        var allSelected = _filteredRows.Count > 0 && _filteredRows.All(r => r.IsSelected);
         foreach (var row in _filteredRows)
-            row.IsSelected = false;
+            row.IsSelected = !allSelected;
+        SelectToggleButton.Content = allSelected ? "Select All" : "Select None";
     }
 
     private void LoadSelected_Click(object? sender, RoutedEventArgs e)
@@ -114,8 +213,11 @@ public partial class QueryStoreGridControl : UserControl
 
     private static readonly Dictionary<string, Func<QueryStoreRow, string>> TextAccessors = new()
     {
-        ["LastExecuted"] = r => r.LastExecutedLocal,
-        ["QueryText"]    = r => r.FullQueryText,
+        ["QueryHash"]     = r => r.QueryHash,
+        ["PlanHash"]      = r => r.QueryPlanHash,
+        ["ModuleName"]    = r => r.ModuleName,
+        ["LastExecuted"]  = r => r.LastExecutedLocal,
+        ["QueryText"]     = r => r.FullQueryText,
     };
 
     private static readonly Dictionary<string, Func<QueryStoreRow, double>> NumericAccessors = new()
@@ -142,21 +244,24 @@ public partial class QueryStoreGridControl : UserControl
         var cols = ResultsGrid.Columns;
         SetColumnFilterButton(cols[1],  "QueryId",        "Query ID");
         SetColumnFilterButton(cols[2],  "PlanId",         "Plan ID");
-        SetColumnFilterButton(cols[3],  "LastExecuted",   "Last Executed (Local)");
-        SetColumnFilterButton(cols[4],  "Executions",     "Executions");
-        SetColumnFilterButton(cols[5],  "TotalCpu",       "Total CPU (ms)");
-        SetColumnFilterButton(cols[6],  "AvgCpu",         "Avg CPU (ms)");
-        SetColumnFilterButton(cols[7],  "TotalDuration",  "Total Duration (ms)");
-        SetColumnFilterButton(cols[8],  "AvgDuration",    "Avg Duration (ms)");
-        SetColumnFilterButton(cols[9],  "TotalReads",     "Total Reads");
-        SetColumnFilterButton(cols[10], "AvgReads",       "Avg Reads");
-        SetColumnFilterButton(cols[11], "TotalWrites",    "Total Writes");
-        SetColumnFilterButton(cols[12], "AvgWrites",      "Avg Writes");
-        SetColumnFilterButton(cols[13], "TotalPhysReads", "Total Physical Reads");
-        SetColumnFilterButton(cols[14], "AvgPhysReads",   "Avg Physical Reads");
-        SetColumnFilterButton(cols[15], "TotalMemory",    "Total Memory (MB)");
-        SetColumnFilterButton(cols[16], "AvgMemory",      "Avg Memory (MB)");
-        SetColumnFilterButton(cols[17], "QueryText",      "Query Text");
+        SetColumnFilterButton(cols[3],  "QueryHash",      "Query Hash");
+        SetColumnFilterButton(cols[4],  "PlanHash",       "Plan Hash");
+        SetColumnFilterButton(cols[5],  "ModuleName",     "Module");
+        SetColumnFilterButton(cols[6],  "LastExecuted",   "Last Executed (Local)");
+        SetColumnFilterButton(cols[7],  "Executions",     "Executions");
+        SetColumnFilterButton(cols[8],  "TotalCpu",       "Total CPU (ms)");
+        SetColumnFilterButton(cols[9],  "AvgCpu",         "Avg CPU (ms)");
+        SetColumnFilterButton(cols[10], "TotalDuration",  "Total Duration (ms)");
+        SetColumnFilterButton(cols[11], "AvgDuration",    "Avg Duration (ms)");
+        SetColumnFilterButton(cols[12], "TotalReads",     "Total Reads");
+        SetColumnFilterButton(cols[13], "AvgReads",       "Avg Reads");
+        SetColumnFilterButton(cols[14], "TotalWrites",    "Total Writes");
+        SetColumnFilterButton(cols[15], "AvgWrites",      "Avg Writes");
+        SetColumnFilterButton(cols[16], "TotalPhysReads", "Total Physical Reads");
+        SetColumnFilterButton(cols[17], "AvgPhysReads",   "Avg Physical Reads");
+        SetColumnFilterButton(cols[18], "TotalMemory",    "Total Memory (MB)");
+        SetColumnFilterButton(cols[19], "AvgMemory",      "Avg Memory (MB)");
+        SetColumnFilterButton(cols[20], "QueryText",      "Query Text");
     }
 
     private void SetColumnFilterButton(DataGridColumn col, string columnId, string label)
@@ -353,6 +458,9 @@ public class QueryStoreRow : INotifyPropertyChanged
 
     public long QueryId => Plan.QueryId;
     public long PlanId => Plan.PlanId;
+    public string QueryHash => Plan.QueryHash;
+    public string QueryPlanHash => Plan.QueryPlanHash;
+    public string ModuleName => Plan.ModuleName;
 
     public string ExecsDisplay => Plan.CountExecutions.ToString("N0");
     public string TotalCpuDisplay => (Plan.TotalCpuTimeUs / 1000.0).ToString("N0");

--- a/src/PlanViewer.App/Dialogs/QueryStoreDialog.axaml.cs
+++ b/src/PlanViewer.App/Dialogs/QueryStoreDialog.axaml.cs
@@ -50,7 +50,7 @@ public partial class QueryStoreDialog : Window
         try
         {
             _plans = await QueryStoreService.FetchTopPlansAsync(
-                _connectionString, topN, orderBy, hoursBack, ct);
+                _connectionString, topN, orderBy, hoursBack, filter: null, ct);
 
             if (_plans.Count == 0)
             {

--- a/src/PlanViewer.App/Mcp/McpQueryStoreTools.cs
+++ b/src/PlanViewer.App/Mcp/McpQueryStoreTools.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using ModelContextProtocol.Server;
 using PlanViewer.App.Services;
 using PlanViewer.Core.Interfaces;
+using PlanViewer.Core.Models;
 using PlanViewer.Core.Services;
 
 #pragma warning disable CA1707 // Identifiers should not contain underscores (MCP snake_case convention)
@@ -51,7 +52,9 @@ public sealed class McpQueryStoreTools
     [Description("Fetches the top N queries from Query Store ranked by the specified metric. " +
         "Uses the application's built-in Query Store query — no arbitrary SQL is executed. " +
         "Each fetched plan is automatically loaded into the application for further analysis " +
-        "with analyze_plan, get_plan_warnings, etc. Returns summary stats and session IDs.")]
+        "with analyze_plan, get_plan_warnings, etc. Returns summary stats and session IDs. " +
+        "Optional filters narrow results server-side by query_id, plan_id, query_hash, " +
+        "plan_hash, or module name (schema.name, supports % wildcards).")]
     public static async Task<string> GetQueryStoreTop(
         PlanSessionManager sessionManager,
         ConnectionStore connectionStore,
@@ -62,7 +65,12 @@ public sealed class McpQueryStoreTools
         [Description("Ranking metric: cpu, avg-cpu, duration, avg-duration, reads, avg-reads, " +
             "writes, avg-writes, physical-reads, avg-physical-reads, memory, avg-memory, executions. " +
             "Default: cpu.")] string order_by = "cpu",
-        [Description("Hours of history to include. Default 24, max 168.")] int hours_back = 24)
+        [Description("Hours of history to include. Default 24, max 168.")] int hours_back = 24,
+        [Description("Filter by Query Store query ID.")] long? query_id = null,
+        [Description("Filter by Query Store plan ID.")] long? plan_id = null,
+        [Description("Filter by query hash (hex, e.g. 0x1AB2C3D4).")] string? query_hash = null,
+        [Description("Filter by query plan hash (hex, e.g. 0x1AB2C3D4).")] string? plan_hash = null,
+        [Description("Filter by module name (schema.name, supports % wildcards).")] string? module = null)
     {
         try
         {
@@ -76,6 +84,20 @@ public sealed class McpQueryStoreTools
             if (hours_back < 1 || hours_back > 168)
                 return "Invalid hours_back value. Must be between 1 and 168.";
 
+            QueryStoreFilter? filter = null;
+            if (query_id != null || plan_id != null ||
+                query_hash != null || plan_hash != null || module != null)
+            {
+                filter = new QueryStoreFilter
+                {
+                    QueryId = query_id,
+                    PlanId = plan_id,
+                    QueryHash = query_hash,
+                    QueryPlanHash = plan_hash,
+                    ModuleName = module,
+                };
+            }
+
             var connectionString = conn.GetConnectionString(credentialService, database);
 
             // Check Query Store is enabled first
@@ -85,7 +107,7 @@ public sealed class McpQueryStoreTools
 
             // Fetch plans using the app's built-in query
             var plans = await QueryStoreService.FetchTopPlansAsync(
-                connectionString, top, order_by, hours_back);
+                connectionString, top, order_by, hours_back, filter);
 
             if (plans.Count == 0)
                 return $"No Query Store data found in [{database}] for the last {hours_back} hours.";
@@ -126,6 +148,9 @@ public sealed class McpQueryStoreTools
                         session_id = sessionId,
                         query_id = qsPlan.QueryId,
                         plan_id = qsPlan.PlanId,
+                        query_hash = qsPlan.QueryHash,
+                        query_plan_hash = qsPlan.QueryPlanHash,
+                        module_name = string.IsNullOrEmpty(qsPlan.ModuleName) ? (string?)null : qsPlan.ModuleName,
                         label,
                         query_text = McpHelpers.Truncate(qsPlan.QueryText, 500),
                         executions = qsPlan.CountExecutions,
@@ -149,6 +174,9 @@ public sealed class McpQueryStoreTools
                         session_id = (string)"",
                         query_id = qsPlan.QueryId,
                         plan_id = qsPlan.PlanId,
+                        query_hash = qsPlan.QueryHash,
+                        query_plan_hash = qsPlan.QueryPlanHash,
+                        module_name = string.IsNullOrEmpty(qsPlan.ModuleName) ? (string?)null : qsPlan.ModuleName,
                         label,
                         query_text = McpHelpers.Truncate(qsPlan.QueryText, 500),
                         executions = qsPlan.CountExecutions,

--- a/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
+++ b/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
@@ -72,11 +72,27 @@ public static class QueryStoreCommand
         var passwordOption = new Option<string?>(
             "--password", "SQL Server password");
 
+        var queryIdOption = new Option<long?>(
+            "--query-id", "Filter by Query Store query ID");
+
+        var planIdOption = new Option<long?>(
+            "--plan-id", "Filter by Query Store plan ID");
+
+        var queryHashOption = new Option<string?>(
+            "--query-hash", "Filter by query hash (hex, e.g. 0x1AB2C3D4)");
+
+        var planHashOption = new Option<string?>(
+            "--plan-hash", "Filter by query plan hash (hex, e.g. 0x1AB2C3D4)");
+
+        var moduleOption = new Option<string?>(
+            "--module", "Filter by module name (schema.name, supports % wildcards)");
+
         var cmd = new Command("query-store", "Analyze top queries from Query Store")
         {
             serverOption, databaseOption, topOption, orderByOption, hoursBackOption,
             outputDirOption, outputOption, compactOption, warningsOnlyOption, configOption,
-            authOption, trustCertOption, loginOption, passwordOption
+            authOption, trustCertOption, loginOption, passwordOption,
+            queryIdOption, planIdOption, queryHashOption, planHashOption, moduleOption
         };
 
         cmd.SetHandler(async (ctx) =>
@@ -95,6 +111,25 @@ public static class QueryStoreCommand
             var trustCert = ctx.ParseResult.GetValueForOption(trustCertOption);
             var login = ctx.ParseResult.GetValueForOption(loginOption);
             var password = ctx.ParseResult.GetValueForOption(passwordOption);
+            var filterQueryId = ctx.ParseResult.GetValueForOption(queryIdOption);
+            var filterPlanId = ctx.ParseResult.GetValueForOption(planIdOption);
+            var filterQueryHash = ctx.ParseResult.GetValueForOption(queryHashOption);
+            var filterPlanHash = ctx.ParseResult.GetValueForOption(planHashOption);
+            var filterModule = ctx.ParseResult.GetValueForOption(moduleOption);
+
+            QueryStoreFilter? filter = null;
+            if (filterQueryId != null || filterPlanId != null ||
+                filterQueryHash != null || filterPlanHash != null || filterModule != null)
+            {
+                filter = new QueryStoreFilter
+                {
+                    QueryId = filterQueryId,
+                    PlanId = filterPlanId,
+                    QueryHash = filterQueryHash,
+                    QueryPlanHash = filterPlanHash,
+                    ModuleName = filterModule,
+                };
+            }
 
             var analyzerConfig = ConfigLoader.Load(configPath);
 
@@ -136,7 +171,7 @@ public static class QueryStoreCommand
             try
             {
                 await RunAsync(connectionString, server, database, top, orderBy, hoursBack,
-                    outputDir, output, compact, warningsOnly, analyzerConfig);
+                    outputDir, output, compact, warningsOnly, analyzerConfig, filter);
             }
             catch (SqlException ex)
             {
@@ -157,7 +192,7 @@ public static class QueryStoreCommand
         string connectionString, string server, string database,
         int top, string orderBy, int hoursBack,
         DirectoryInfo? outputDir, string outputFormat, bool compact, bool warningsOnly,
-        AnalyzerConfig analyzerConfig)
+        AnalyzerConfig analyzerConfig, QueryStoreFilter? filter = null)
     {
         // Verify Query Store is enabled
         Console.Error.Write($"Checking Query Store on {server}/{database}... ");
@@ -174,7 +209,7 @@ public static class QueryStoreCommand
         // Fetch plans
         Console.Error.Write($"Fetching top {top} queries by {orderBy} (last {hoursBack}h)... ");
         var plans = await QueryStoreService.FetchTopPlansAsync(
-            connectionString, top, orderBy, hoursBack);
+            connectionString, top, orderBy, hoursBack, filter);
 
         if (plans.Count == 0)
         {
@@ -195,9 +230,9 @@ public static class QueryStoreCommand
         var summaryLines = new List<string>();
         summaryLines.Add($"=== Query Store Analysis: {database} ({plans.Count} queries, top by {orderBy}, last {hoursBack}h) ===");
         summaryLines.Add("");
-        summaryLines.Add(string.Format(" {0,-4} {1,-10} {2,-10} {3,14} {4,12} {5,8} {6,8}",
-            "#", "Query ID", "Plan ID", metricHeader, "Executions", "Warns", "Crit"));
-        summaryLines.Add(new string('-', 78));
+        summaryLines.Add(string.Format(" {0,-4} {1,-10} {2,-10} {3,-20} {4,-20} {5,14} {6,12} {7,8} {8,8}",
+            "#", "Query ID", "Plan ID", "Query Hash", "Module", metricHeader, "Executions", "Warns", "Crit"));
+        summaryLines.Add(new string('-', 130));
 
         for (int i = 0; i < plans.Count; i++)
         {
@@ -242,17 +277,19 @@ public static class QueryStoreCommand
                 var critical = result.Summary.CriticalWarnings;
                 var metricValue = metricFmt(qsPlan);
 
-                summaryLines.Add(string.Format(" {0,-4} {1,-10} {2,-10} {3,14} {4,12:N0} {5,8} {6,8}",
-                    i + 1, qsPlan.QueryId, qsPlan.PlanId, metricValue,
-                    qsPlan.CountExecutions, warnings, critical));
+                var moduleName = string.IsNullOrEmpty(qsPlan.ModuleName) ? "(ad hoc)" : qsPlan.ModuleName;
+                summaryLines.Add(string.Format(" {0,-4} {1,-10} {2,-10} {3,-20} {4,-20} {5,14} {6,12:N0} {7,8} {8,8}",
+                    i + 1, qsPlan.QueryId, qsPlan.PlanId, qsPlan.QueryHash,
+                    moduleName.Length > 18 ? moduleName[..18] + ".." : moduleName,
+                    metricValue, qsPlan.CountExecutions, warnings, critical));
 
                 Console.Error.WriteLine($"OK ({warnings} warnings, {critical} critical)");
             }
             catch (Exception ex)
             {
                 Console.Error.WriteLine($"ERROR: {ex.Message}");
-                summaryLines.Add(string.Format(" {0,-4} {1,-10} {2,-10} ERROR: {3}",
-                    i + 1, qsPlan.QueryId, qsPlan.PlanId, ex.Message));
+                summaryLines.Add(string.Format(" {0,-4} {1,-10} {2,-10} {3,-20} {4,-20} ERROR: {5}",
+                    i + 1, qsPlan.QueryId, qsPlan.PlanId, qsPlan.QueryHash, "", ex.Message));
             }
         }
 

--- a/src/PlanViewer.Core/Models/QueryStorePlan.cs
+++ b/src/PlanViewer.Core/Models/QueryStorePlan.cs
@@ -2,10 +2,26 @@ using System;
 
 namespace PlanViewer.Core.Models;
 
+/// <summary>
+/// Server-side search filter for Query Store fetches.
+/// All properties are optional — only non-null values generate WHERE clauses.
+/// </summary>
+public class QueryStoreFilter
+{
+    public long? QueryId { get; set; }
+    public long? PlanId { get; set; }
+    public string? QueryHash { get; set; }
+    public string? QueryPlanHash { get; set; }
+    public string? ModuleName { get; set; }
+}
+
 public class QueryStorePlan
 {
     public long QueryId { get; set; }
     public long PlanId { get; set; }
+    public string QueryHash { get; set; } = "";
+    public string QueryPlanHash { get; set; } = "";
+    public string ModuleName { get; set; } = "";
     public string QueryText { get; set; } = "";
     public string PlanXml { get; set; } = "";
 

--- a/src/PlanViewer.Core/Services/QueryStoreService.cs
+++ b/src/PlanViewer.Core/Services/QueryStoreService.cs
@@ -39,10 +39,13 @@ FROM sys.database_query_store_options;";
     /// Plans are estimated plans from the plan cache — Query Store does not store actual execution plans.
     /// Supported orderBy values: cpu, avg-cpu, duration, avg-duration, reads, avg-reads,
     /// writes, avg-writes, physical-reads, avg-physical-reads, memory, avg-memory, executions.
+    /// Optional filter narrows results server-side by query_id, plan_id, query_hash,
+    /// query_plan_hash, or module name (schema.name, supports % wildcards).
     /// </summary>
     public static async Task<List<QueryStorePlan>> FetchTopPlansAsync(
         string connectionString, int topN = 25, string orderBy = "cpu",
-        int hoursBack = 24, CancellationToken ct = default)
+        int hoursBack = 24, QueryStoreFilter? filter = null,
+        CancellationToken ct = default)
     {
         var key = orderBy.ToLowerInvariant();
 
@@ -80,11 +83,55 @@ FROM sys.database_query_store_options;";
             _ => "r.total_cpu_us"
         };
 
+        // Build optional WHERE clauses from filter (parameterized for safety).
+        var filterClauses = new List<string>();
+        var parameters = new List<SqlParameter>();
+
+        if (filter?.QueryId != null)
+        {
+            filterClauses.Add("AND q.query_id = @filterQueryId");
+            parameters.Add(new SqlParameter("@filterQueryId", filter.QueryId.Value));
+        }
+        if (filter?.PlanId != null)
+        {
+            filterClauses.Add("AND r.plan_id = @filterPlanId");
+            parameters.Add(new SqlParameter("@filterPlanId", filter.PlanId.Value));
+        }
+        if (!string.IsNullOrWhiteSpace(filter?.QueryHash))
+        {
+            filterClauses.Add("AND q.query_hash = CONVERT(binary(8), @filterQueryHash, 1)");
+            parameters.Add(new SqlParameter("@filterQueryHash", filter.QueryHash.Trim()));
+        }
+        if (!string.IsNullOrWhiteSpace(filter?.QueryPlanHash))
+        {
+            filterClauses.Add("AND p.query_plan_hash = CONVERT(binary(8), @filterPlanHash, 1)");
+            parameters.Add(new SqlParameter("@filterPlanHash", filter.QueryPlanHash.Trim()));
+        }
+        if (!string.IsNullOrWhiteSpace(filter?.ModuleName))
+        {
+            // Support wildcards (%) like sp_QuickieStore. If no wildcard, exact match.
+            var moduleVal = filter.ModuleName.Trim();
+            if (moduleVal.Contains('%'))
+            {
+                filterClauses.Add("AND OBJECT_SCHEMA_NAME(q.object_id) + N'.' + OBJECT_NAME(q.object_id) LIKE @filterModule");
+            }
+            else
+            {
+                filterClauses.Add("AND OBJECT_SCHEMA_NAME(q.object_id) + N'.' + OBJECT_NAME(q.object_id) = @filterModule");
+            }
+            parameters.Add(new SqlParameter("@filterModule", moduleVal));
+        }
+
+        var filterSql = filterClauses.Count > 0
+            ? "\n" + string.Join("\n", filterClauses)
+            : "";
+
         // 1. plan_agg: aggregate runtime_stats by plan_id only (cheapest grouping,
         //    avoids joining query_text for the entire dataset).
         // 2. ranked: join the small aggregated result to plan to get query_id,
         //    ROW_NUMBER to pick best plan per query.
         // 3. Final SELECT: TOP N, then join query_text + plan XML only for winners.
+        //    Filter clauses applied here where q/p are available.
         var sql = $@"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
@@ -150,12 +197,19 @@ SELECT TOP ({topN})
     CAST(r.total_writes AS bigint),
     CAST(r.total_physical_reads AS bigint),
     CAST(r.total_memory_pages AS bigint),
-    r.last_execution_time
+    r.last_execution_time,
+    CONVERT(varchar(18), q.query_hash, 1),
+    CONVERT(varchar(18), p.query_plan_hash, 1),
+    CASE
+        WHEN q.object_id <> 0
+        THEN OBJECT_SCHEMA_NAME(q.object_id) + N'.' + OBJECT_NAME(q.object_id)
+        ELSE N''
+    END
 FROM ranked r
 JOIN sys.query_store_plan p ON r.plan_id = p.plan_id
 JOIN sys.query_store_query q ON p.query_id = q.query_id
 JOIN sys.query_store_query_text qt ON q.query_text_id = qt.query_text_id
-WHERE r.rn = 1
+WHERE r.rn = 1{filterSql}
 ORDER BY {outerOrder} DESC
 OPTION (LOOP JOIN);";
 
@@ -164,6 +218,8 @@ OPTION (LOOP JOIN);";
         await using var conn = new SqlConnection(connectionString);
         await conn.OpenAsync(ct);
         await using var cmd = new SqlCommand(sql, conn) { CommandTimeout = 120 };
+        foreach (var p in parameters)
+            cmd.Parameters.Add(p);
         await using var reader = await cmd.ExecuteReaderAsync(ct);
 
         while (await reader.ReadAsync(ct))
@@ -191,7 +247,10 @@ OPTION (LOOP JOIN);";
                 TotalLogicalIoWrites = reader.GetInt64(14),
                 TotalPhysicalIoReads = reader.GetInt64(15),
                 TotalMemoryGrantPages = reader.GetInt64(16),
-                LastExecutedUtc = ((DateTimeOffset)reader.GetValue(17)).UtcDateTime
+                LastExecutedUtc = ((DateTimeOffset)reader.GetValue(17)).UtcDateTime,
+                QueryHash = reader.IsDBNull(18) ? "" : reader.GetString(18),
+                QueryPlanHash = reader.IsDBNull(19) ? "" : reader.GetString(19),
+                ModuleName = reader.IsDBNull(20) ? "" : reader.GetString(20),
             });
         }
 


### PR DESCRIPTION
## Summary
- Server-side Query Store search by query_id, plan_id, query_hash, query_plan_hash, and module name (schema-qualified, wildcard support)
- New grid columns: Query Hash, Plan Hash, Module — all with column-level filtering
- Inline search bar with Enter-to-fetch, database picker on QS tab, Select All/None toggle
- Second QS button click shows connection dialog for a fresh tab
- CLI (`--query-id`, `--query-hash`, `--module`, etc.) and MCP tool filter parameters added

## Test plan
- [x] CLI: `--query-hash 0x...` returns matching plans only
- [x] CLI: `--query-id 838` returns single plan
- [x] CLI: `--module "collect.%cpu%"` returns wildcard-matched module plans
- [x] Desktop: Search by dropdown + value box filters server-side on Fetch
- [x] Desktop: Enter key in search box triggers Fetch
- [x] Desktop: Database picker on QS tab switches databases with QS-enabled check
- [x] Desktop: Select All/None toggle button works correctly
- [x] Desktop: Second QS button click opens connection dialog
- [x] Build: 0 errors

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)