### PR TITLE
Add copy commands to Query Store context menu (#91)

### DIFF
--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
@@ -100,8 +100,17 @@
                   BorderThickness="0"
                   ScrollViewer.HorizontalScrollBarVisibility="Auto">
             <DataGrid.ContextMenu>
-                <ContextMenu>
+                <ContextMenu Opening="ContextMenu_Opening">
                     <MenuItem Header="Load Plan" Click="LoadHighlightedPlan_Click"/>
+                    <Separator/>
+                    <MenuItem x:Name="CopyQueryIdItem" Header="Copy Query ID"/>
+                    <MenuItem x:Name="CopyPlanIdItem" Header="Copy Plan ID"/>
+                    <MenuItem x:Name="CopyQueryHashItem" Header="Copy Query Hash"/>
+                    <MenuItem x:Name="CopyPlanHashItem" Header="Copy Plan Hash"/>
+                    <MenuItem x:Name="CopyModuleItem" Header="Copy Module Name"/>
+                    <Separator/>
+                    <MenuItem x:Name="CopyQueryTextItem" Header="Copy Query Text"/>
+                    <MenuItem x:Name="CopyRowItem" Header="Copy Row"/>
                 </ContextMenu>
             </DataGrid.ContextMenu>
             <DataGrid.Columns>

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
@@ -209,6 +209,62 @@ public partial class QueryStoreGridControl : UserControl
             PlansSelected?.Invoke(this, new List<QueryStorePlan> { row.Plan });
     }
 
+    // ── Context menu ────────────────────────────────────────────────────────
+
+    private void ContextMenu_Opening(object? sender, System.ComponentModel.CancelEventArgs e)
+    {
+        var row = ResultsGrid.SelectedItem as QueryStoreRow;
+        var hasRow = row != null;
+
+        CopyQueryIdItem.IsEnabled = hasRow;
+        CopyPlanIdItem.IsEnabled = hasRow;
+        CopyQueryHashItem.IsEnabled = hasRow && !string.IsNullOrEmpty(row!.QueryHash);
+        CopyPlanHashItem.IsEnabled = hasRow && !string.IsNullOrEmpty(row!.QueryPlanHash);
+        CopyModuleItem.IsEnabled = hasRow && !string.IsNullOrEmpty(row!.ModuleName);
+        CopyQueryTextItem.IsEnabled = hasRow;
+        CopyRowItem.IsEnabled = hasRow;
+
+        // Wire click handlers (clear first to avoid stacking)
+        CopyQueryIdItem.Click -= CopyMenuItem_Click;
+        CopyPlanIdItem.Click -= CopyMenuItem_Click;
+        CopyQueryHashItem.Click -= CopyMenuItem_Click;
+        CopyPlanHashItem.Click -= CopyMenuItem_Click;
+        CopyModuleItem.Click -= CopyMenuItem_Click;
+        CopyQueryTextItem.Click -= CopyMenuItem_Click;
+        CopyRowItem.Click -= CopyMenuItem_Click;
+
+        if (!hasRow) return;
+
+        CopyQueryIdItem.Tag = row!.QueryId.ToString();
+        CopyPlanIdItem.Tag = row.PlanId.ToString();
+        CopyQueryHashItem.Tag = row.QueryHash;
+        CopyPlanHashItem.Tag = row.QueryPlanHash;
+        CopyModuleItem.Tag = row.ModuleName;
+        CopyQueryTextItem.Tag = row.FullQueryText;
+        CopyRowItem.Tag = $"{row.QueryId}\t{row.PlanId}\t{row.QueryHash}\t{row.QueryPlanHash}\t{row.ModuleName}\t{row.LastExecutedLocal}\t{row.ExecsDisplay}\t{row.TotalCpuDisplay}\t{row.AvgCpuDisplay}\t{row.TotalDurDisplay}\t{row.AvgDurDisplay}\t{row.TotalReadsDisplay}\t{row.AvgReadsDisplay}\t{row.TotalWritesDisplay}\t{row.AvgWritesDisplay}\t{row.TotalPhysReadsDisplay}\t{row.AvgPhysReadsDisplay}\t{row.TotalMemDisplay}\t{row.AvgMemDisplay}\t{row.FullQueryText}";
+
+        CopyQueryIdItem.Click += CopyMenuItem_Click;
+        CopyPlanIdItem.Click += CopyMenuItem_Click;
+        CopyQueryHashItem.Click += CopyMenuItem_Click;
+        CopyPlanHashItem.Click += CopyMenuItem_Click;
+        CopyModuleItem.Click += CopyMenuItem_Click;
+        CopyQueryTextItem.Click += CopyMenuItem_Click;
+        CopyRowItem.Click += CopyMenuItem_Click;
+    }
+
+    private async void CopyMenuItem_Click(object? sender, RoutedEventArgs e)
+    {
+        if (sender is MenuItem item && item.Tag is string text)
+            await SetClipboardTextAsync(text);
+    }
+
+    private async System.Threading.Tasks.Task SetClipboardTextAsync(string text)
+    {
+        var topLevel = Avalonia.Controls.TopLevel.GetTopLevel(this);
+        if (topLevel?.Clipboard != null)
+            await topLevel.Clipboard.SetTextAsync(text);
+    }
+
     // ── Column filter infrastructure ───────────────────────────────────────
 
     private static readonly Dictionary<string, Func<QueryStoreRow, string>> TextAccessors = new()


### PR DESCRIPTION
## Summary
- Right-click context menu on Query Store grid now includes copy commands for all identifier and data columns
- Copy Query ID, Plan ID, Query Hash, Plan Hash, Module Name, Query Text, and full Row (tab-delimited)
- Items are disabled when no row is selected or the value is empty

## Test plan
- [x] Right-click shows all copy menu items
- [x] Copy Query ID/Plan ID copies numeric value
- [x] Copy Query Hash/Plan Hash copies hex string
- [x] Copy Module Name disabled for ad-hoc queries
- [x] Copy Query Text copies full SQL
- [x] Copy Row copies all columns tab-delimited
- [x] Load Plan still works

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)