### PR TITLE
Fix ObjectDisposedException crash in SetStatus (#105)

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -322,30 +322,25 @@ public partial class QuerySessionControl : UserControl
 
     private void SetStatus(string text, bool autoClear = true)
     {
-        _statusClearCts?.Cancel();
-        _statusClearCts?.Dispose();
-        _statusClearCts = null; // ← prevent stale reference to a disposed CTS
+        var old = _statusClearCts;
+        _statusClearCts = null;
+        old?.Cancel();
+        old?.Dispose();
 
         StatusText.Text = text;
 
         if (autoClear && !string.IsNullOrEmpty(text))
         {
-            _statusClearCts = new CancellationTokenSource();
-            var token = _statusClearCts.Token;
-            _ = Task.Delay(3000, token).ContinueWith(_ =>
+            var cts = new CancellationTokenSource();
+            _statusClearCts = cts;
+            _ = Task.Delay(3000, cts.Token).ContinueWith(_ =>
             {
-                Avalonia.Threading.Dispatcher.UIThread.Post(() =>
-                {
-                    StatusText.Text = "";
-                    _statusClearCts = null; // ← also clear after natural expiry
-                });
+                Avalonia.Threading.Dispatcher.UIThread.Post(() => StatusText.Text = "");
             }, TaskContinuationOptions.OnlyOnRanToCompletion);
-
         }
     }
 
-
-	private async void Connect_Click(object? sender, RoutedEventArgs e)
+    private async void Connect_Click(object? sender, RoutedEventArgs e)
     {
         await ShowConnectionDialogAsync();
     }


### PR DESCRIPTION
## Summary
Fix app crash when loading Query Store plans or switching databases. The CTS disposal added in #97 raced with the 3-second `Task.Delay` continuation — calling `Cancel()` on an already-disposed CTS threw `ObjectDisposedException`.

Fix: null out the field before Cancel/Dispose so subsequent calls never touch the disposed instance.

## Test plan
- [x] Build: 0 errors
- [x] Load plans from Query Store — no crash
- [x] Switch databases + click Query Store — no crash

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of status message auto-clearing behavior in the query session control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->