### PR TITLE
Fix Query Store time slicer metric display

### DIFF
--- a/src/PlanViewer.App/Controls/TimeRangeSlicerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/TimeRangeSlicerControl.axaml.cs
@@ -140,12 +140,18 @@ public partial class TimeRangeSlicerControl : UserControl
     {
         return _metric switch
         {
-            "cpu" or "avg-cpu" => _data.Select(d => d.TotalCpu).ToArray(),
-            "duration" or "avg-duration" => _data.Select(d => d.TotalDuration).ToArray(),
-            "reads" or "avg-reads" => _data.Select(d => d.TotalReads).ToArray(),
-            "writes" or "avg-writes" => _data.Select(d => d.TotalWrites).ToArray(),
-            "physical-reads" or "avg-physical-reads" => _data.Select(d => d.TotalPhysicalReads).ToArray(),
-            "memory" or "avg-memory" => _data.Select(d => d.TotalMemory).ToArray(),
+            "cpu" => _data.Select(d => d.TotalCpu).ToArray(),
+            "avg-cpu" => _data.Select(d => d.AvgCpu).ToArray(),
+            "duration" => _data.Select(d => d.TotalDuration).ToArray(),
+            "avg-duration" => _data.Select(d => d.AvgDuration).ToArray(),
+            "reads" => _data.Select(d => d.TotalReads).ToArray(),
+            "avg-reads" => _data.Select(d => d.AvgReads).ToArray(),
+            "writes" => _data.Select(d => d.TotalWrites).ToArray(),
+            "avg-writes" => _data.Select(d => d.AvgWrites).ToArray(),
+            "physical-reads" => _data.Select(d => d.TotalPhysicalReads).ToArray(),
+            "avg-physical-reads" => _data.Select(d => d.AvgPhysicalReads).ToArray(),
+            "memory" => _data.Select(d => d.TotalMemory).ToArray(),
+            "avg-memory" => _data.Select(d => d.AvgMemory).ToArray(),
             "executions" => _data.Select(d => (double)d.TotalExecutions).ToArray(),
             _ => _data.Select(d => d.TotalCpu).ToArray(),
         };
@@ -155,12 +161,18 @@ public partial class TimeRangeSlicerControl : UserControl
     {
         return _metric switch
         {
-            "cpu" or "avg-cpu" => "Total CPU (ms)",
-            "duration" or "avg-duration" => "Total Duration (ms)",
-            "reads" or "avg-reads" => "Total Reads",
-            "writes" or "avg-writes" => "Total Writes",
-            "physical-reads" or "avg-physical-reads" => "Total Physical Reads",
-            "memory" or "avg-memory" => "Total Memory (MB)",
+            "cpu" => "Total CPU (ms)",
+            "avg-cpu" => "Avg CPU (ms)",
+            "duration" => "Total Duration (ms)",
+            "avg-duration" => "Avg Duration (ms)",
+            "reads" => "Total Reads",
+            "avg-reads" => "Avg Reads",
+            "writes" => "Total Writes",
+            "avg-writes" => "Avg Writes",
+            "physical-reads" => "Total Physical Reads",
+            "avg-physical-reads" => "Avg Physical Reads",
+            "memory" => "Total Memory (MB)",
+            "avg-memory" => "Avg Memory (MB)",
             "executions" => "Executions",
             _ => "Total CPU (ms)",
         };
@@ -256,8 +268,8 @@ public partial class TimeRangeSlicerControl : UserControl
         var metricTb = new TextBlock
         {
             Text = GetMetricLabel(),
-            FontSize = 9,
-            Foreground = labelBrush,
+            FontSize = 12,
+            Foreground = TryFindBrush("ForegroundBrush", new SolidColorBrush(Color.Parse("#E4E6EB"))),
         };
         Canvas.SetRight(metricTb, 4);
         Canvas.SetTop(metricTb, 2);

--- a/src/PlanViewer.Core/Models/QueryStoreTimeSlice.cs
+++ b/src/PlanViewer.Core/Models/QueryStoreTimeSlice.cs
@@ -15,4 +15,11 @@ public class QueryStoreTimeSlice
     public double TotalPhysicalReads { get; set; }
     public double TotalMemory { get; set; }
     public long TotalExecutions { get; set; }
+
+    public double AvgCpu => TotalExecutions > 0 ? TotalCpu / TotalExecutions : 0;
+    public double AvgDuration => TotalExecutions > 0 ? TotalDuration / TotalExecutions : 0;
+    public double AvgReads => TotalExecutions > 0 ? TotalReads / TotalExecutions : 0;
+    public double AvgWrites => TotalExecutions > 0 ? TotalWrites / TotalExecutions : 0;
+    public double AvgPhysicalReads => TotalExecutions > 0 ? TotalPhysicalReads / TotalExecutions : 0;
+    public double AvgMemory => TotalExecutions > 0 ? TotalMemory / TotalExecutions : 0;
 }


### PR DESCRIPTION
## Summary
- Increase slicer metric label font size (9 → 12) and switch from muted to foreground brush
- Fix metric label always showing "Total" even when an avg metric is selected (e.g., "Avg CPU" dropdown showed "Total CPU (ms)" in the chart)
- Add per-bucket average properties to `QueryStoreTimeSlice` so the slicer chart shape reflects total vs avg correctly

## Test plan
- [x] Switch between Total CPU and Avg CPU — label updates, chart shape changes
- [x] Verified across all 6 metric pairs (CPU, Duration, Reads, Writes, Physical Reads, Memory)
- [x] Metric label is larger and readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)