### PR TITLE
Fix issue #105

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -319,10 +319,13 @@ public partial class QuerySessionControl : UserControl
         return text[batchStart..batchEnd].Trim();
     }
 
+
     private void SetStatus(string text, bool autoClear = true)
     {
         _statusClearCts?.Cancel();
         _statusClearCts?.Dispose();
+        _statusClearCts = null; // ← prevent stale reference to a disposed CTS
+
         StatusText.Text = text;
 
         if (autoClear && !string.IsNullOrEmpty(text))
@@ -331,12 +334,18 @@ public partial class QuerySessionControl : UserControl
             var token = _statusClearCts.Token;
             _ = Task.Delay(3000, token).ContinueWith(_ =>
             {
-                Avalonia.Threading.Dispatcher.UIThread.Post(() => StatusText.Text = "");
+                Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                {
+                    StatusText.Text = "";
+                    _statusClearCts = null; // ← also clear after natural expiry
+                });
             }, TaskContinuationOptions.OnlyOnRanToCompletion);
+
         }
     }
 
-    private async void Connect_Click(object? sender, RoutedEventArgs e)
+
+	private async void Connect_Click(object? sender, RoutedEventArgs e)
     {
         await ShowConnectionDialogAsync();
     }


### PR DESCRIPTION
## What does this PR do?

A clear description of the change and why it's being made.

## Which component(s) does this affect?

- [x] Desktop App (PlanViewer.App)
- [ ] Core Library (PlanViewer.Core)
- [ ] CLI Tool (PlanViewer.Cli)
- [ ] SSMS Extension (PlanViewer.Ssms)
- [ ] Tests
- [ ] Documentation

## How was this tested?

- Compile
- load query store
- load a plan from QS

## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceStudio/blob/main/CONTRIBUTING.md)
- [x] My code builds with zero warnings (`dotnet build -c Debug`)
- [x ] All tests pass (`dotnet test`)
- [x ] I have not introduced any hardcoded credentials or server names


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved potential issues with status message clearing in the query session control to improve overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->