### PR TITLE
Enable Query Store button on standalone plan tabs

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -973,6 +973,8 @@ public partial class QuerySessionControl : UserControl
             .Any(t => t.Content is QueryStoreGridControl);
     }
 
+    public void TriggerQueryStore() => QueryStore_Click(null, new RoutedEventArgs());
+
     private async void QueryStore_Click(object? sender, RoutedEventArgs e)
     {
         // If a QS tab already exists, always show connection dialog for a fresh tab

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -562,10 +562,19 @@ public partial class MainWindow : Window
             Margin = new Avalonia.Thickness(6, 0, 0, 0),
             VerticalContentAlignment = VerticalAlignment.Center,
             HorizontalContentAlignment = HorizontalAlignment.Center,
-            IsEnabled = false,
             Theme = (Avalonia.Styling.ControlTheme)this.FindResource("AppButton")!
         };
-        ToolTip.SetTip(queryStoreBtn, "Connect to a server (Ctrl+N) to use Query Store");
+        ToolTip.SetTip(queryStoreBtn, "Open a Query Store session");
+        queryStoreBtn.Click += (_, _) =>
+        {
+            _queryCounter++;
+            var session = new QuerySessionControl(_credentialService, _connectionStore);
+            var tab = CreateTab($"Query {_queryCounter}", session);
+            MainTabControl.Items.Add(tab);
+            MainTabControl.SelectedItem = tab;
+            UpdateEmptyOverlay();
+            session.TriggerQueryStore();
+        };
 
         var toolbar = new StackPanel
         {


### PR DESCRIPTION
## Summary
Query Store button was disabled (greyed out) on the MainWindow toolbar when viewing standalone .sqlplan files. Now it creates a new query session and triggers the connection dialog + Query Store flow.

## Test plan
- [x] Open a .sqlplan file — Query Store button is enabled
- [x] Click it — opens new session tab with connection dialog
- [x] Connect and use Query Store normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)