### PR TITLE
Add time display picker (Local/UTC/Server) and parameterize SQL

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -362,6 +362,7 @@ public partial class QuerySessionControl : UserControl
 
             await PopulateDatabases();
             await FetchServerMetadataAsync();
+            await FetchServerUtcOffset();
 
             if (_selectedDatabase != null)
             {
@@ -437,6 +438,22 @@ public partial class QuerySessionControl : UserControl
             // Non-fatal — advice will just lack server context
             _serverMetadata = null;
         }
+    }
+
+    private async Task FetchServerUtcOffset()
+    {
+        if (_connectionString == null) return;
+        try
+        {
+            await using var conn = new SqlConnection(_connectionString);
+            await conn.OpenAsync();
+            await using var cmd = new SqlCommand(
+                "SELECT DATEDIFF(MINUTE, GETUTCDATE(), GETDATE())", conn);
+            var offset = await cmd.ExecuteScalarAsync();
+            if (offset is int mins)
+                PlanViewer.Core.Services.TimeDisplayHelper.ServerUtcOffsetMinutes = mins;
+        }
+        catch { }
     }
 
     private async Task FetchDatabaseMetadataAsync()

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
@@ -67,6 +67,15 @@
                              Watermark="0x1AB2C3, dbo.MyProc"
                              KeyDown="SearchValue_KeyDown"/>
                 </StackPanel>
+                <StackPanel Spacing="4">
+                    <TextBlock Text="Time display" Foreground="{DynamicResource ForegroundBrush}" FontSize="11"/>
+                    <ComboBox x:Name="TimeDisplayBox" Width="100" Height="36" FontSize="13"
+                              SelectedIndex="0" SelectionChanged="TimeDisplay_SelectionChanged">
+                        <ComboBoxItem Content="Local" Tag="Local"/>
+                        <ComboBoxItem Content="UTC" Tag="Utc"/>
+                        <ComboBoxItem Content="Server" Tag="Server"/>
+                    </ComboBox>
+                </StackPanel>
                 <StackPanel Spacing="2" VerticalAlignment="Center">
                     <Button x:Name="FetchButton" Content="Fetch" Click="Fetch_Click"
                             Height="28" Padding="16,0" FontSize="12"

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
@@ -299,6 +299,29 @@ public partial class QueryStoreGridControl : UserControl
         }
     }
 
+    private void TimeDisplay_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (!IsInitialized) return;
+        var tag = (TimeDisplayBox.SelectedItem as ComboBoxItem)?.Tag?.ToString();
+        if (tag == null) return;
+        TimeDisplayHelper.Current = tag switch
+        {
+            "Utc" => TimeDisplayMode.Utc,
+            "Server" => TimeDisplayMode.Server,
+            _ => TimeDisplayMode.Local
+        };
+        // Refresh grid display
+        if (_filteredRows.Count > 0)
+        {
+            foreach (var row in _filteredRows)
+                row.NotifyTimeDisplayChanged();
+            ResultsGrid.ItemsSource = null;
+            ResultsGrid.ItemsSource = _filteredRows;
+        }
+        // Refresh slicer labels
+        TimeRangeSlicer.Redraw();
+    }
+
     private void ClearSearch_Click(object? sender, RoutedEventArgs e)
     {
         SearchTypeBox.SelectedIndex = 0;
@@ -943,7 +966,10 @@ public class QueryStoreRow : INotifyPropertyChanged
     public long TotalMemSort => Plan.TotalMemoryGrantPages;
     public double AvgMemSort => Plan.AvgMemoryGrantPages;
 
-    public string LastExecutedLocal => Plan.LastExecutedUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm");
+    public string LastExecutedLocal => TimeDisplayHelper.FormatForDisplay(Plan.LastExecutedUtc);
+
+    public void NotifyTimeDisplayChanged() => OnPropertyChanged(nameof(LastExecutedLocal));
+
     public string QueryPreview => Plan.QueryText.Length > 80
         ? Plan.QueryText[..80].Replace("\n", " ").Replace("\r", "") + "..."
         : Plan.QueryText.Replace("\n", " ").Replace("\r", "");

--- a/src/PlanViewer.App/Controls/TimeRangeSlicerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/TimeRangeSlicerControl.axaml.cs
@@ -8,6 +8,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using PlanViewer.Core.Models;
+using PlanViewer.Core.Services;
 
 namespace PlanViewer.App.Controls;
 
@@ -167,7 +168,7 @@ public partial class TimeRangeSlicerControl : UserControl
 
     // ── Drawing ────────────────────────────────────────────────────────────
 
-    private void Redraw()
+    public void Redraw()
     {
         SlicerCanvas.Children.Clear();
         if (_data.Count < 2) return;
@@ -238,7 +239,7 @@ public partial class TimeRangeSlicerControl : UserControl
         for (int i = 0; i < n; i += labelInterval)
         {
             var x = i * stepX + stepX / 2;
-            var dt = _data[i].IntervalStartUtc.ToLocalTime();
+            var dt = TimeDisplayHelper.ConvertForDisplay(_data[i].IntervalStartUtc);
             var label = dt.ToString("MM/dd HH:mm");
             var tb = new TextBlock
             {
@@ -531,8 +532,8 @@ public partial class TimeRangeSlicerControl : UserControl
             RangeLabel.Text = "";
             return;
         }
-        var start = GetDateTimeAtNorm(_rangeStart).ToLocalTime();
-        var end = GetDateTimeAtNorm(_rangeEnd).ToLocalTime();
+        var start = TimeDisplayHelper.ConvertForDisplay(GetDateTimeAtNorm(_rangeStart));
+        var end = TimeDisplayHelper.ConvertForDisplay(GetDateTimeAtNorm(_rangeEnd));
         var span = end - start;
         RangeLabel.Text = $"{start:yyyy-MM-dd HH:mm} → {end:yyyy-MM-dd HH:mm}  ({span.TotalHours:F0}h)";
     }

--- a/src/PlanViewer.App/Dialogs/QueryStoreHistoryWindow.axaml.cs
+++ b/src/PlanViewer.App/Dialogs/QueryStoreHistoryWindow.axaml.cs
@@ -107,8 +107,8 @@ public partial class QueryStoreHistoryWindow : Window
             {
                 var planCount = _historyData.Select(r => r.PlanId).Distinct().Count();
                 var totalExec = _historyData.Sum(r => r.CountExecutions);
-                var first = _historyData.Min(r => r.IntervalStartUtc).ToLocalTime();
-                var last = _historyData.Max(r => r.IntervalStartUtc).ToLocalTime();
+                var first = TimeDisplayHelper.ConvertForDisplay(_historyData.Min(r => r.IntervalStartUtc));
+                var last = TimeDisplayHelper.ConvertForDisplay(_historyData.Max(r => r.IntervalStartUtc));
                 StatusText.Text = $"{_historyData.Count} intervals, {planCount} plan(s), " +
                                   $"{totalExec:N0} total executions | " +
                                   $"{first:MM/dd HH:mm} to {last:MM/dd HH:mm}";
@@ -158,7 +158,7 @@ public partial class QueryStoreHistoryWindow : Window
         foreach (var group in planGroups)
         {
             var ordered = group.OrderBy(r => r.IntervalStartUtc).ToList();
-            var xs = ordered.Select(r => r.IntervalStartUtc.ToLocalTime().ToOADate()).ToArray();
+            var xs = ordered.Select(r => TimeDisplayHelper.ConvertForDisplay(r.IntervalStartUtc).ToOADate()).ToArray();
             var ys = ordered.Select(r => GetMetricValue(r, tag)).ToArray();
 
             var scatter = HistoryChart.Plot.Add.Scatter(xs, ys);

--- a/src/PlanViewer.Core/Models/QueryStoreHistoryRow.cs
+++ b/src/PlanViewer.Core/Models/QueryStoreHistoryRow.cs
@@ -1,4 +1,5 @@
 using System;
+using PlanViewer.Core.Services;
 
 namespace PlanViewer.Core.Models;
 
@@ -27,6 +28,6 @@ public class QueryStoreHistoryRow
     public int MaxDop { get; set; }
     public DateTime? LastExecutionUtc { get; set; }
 
-    public string IntervalStartLocal => IntervalStartUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm");
-    public string LastExecutionLocal => LastExecutionUtc?.ToLocalTime().ToString("yyyy-MM-dd HH:mm") ?? "";
+    public string IntervalStartLocal => TimeDisplayHelper.FormatForDisplay(IntervalStartUtc);
+    public string LastExecutionLocal => LastExecutionUtc.HasValue ? TimeDisplayHelper.FormatForDisplay(LastExecutionUtc.Value) : "";
 }

--- a/src/PlanViewer.Core/Services/QueryStoreService.cs
+++ b/src/PlanViewer.Core/Services/QueryStoreService.cs
@@ -139,7 +139,8 @@ FROM sys.database_query_store_options;";
         }
         else
         {
-            timeWhereClause = $"WHERE rs.last_execution_time >= DATEADD(HOUR, -{hoursBack}, GETUTCDATE())";
+            timeWhereClause = "WHERE rs.last_execution_time >= DATEADD(HOUR, -@hoursBack, GETUTCDATE())";
+            parameters.Add(new SqlParameter("@hoursBack", hoursBack));
         }
 
         // 1. plan_agg: aggregate runtime_stats by plan_id only (cheapest grouping,
@@ -374,7 +375,7 @@ ORDER BY rsi.start_time, p.plan_id;";
         int daysBack = 30,
         CancellationToken ct = default)
     {
-        var sql = $@"
+        var sql = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT
@@ -389,8 +390,8 @@ SELECT
 FROM sys.query_store_runtime_stats rs
 JOIN sys.query_store_runtime_stats_interval rsi
     ON rs.runtime_stats_interval_id = rsi.runtime_stats_interval_id
-WHERE rsi.start_time >= DATEADD(DAY, -{daysBack}, GETUTCDATE())
-AND   rs.first_execution_time >= DATEADD(DAY, -{daysBack}, GETUTCDATE()) --performance: filter runtime_stats directly
+WHERE rsi.start_time >= DATEADD(DAY, -@daysBack, GETUTCDATE())
+AND   rs.first_execution_time >= DATEADD(DAY, -@daysBack, GETUTCDATE()) --performance: filter runtime_stats directly
 GROUP BY DATEADD(HOUR, DATEDIFF(HOUR, 0, rsi.start_time), 0)
 ORDER BY bucket_hour DESC;";
 
@@ -399,6 +400,7 @@ ORDER BY bucket_hour DESC;";
         await using var conn = new SqlConnection(connectionString);
         await conn.OpenAsync(ct);
         await using var cmd = new SqlCommand(sql, conn) { CommandTimeout = 120 };
+        cmd.Parameters.Add(new SqlParameter("@daysBack", daysBack));
         await using var reader = await cmd.ExecuteReaderAsync(ct);
 
         while (await reader.ReadAsync(ct))

--- a/src/PlanViewer.Core/Services/TimeDisplayHelper.cs
+++ b/src/PlanViewer.Core/Services/TimeDisplayHelper.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace PlanViewer.Core.Services;
+
+public enum TimeDisplayMode
+{
+    Local,
+    Utc,
+    Server
+}
+
+public static class TimeDisplayHelper
+{
+    public static TimeDisplayMode Current { get; set; } = TimeDisplayMode.Local;
+
+    /// <summary>
+    /// Offset in minutes from UTC to the connected SQL Server's local time.
+    /// Set after connecting to a server.
+    /// </summary>
+    public static int ServerUtcOffsetMinutes { get; set; }
+
+    public static DateTime ConvertForDisplay(DateTime utcTime)
+    {
+        return Current switch
+        {
+            TimeDisplayMode.Local => utcTime.ToLocalTime(),
+            TimeDisplayMode.Utc => DateTime.SpecifyKind(utcTime, DateTimeKind.Utc),
+            TimeDisplayMode.Server => utcTime.AddMinutes(ServerUtcOffsetMinutes),
+            _ => utcTime.ToLocalTime()
+        };
+    }
+
+    public static string FormatForDisplay(DateTime utcTime, string format = "yyyy-MM-dd HH:mm")
+    {
+        return ConvertForDisplay(utcTime).ToString(format);
+    }
+
+    public static string Suffix => Current switch
+    {
+        TimeDisplayMode.Local => "",
+        TimeDisplayMode.Utc => " (UTC)",
+        TimeDisplayMode.Server => " (Server)",
+        _ => ""
+    };
+}


### PR DESCRIPTION
## Summary
- **Time display picker** on Query Store toolbar: switch between Local, UTC, and Server time
- All timestamps update live across the grid, time-range slicer, and history drill-down window
- Server UTC offset fetched on connect (`DATEDIFF(MINUTE, GETUTCDATE(), GETDATE())`)
- Parameterized `hoursBack` and `daysBack` in QueryStoreService SQL (previously string-interpolated)

## Test plan
- [x] Build: 0 errors
- [x] Switch time modes — grid, slicer labels, and slicer X-axis all update
- [x] History drill-down chart and grid respect the selected mode
- [x] Server mode shows correct offset from UTC
- [x] No crash on QS tab open (IsInitialized guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added time display mode selector allowing users to view query execution times in Local, UTC, or Server time zones.

* **Improvements**
  * Enhanced time formatting consistency across query result displays and history charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->