### PR TITLE
Fix database picker not changing query editor context (#92)

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -495,11 +495,15 @@ public partial class QuerySessionControl : UserControl
 
     private async Task CaptureAndShowPlan(bool estimated, string? queryTextOverride = null)
     {
-        if (_connectionString == null || _selectedDatabase == null)
+        if (_serverConnection == null || _selectedDatabase == null)
         {
             SetStatus("Connect to a server first", autoClear: false);
             return;
         }
+
+        // Always rebuild connection string from current database selection
+        // to guarantee the picker state is reflected at execution time
+        _connectionString = _serverConnection.GetConnectionString(_credentialService, _selectedDatabase);
 
         var queryText = queryTextOverride?.Trim()
                         ?? GetSelectedTextOrNull()?.Trim()


### PR DESCRIPTION
## Summary
- Rebuild connection string from current `_serverConnection` + `_selectedDatabase` at query execution time
- Eliminates any edge case where cached `_connectionString` could be stale after changing the database picker

## Test plan
- [x] Connect to server, run `SELECT DB_NAME()`, change database picker, run again — returns new database name
- [x] Build: 0 errors

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)