### PR TITLE
Add Query Store history drill-down with multi-plan charting

### DIFF
--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
@@ -102,6 +102,7 @@
             <DataGrid.ContextMenu>
                 <ContextMenu Opening="ContextMenu_Opening">
                     <MenuItem Header="Load Plan" Click="LoadHighlightedPlan_Click"/>
+                    <MenuItem x:Name="ViewHistoryItem" Header="View History" Click="ViewHistory_Click"/>
                     <Separator/>
                     <MenuItem x:Name="CopyQueryIdItem" Header="Copy Query ID"/>
                     <MenuItem x:Name="CopyPlanIdItem" Header="Copy Plan ID"/>

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
@@ -13,6 +13,7 @@ using Avalonia.Media;
 using Microsoft.Data.SqlClient;
 using PlanViewer.Core.Interfaces;
 using PlanViewer.Core.Models;
+using PlanViewer.App.Dialogs;
 using PlanViewer.Core.Services;
 
 namespace PlanViewer.App.Controls;
@@ -218,6 +219,26 @@ public partial class QueryStoreGridControl : UserControl
             PlansSelected?.Invoke(this, new List<QueryStorePlan> { row.Plan });
     }
 
+    private async void ViewHistory_Click(object? sender, RoutedEventArgs e)
+    {
+        if (ResultsGrid.SelectedItem is not QueryStoreRow row) return;
+
+        var hoursBack = (int)(HoursBackBox.Value ?? 24);
+
+        var window = new QueryStoreHistoryWindow(
+            _connectionString,
+            row.QueryId,
+            row.FullQueryText,
+            _database,
+            hoursBack);
+
+        var topLevel = Avalonia.Controls.TopLevel.GetTopLevel(this);
+        if (topLevel is Window parentWindow)
+            await window.ShowDialog(parentWindow);
+        else
+            window.Show();
+    }
+
     // ── Context menu ────────────────────────────────────────────────────────
 
     private void ContextMenu_Opening(object? sender, System.ComponentModel.CancelEventArgs e)
@@ -225,6 +246,7 @@ public partial class QueryStoreGridControl : UserControl
         var row = ResultsGrid.SelectedItem as QueryStoreRow;
         var hasRow = row != null;
 
+        ViewHistoryItem.IsEnabled = hasRow;
         CopyQueryIdItem.IsEnabled = hasRow;
         CopyPlanIdItem.IsEnabled = hasRow;
         CopyQueryHashItem.IsEnabled = hasRow && !string.IsNullOrEmpty(row!.QueryHash);

--- a/src/PlanViewer.App/Dialogs/QueryStoreHistoryWindow.axaml
+++ b/src/PlanViewer.App/Dialogs/QueryStoreHistoryWindow.axaml
@@ -1,0 +1,112 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:scottplot="clr-namespace:ScottPlot.Avalonia;assembly=ScottPlot.Avalonia"
+        x:Class="PlanViewer.App.Dialogs.QueryStoreHistoryWindow"
+        Title="Query Store History"
+        Width="1280" Height="800"
+        MinWidth="900" MinHeight="600"
+        WindowStartupLocation="CenterOwner"
+        Icon="avares://PlanViewer.App/EDD.ico"
+        Background="{DynamicResource BackgroundBrush}">
+
+    <Grid Margin="12" RowDefinitions="Auto,Auto,300,*,Auto">
+
+        <!-- Row 0: Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,8">
+            <TextBlock x:Name="QueryIdentifierText" FontSize="16" FontWeight="Bold"
+                       Foreground="{DynamicResource ForegroundBrush}"/>
+            <TextBlock x:Name="SummaryText" FontSize="12" Margin="0,4,0,0"
+                       Foreground="{DynamicResource ForegroundBrush}"
+                       TextTrimming="CharacterEllipsis"/>
+        </StackPanel>
+
+        <!-- Row 1: Controls toolbar -->
+        <Border Grid.Row="1" Background="{DynamicResource BackgroundDarkBrush}" Padding="8,6"
+                BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" CornerRadius="3"
+                Margin="0,0,0,8">
+            <StackPanel Orientation="Horizontal" Spacing="12">
+                <StackPanel Spacing="2">
+                    <TextBlock Text="Metric" FontSize="11"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <ComboBox x:Name="MetricSelector" Width="200" Height="32" FontSize="13"
+                              SelectionChanged="MetricSelector_SelectionChanged">
+                        <ComboBoxItem Content="Avg CPU (ms)" Tag="AvgCpuMs" IsSelected="True"/>
+                        <ComboBoxItem Content="Avg Duration (ms)" Tag="AvgDurationMs"/>
+                        <ComboBoxItem Content="Avg Logical Reads" Tag="AvgLogicalReads"/>
+                        <ComboBoxItem Content="Avg Logical Writes" Tag="AvgLogicalWrites"/>
+                        <ComboBoxItem Content="Avg Physical Reads" Tag="AvgPhysicalReads"/>
+                        <ComboBoxItem Content="Avg Memory (MB)" Tag="AvgMemoryMb"/>
+                        <ComboBoxItem Content="Avg Rows" Tag="AvgRowcount"/>
+                        <ComboBoxItem Content="Total CPU (ms)" Tag="TotalCpuMs"/>
+                        <ComboBoxItem Content="Total Duration (ms)" Tag="TotalDurationMs"/>
+                        <ComboBoxItem Content="Total Reads" Tag="TotalLogicalReads"/>
+                        <ComboBoxItem Content="Total Writes" Tag="TotalLogicalWrites"/>
+                        <ComboBoxItem Content="Total Physical Reads" Tag="TotalPhysicalReads"/>
+                        <ComboBoxItem Content="Executions" Tag="CountExecutions"/>
+                    </ComboBox>
+                </StackPanel>
+                <StackPanel Spacing="2">
+                    <TextBlock Text="Hours back" FontSize="11"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <NumericUpDown x:Name="HoursBackBox" Value="24" Minimum="1" Maximum="720"
+                                   Width="120" Height="32" FontSize="13" FormatString="0"
+                                   HorizontalContentAlignment="Center"/>
+                </StackPanel>
+                <StackPanel Spacing="2" VerticalAlignment="Bottom">
+                    <Button x:Name="RefreshButton" Content="Refresh" Click="Refresh_Click"
+                            Height="28" Padding="16,0" FontSize="12"
+                            Theme="{StaticResource AppButton}"/>
+                </StackPanel>
+                <TextBlock x:Name="StatusText" VerticalAlignment="Center"
+                           FontSize="12" Foreground="{DynamicResource ForegroundBrush}"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Row 2: Chart -->
+        <Border Grid.Row="2" Background="{DynamicResource BackgroundDarkBrush}"
+                BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" CornerRadius="3"
+                Margin="0,0,0,8">
+            <scottplot:AvaPlot x:Name="HistoryChart"/>
+        </Border>
+
+        <!-- Row 3: DataGrid -->
+        <DataGrid Grid.Row="3" x:Name="HistoryDataGrid"
+                  AutoGenerateColumns="False" IsReadOnly="True"
+                  CanUserSortColumns="True" CanUserReorderColumns="True"
+                  CanUserResizeColumns="True"
+                  GridLinesVisibility="Horizontal" HeadersVisibility="Column"
+                  FontSize="11"
+                  Background="{DynamicResource BackgroundDarkBrush}"
+                  BorderThickness="0"
+                  ScrollViewer.HorizontalScrollBarVisibility="Auto">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Plan ID" Binding="{ReflectionBinding PlanId}" Width="80"/>
+                <DataGridTextColumn Header="Plan Hash" Binding="{ReflectionBinding QueryPlanHash}" Width="150"/>
+                <DataGridTextColumn Header="Interval Start" Binding="{ReflectionBinding IntervalStartLocal}" Width="140"/>
+                <DataGridTextColumn Header="Executions" Binding="{ReflectionBinding CountExecutions}" Width="90"/>
+                <DataGridTextColumn Header="Avg Duration (ms)" Binding="{ReflectionBinding AvgDurationMs}" Width="130"/>
+                <DataGridTextColumn Header="Avg CPU (ms)" Binding="{ReflectionBinding AvgCpuMs}" Width="110"/>
+                <DataGridTextColumn Header="Avg Reads" Binding="{ReflectionBinding AvgLogicalReads}" Width="90"/>
+                <DataGridTextColumn Header="Avg Writes" Binding="{ReflectionBinding AvgLogicalWrites}" Width="90"/>
+                <DataGridTextColumn Header="Avg Phys Reads" Binding="{ReflectionBinding AvgPhysicalReads}" Width="110"/>
+                <DataGridTextColumn Header="Avg Memory (MB)" Binding="{ReflectionBinding AvgMemoryMb}" Width="120"/>
+                <DataGridTextColumn Header="Avg Rows" Binding="{ReflectionBinding AvgRowcount}" Width="80"/>
+                <DataGridTextColumn Header="Total Duration (ms)" Binding="{ReflectionBinding TotalDurationMs}" Width="140"/>
+                <DataGridTextColumn Header="Total CPU (ms)" Binding="{ReflectionBinding TotalCpuMs}" Width="120"/>
+                <DataGridTextColumn Header="Total Reads" Binding="{ReflectionBinding TotalLogicalReads}" Width="100"/>
+                <DataGridTextColumn Header="Total Writes" Binding="{ReflectionBinding TotalLogicalWrites}" Width="100"/>
+                <DataGridTextColumn Header="Total Phys Reads" Binding="{ReflectionBinding TotalPhysicalReads}" Width="120"/>
+                <DataGridTextColumn Header="Min DOP" Binding="{ReflectionBinding MinDop}" Width="70"/>
+                <DataGridTextColumn Header="Max DOP" Binding="{ReflectionBinding MaxDop}" Width="70"/>
+                <DataGridTextColumn Header="Last Execution" Binding="{ReflectionBinding LastExecutionLocal}" Width="140"/>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <!-- Row 4: Footer -->
+        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right"
+                    Margin="0,8,0,0">
+            <Button Content="Close" Click="Close_Click" Padding="20,6" FontSize="12"
+                    Theme="{StaticResource AppButton}"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/PlanViewer.App/Dialogs/QueryStoreHistoryWindow.axaml.cs
+++ b/src/PlanViewer.App/Dialogs/QueryStoreHistoryWindow.axaml.cs
@@ -1,0 +1,283 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using PlanViewer.Core.Models;
+using PlanViewer.Core.Services;
+using ScottPlot;
+
+namespace PlanViewer.App.Dialogs;
+
+public partial class QueryStoreHistoryWindow : Window
+{
+    private readonly string _connectionString;
+    private readonly long _queryId;
+    private readonly string _database;
+    private CancellationTokenSource? _fetchCts;
+    private List<QueryStoreHistoryRow> _historyData = new();
+    private readonly List<(ScottPlot.Plottables.Scatter Scatter, string Label)> _scatters = new();
+
+    // Hover tooltip
+    private readonly Popup _tooltip;
+    private readonly TextBlock _tooltipText;
+
+    private static readonly ScottPlot.Color[] PlanColors =
+    {
+        ScottPlot.Color.FromHex("#4FC3F7"),
+        ScottPlot.Color.FromHex("#FF7043"),
+        ScottPlot.Color.FromHex("#66BB6A"),
+        ScottPlot.Color.FromHex("#AB47BC"),
+        ScottPlot.Color.FromHex("#FFA726"),
+        ScottPlot.Color.FromHex("#26C6DA"),
+        ScottPlot.Color.FromHex("#F06292"),
+        ScottPlot.Color.FromHex("#A1887F"),
+    };
+
+    public QueryStoreHistoryWindow(string connectionString, long queryId,
+        string queryText, string database, int hoursBack = 24)
+    {
+        _connectionString = connectionString;
+        _queryId = queryId;
+        _database = database;
+        InitializeComponent();
+
+        HoursBackBox.Value = hoursBack;
+
+        var preview = queryText.Length > 120
+            ? queryText[..120].Replace("\n", " ").Replace("\r", "") + "..."
+            : queryText.Replace("\n", " ").Replace("\r", "");
+        QueryIdentifierText.Text = $"Query Store History: Query {queryId} in [{database}]";
+        SummaryText.Text = preview;
+
+        // Build hover tooltip
+        _tooltipText = new TextBlock
+        {
+            Foreground = new SolidColorBrush(Avalonia.Media.Color.FromRgb(0xE0, 0xE0, 0xE0)),
+            FontSize = 13
+        };
+        _tooltip = new Popup
+        {
+            PlacementTarget = HistoryChart,
+            Placement = PlacementMode.Pointer,
+            IsHitTestVisible = false,
+            IsLightDismissEnabled = false,
+            Child = new Border
+            {
+                Background = new SolidColorBrush(Avalonia.Media.Color.FromRgb(0x33, 0x33, 0x33)),
+                BorderBrush = new SolidColorBrush(Avalonia.Media.Color.FromRgb(0x55, 0x55, 0x55)),
+                BorderThickness = new Thickness(1),
+                CornerRadius = new CornerRadius(3),
+                Padding = new Thickness(8, 4, 8, 4),
+                Child = _tooltipText
+            }
+        };
+        ((Grid)Content!).Children.Add(_tooltip);
+
+        HistoryChart.PointerMoved += OnChartPointerMoved;
+        HistoryChart.PointerExited += (_, _) => _tooltip.IsOpen = false;
+
+        Opened += async (_, _) => await LoadHistoryAsync();
+    }
+
+    private async System.Threading.Tasks.Task LoadHistoryAsync()
+    {
+        _fetchCts?.Cancel();
+        _fetchCts?.Dispose();
+        _fetchCts = new CancellationTokenSource();
+        var ct = _fetchCts.Token;
+
+        var hoursBack = (int)(HoursBackBox.Value ?? 24);
+        RefreshButton.IsEnabled = false;
+        StatusText.Text = "Loading...";
+
+        try
+        {
+            _historyData = await QueryStoreService.FetchHistoryAsync(
+                _connectionString, _queryId, hoursBack, ct);
+
+            HistoryDataGrid.ItemsSource = _historyData;
+
+            if (_historyData.Count > 0)
+            {
+                var planCount = _historyData.Select(r => r.PlanId).Distinct().Count();
+                var totalExec = _historyData.Sum(r => r.CountExecutions);
+                var first = _historyData.Min(r => r.IntervalStartUtc).ToLocalTime();
+                var last = _historyData.Max(r => r.IntervalStartUtc).ToLocalTime();
+                StatusText.Text = $"{_historyData.Count} intervals, {planCount} plan(s), " +
+                                  $"{totalExec:N0} total executions | " +
+                                  $"{first:MM/dd HH:mm} to {last:MM/dd HH:mm}";
+            }
+            else
+            {
+                StatusText.Text = "No history data found for this query.";
+            }
+
+            UpdateChart();
+        }
+        catch (OperationCanceledException)
+        {
+            StatusText.Text = "Cancelled.";
+        }
+        catch (Exception ex)
+        {
+            StatusText.Text = ex.Message.Length > 80 ? ex.Message[..80] + "..." : ex.Message;
+        }
+        finally
+        {
+            RefreshButton.IsEnabled = true;
+        }
+    }
+
+    private void UpdateChart()
+    {
+        HistoryChart.Plot.Clear();
+        _scatters.Clear();
+
+        if (_historyData.Count == 0)
+        {
+            HistoryChart.Refresh();
+            return;
+        }
+
+        var selected = MetricSelector.SelectedItem as ComboBoxItem;
+        var tag = selected?.Tag?.ToString() ?? "AvgCpuMs";
+        var label = selected?.Content?.ToString() ?? "Avg CPU (ms)";
+
+        var planGroups = _historyData
+            .GroupBy(r => r.PlanId)
+            .OrderBy(g => g.Key)
+            .ToList();
+
+        int colorIndex = 0;
+        foreach (var group in planGroups)
+        {
+            var ordered = group.OrderBy(r => r.IntervalStartUtc).ToList();
+            var xs = ordered.Select(r => r.IntervalStartUtc.ToLocalTime().ToOADate()).ToArray();
+            var ys = ordered.Select(r => GetMetricValue(r, tag)).ToArray();
+
+            var scatter = HistoryChart.Plot.Add.Scatter(xs, ys);
+            scatter.Color = PlanColors[colorIndex % PlanColors.Length];
+            scatter.LegendText = $"Plan {group.Key}";
+            scatter.LineWidth = 2;
+            scatter.MarkerSize = ordered.Count <= 2 ? 8 : 4;
+
+            _scatters.Add((scatter, $"Plan {group.Key}"));
+            colorIndex++;
+        }
+
+        HistoryChart.Plot.Axes.DateTimeTicksBottom();
+        HistoryChart.Plot.YLabel(label);
+        ApplyDarkTheme();
+        HistoryChart.Refresh();
+    }
+
+    private void OnChartPointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (_scatters.Count == 0) { _tooltip.IsOpen = false; return; }
+
+        try
+        {
+            var pos = e.GetPosition(HistoryChart);
+            var scaling = HistoryChart.Bounds.Width > 0
+                ? (float)(HistoryChart.Plot.RenderManager.LastRender.FigureRect.Width / HistoryChart.Bounds.Width)
+                : 1f;
+            var pixel = new ScottPlot.Pixel((float)(pos.X * scaling), (float)(pos.Y * scaling));
+            var mouseCoords = HistoryChart.Plot.GetCoordinates(pixel);
+
+            double bestDist = double.MaxValue;
+            ScottPlot.DataPoint bestPoint = default;
+            string bestLabel = "";
+            bool found = false;
+
+            foreach (var (scatter, label) in _scatters)
+            {
+                var nearest = scatter.Data.GetNearest(mouseCoords, HistoryChart.Plot.LastRender);
+                if (!nearest.IsReal) continue;
+
+                var nearestPixel = HistoryChart.Plot.GetPixel(
+                    new ScottPlot.Coordinates(nearest.X, nearest.Y));
+                double dx = Math.Abs(nearestPixel.X - pixel.X);
+                double dy = Math.Abs(nearestPixel.Y - pixel.Y);
+
+                if (dx < 80 && dy < bestDist)
+                {
+                    bestDist = dy;
+                    bestPoint = nearest;
+                    bestLabel = label;
+                    found = true;
+                }
+            }
+
+            if (found)
+            {
+                var time = DateTime.FromOADate(bestPoint.X);
+                var metricLabel = (MetricSelector.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? "";
+                _tooltipText.Text = $"{bestLabel}\n{metricLabel}: {bestPoint.Y:N2}\n{time:MM/dd HH:mm}";
+                _tooltip.IsOpen = true;
+            }
+            else
+            {
+                _tooltip.IsOpen = false;
+            }
+        }
+        catch
+        {
+            _tooltip.IsOpen = false;
+        }
+    }
+
+    private static double GetMetricValue(QueryStoreHistoryRow row, string tag) => tag switch
+    {
+        "AvgCpuMs"           => row.AvgCpuMs,
+        "AvgDurationMs"      => row.AvgDurationMs,
+        "AvgLogicalReads"    => row.AvgLogicalReads,
+        "AvgLogicalWrites"   => row.AvgLogicalWrites,
+        "AvgPhysicalReads"   => row.AvgPhysicalReads,
+        "AvgMemoryMb"        => row.AvgMemoryMb,
+        "AvgRowcount"        => row.AvgRowcount,
+        "TotalCpuMs"         => row.TotalCpuMs,
+        "TotalDurationMs"    => row.TotalDurationMs,
+        "TotalLogicalReads"  => row.TotalLogicalReads,
+        "TotalLogicalWrites" => row.TotalLogicalWrites,
+        "TotalPhysicalReads" => row.TotalPhysicalReads,
+        "CountExecutions"    => row.CountExecutions,
+        _                    => row.AvgCpuMs,
+    };
+
+    private void ApplyDarkTheme()
+    {
+        var fig = ScottPlot.Color.FromHex("#22252b");
+        var data = ScottPlot.Color.FromHex("#111217");
+        var text = ScottPlot.Color.FromHex("#9DA5B4");
+        var grid = ScottPlot.Colors.White.WithAlpha(40);
+
+        HistoryChart.Plot.FigureBackground.Color = fig;
+        HistoryChart.Plot.DataBackground.Color = data;
+        HistoryChart.Plot.Axes.Color(text);
+        HistoryChart.Plot.Grid.MajorLineColor = grid;
+        HistoryChart.Plot.Axes.Bottom.TickLabelStyle.ForeColor = text;
+        HistoryChart.Plot.Axes.Left.TickLabelStyle.ForeColor = text;
+        HistoryChart.Plot.Legend.BackgroundColor = fig;
+        HistoryChart.Plot.Legend.FontColor = ScottPlot.Color.FromHex("#E4E6EB");
+        HistoryChart.Plot.Legend.OutlineColor = ScottPlot.Color.FromHex("#3A3D45");
+    }
+
+    private void MetricSelector_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (IsVisible && _historyData.Count > 0)
+            UpdateChart();
+    }
+
+    private async void Refresh_Click(object? sender, RoutedEventArgs e)
+    {
+        await LoadHistoryAsync();
+    }
+
+    private void Close_Click(object? sender, RoutedEventArgs e) => Close();
+}

--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Avalonia" Version="11.3.12" />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.4.1" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.12" />
+    <PackageReference Include="ScottPlot.Avalonia" Version="5.1.57" />
     <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.12" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.12" />

--- a/src/PlanViewer.Core/Models/QueryStoreHistoryRow.cs
+++ b/src/PlanViewer.Core/Models/QueryStoreHistoryRow.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace PlanViewer.Core.Models;
+
+public class QueryStoreHistoryRow
+{
+    public long PlanId { get; set; }
+    public string QueryPlanHash { get; set; } = "";
+    public DateTime IntervalStartUtc { get; set; }
+    public long CountExecutions { get; set; }
+
+    public double AvgDurationMs { get; set; }
+    public double AvgCpuMs { get; set; }
+    public double AvgLogicalReads { get; set; }
+    public double AvgLogicalWrites { get; set; }
+    public double AvgPhysicalReads { get; set; }
+    public double AvgMemoryMb { get; set; }
+    public double AvgRowcount { get; set; }
+
+    public double TotalDurationMs { get; set; }
+    public double TotalCpuMs { get; set; }
+    public double TotalLogicalReads { get; set; }
+    public double TotalLogicalWrites { get; set; }
+    public double TotalPhysicalReads { get; set; }
+
+    public int MinDop { get; set; }
+    public int MaxDop { get; set; }
+    public DateTime? LastExecutionUtc { get; set; }
+
+    public string IntervalStartLocal => IntervalStartUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm");
+    public string LastExecutionLocal => LastExecutionUtc?.ToLocalTime().ToString("yyyy-MM-dd HH:mm") ?? "";
+}

--- a/src/PlanViewer.Core/Services/QueryStoreService.cs
+++ b/src/PlanViewer.Core/Services/QueryStoreService.cs
@@ -257,4 +257,93 @@ OPTION (LOOP JOIN);";
 
         return plans;
     }
+
+    public static async Task<List<QueryStoreHistoryRow>> FetchHistoryAsync(
+        string connectionString, long queryId, int hoursBack = 24,
+        CancellationToken ct = default)
+    {
+        const string sql = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+SELECT
+    p.plan_id,
+    CONVERT(varchar(18), MAX(p.query_plan_hash), 1),
+    rsi.start_time,
+    SUM(rs.count_executions),
+    CASE WHEN SUM(rs.count_executions) > 0
+         THEN SUM(rs.avg_duration * rs.count_executions) / SUM(rs.count_executions) / 1000.0
+         ELSE 0 END,
+    CASE WHEN SUM(rs.count_executions) > 0
+         THEN SUM(rs.avg_cpu_time * rs.count_executions) / SUM(rs.count_executions) / 1000.0
+         ELSE 0 END,
+    CASE WHEN SUM(rs.count_executions) > 0
+         THEN SUM(rs.avg_logical_io_reads * rs.count_executions) / SUM(rs.count_executions)
+         ELSE 0 END,
+    CASE WHEN SUM(rs.count_executions) > 0
+         THEN SUM(rs.avg_logical_io_writes * rs.count_executions) / SUM(rs.count_executions)
+         ELSE 0 END,
+    CASE WHEN SUM(rs.count_executions) > 0
+         THEN SUM(rs.avg_physical_io_reads * rs.count_executions) / SUM(rs.count_executions)
+         ELSE 0 END,
+    CASE WHEN SUM(rs.count_executions) > 0
+         THEN SUM(rs.avg_query_max_used_memory * rs.count_executions) / SUM(rs.count_executions) * 8.0 / 1024.0
+         ELSE 0 END,
+    CASE WHEN SUM(rs.count_executions) > 0
+         THEN SUM(rs.avg_rowcount * rs.count_executions) / SUM(rs.count_executions)
+         ELSE 0 END,
+    SUM(rs.avg_duration * rs.count_executions) / 1000.0,
+    SUM(rs.avg_cpu_time * rs.count_executions) / 1000.0,
+    SUM(rs.avg_logical_io_reads * rs.count_executions),
+    SUM(rs.avg_logical_io_writes * rs.count_executions),
+    SUM(rs.avg_physical_io_reads * rs.count_executions),
+    MIN(rs.min_dop),
+    MAX(rs.max_dop),
+    MAX(rs.last_execution_time)
+FROM sys.query_store_runtime_stats rs
+JOIN sys.query_store_runtime_stats_interval rsi
+    ON rs.runtime_stats_interval_id = rsi.runtime_stats_interval_id
+JOIN sys.query_store_plan p
+    ON rs.plan_id = p.plan_id
+WHERE p.query_id = @queryId
+AND   rsi.start_time >= DATEADD(HOUR, -@hoursBack, GETUTCDATE())
+GROUP BY p.plan_id, rsi.start_time
+ORDER BY rsi.start_time, p.plan_id;";
+
+        var rows = new List<QueryStoreHistoryRow>();
+
+        await using var conn = new SqlConnection(connectionString);
+        await conn.OpenAsync(ct);
+        await using var cmd = new SqlCommand(sql, conn) { CommandTimeout = 120 };
+        cmd.Parameters.Add(new SqlParameter("@queryId", queryId));
+        cmd.Parameters.Add(new SqlParameter("@hoursBack", hoursBack));
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+        while (await reader.ReadAsync(ct))
+        {
+            rows.Add(new QueryStoreHistoryRow
+            {
+                PlanId = reader.GetInt64(0),
+                QueryPlanHash = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                IntervalStartUtc = ((DateTimeOffset)reader.GetValue(2)).UtcDateTime,
+                CountExecutions = reader.GetInt64(3),
+                AvgDurationMs = reader.GetDouble(4),
+                AvgCpuMs = reader.GetDouble(5),
+                AvgLogicalReads = reader.GetDouble(6),
+                AvgLogicalWrites = reader.GetDouble(7),
+                AvgPhysicalReads = reader.GetDouble(8),
+                AvgMemoryMb = reader.GetDouble(9),
+                AvgRowcount = reader.GetDouble(10),
+                TotalDurationMs = reader.GetDouble(11),
+                TotalCpuMs = reader.GetDouble(12),
+                TotalLogicalReads = reader.GetDouble(13),
+                TotalLogicalWrites = reader.GetDouble(14),
+                TotalPhysicalReads = reader.GetDouble(15),
+                MinDop = (int)reader.GetInt64(16),
+                MaxDop = (int)reader.GetInt64(17),
+                LastExecutionUtc = reader.IsDBNull(18) ? null : ((DateTimeOffset)reader.GetValue(18)).UtcDateTime,
+            });
+        }
+
+        return rows;
+    }
 }


### PR DESCRIPTION
## Summary
- Right-click "View History" on any Query Store grid row to see time-series performance history
- ScottPlot.Avalonia chart with one colored line per plan — makes plan regressions immediately visible
- 13 selectable metrics: Avg/Total CPU, Duration, Reads, Writes, Physical Reads, plus Avg Memory, Avg Rows, Executions
- SQL aggregates across execution_type (Regular/Aborted/Exception) with weighted averages
- UTC-aware: filters with `GETUTCDATE()`, displays local time on chart axis and grid
- Hover tooltip shows plan name, metric value, and timestamp
- Adjustable hours-back (1-720) with Refresh button

## Test plan
- [x] Build: 0 errors
- [x] Right-click → View History opens window with chart and grid
- [x] Multi-plan queries show separate colored lines
- [x] Metric selector switches chart data
- [x] Refresh reloads without stacking legends
- [x] Rows consolidated per interval (no execution_type split)
- [x] Hover tooltip shows nearest data point info
- [x] Times displayed in local time, not UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "View History" context menu option to the query grid
  * New Query Store History window for viewing performance metrics over time
  * Interactive chart visualization with selectable metrics
  * Detailed history data grid displaying per-plan execution statistics
  * Time range filtering with customizable lookback period
  * Manual refresh capability to update historical data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->