### PR TITLE
Fix vpk upload token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path releases/velopack
 
           # Download previous release for delta generation
-          vpk download github --repoUrl https://github.com/${{ github.repository }} --channel win -o releases/velopack
+          vpk download github --repoUrl https://github.com/${{ github.repository }} --channel win -o releases/velopack --token $env:GH_TOKEN
 
           # Pack Windows release
           vpk pack -u PerformanceStudio -v $env:VERSION -p publish/win-x64 -e PlanViewer.App.exe -o releases/velopack --channel win
@@ -145,4 +145,4 @@ jobs:
           gh release upload "v$env:VERSION" releases/*.zip releases/SHA256SUMS.txt --clobber
 
           # Upload Velopack artifacts
-          vpk upload github --repoUrl https://github.com/${{ github.repository }} --channel win -o releases/velopack --releaseName "v$env:VERSION" --tag "v$env:VERSION" --merge
+          vpk upload github --repoUrl https://github.com/${{ github.repository }} --channel win -o releases/velopack --releaseName "v$env:VERSION" --tag "v$env:VERSION" --merge --token $env:GH_TOKEN


### PR DESCRIPTION
vpk needs --token explicitly, doesn't read GH_TOKEN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release pipeline security by implementing authenticated access for artifact management operations during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->