### PR TITLE
v1.2.0 Release (with #105 crash fix)

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -322,30 +322,25 @@ public partial class QuerySessionControl : UserControl
 
     private void SetStatus(string text, bool autoClear = true)
     {
-        _statusClearCts?.Cancel();
-        _statusClearCts?.Dispose();
-        _statusClearCts = null; // ← prevent stale reference to a disposed CTS
+        var old = _statusClearCts;
+        _statusClearCts = null;
+        old?.Cancel();
+        old?.Dispose();
 
         StatusText.Text = text;
 
         if (autoClear && !string.IsNullOrEmpty(text))
         {
-            _statusClearCts = new CancellationTokenSource();
-            var token = _statusClearCts.Token;
-            _ = Task.Delay(3000, token).ContinueWith(_ =>
+            var cts = new CancellationTokenSource();
+            _statusClearCts = cts;
+            _ = Task.Delay(3000, cts.Token).ContinueWith(_ =>
             {
-                Avalonia.Threading.Dispatcher.UIThread.Post(() =>
-                {
-                    StatusText.Text = "";
-                    _statusClearCts = null; // ← also clear after natural expiry
-                });
+                Avalonia.Threading.Dispatcher.UIThread.Post(() => StatusText.Text = "");
             }, TaskContinuationOptions.OnlyOnRanToCompletion);
-
         }
     }
 
-
-	private async void Connect_Click(object? sender, RoutedEventArgs e)
+    private async void Connect_Click(object? sender, RoutedEventArgs e)
     {
         await ShowConnectionDialogAsync();
     }


### PR DESCRIPTION
## v1.2.0 Release

Re-release with crash fix for #105 (ObjectDisposedException in SetStatus when loading Query Store plans).

### Query Store Enhancements
- **Search/filter by identifier**: Server-side fetch by Query ID, Plan ID, Query Hash, Plan Hash, Module Name with wildcard support (#93)
- **History drill-down**: Right-click "View History" opens multi-plan time-series chart with ScottPlot, 13 selectable metrics, hover tooltips (#98)
- **Database picker** on Query Store tab — switch databases without reopening (#93)
- **Context menu copy commands**: Copy Query ID, Plan ID, Query Hash, Plan Hash, Module Name, Query Text, Row (#94)
- Select All/None toggle button, Enter-to-fetch in search box

### Bug Fixes
- Database picker now correctly changes query editor execution context (#95)
- Fix crash when loading Query Store plans (#105)

### Code Quality (22 fixes)
- MCP session leak on plan tab close
- CancellationTokenSource disposal across all controls
- TextMate.Installation disposal
- Consolidated duplicate connection dialog code
- CLI: credential check, --output flag, input validation, .env support for query-store command
- Core: async disposal, KeychainCredentialService deadlock fix, ShowPlanParser error handling
- Removed dead QueryStoreDialog code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced status clearing functionality to prevent interruptions and ensure more reliable operation during normal use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->