### PR TITLE
Fix wait stats cleanup: tab indentation and CTS leak

### DIFF
--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
@@ -462,9 +462,9 @@ public partial class QueryStoreGridControl : UserControl
 
         if (!collapsed && _slicerStartUtc.HasValue && _slicerEndUtc.HasValue)
         {
-            // Re-fetch wait stats when expanding
-            var cts = new CancellationTokenSource();
-            _ = FetchWaitStatsAsync(_slicerStartUtc.Value, _slicerEndUtc.Value, cts.Token);
+            // Re-fetch wait stats when expanding — reuse the shared CTS
+            var ct = _fetchCts?.Token ?? CancellationToken.None;
+            _ = FetchWaitStatsAsync(_slicerStartUtc.Value, _slicerEndUtc.Value, ct);
         }
     }
 

--- a/src/PlanViewer.Core/Services/QueryStoreService.cs
+++ b/src/PlanViewer.Core/Services/QueryStoreService.cs
@@ -473,14 +473,13 @@ ORDER BY wait_ratio DESC;";
         return rows;
     }
 
-	/// <summary>
-	/// Per-plan wait stats aggregated for a time range, grouped by plan_id + category.
-	/// WaitRatio = SUM(total_query_wait_time_ms) / sum(rs.avg_duration*rs.count_executions) 
-	/// ==> May be challenged. But at the detail level we use the plan duration use query stats. 
-    /// So it is different from the other wait ratio calculation, which is based on the interval duration. 
-    /// We can consider to align them in the future if needed.
-	/// </summary>
-	public static async Task<List<(long PlanId, WaitCategoryTotal Wait)>> FetchPlanWaitStatsAsync(
+    /// <summary>
+    /// Per-plan wait stats aggregated for a time range, grouped by plan_id + category.
+    /// WaitRatio = SUM(total_query_wait_time_ms) / SUM(avg_duration * count_executions).
+    /// This differs from the global/hourly WTR (which divides by wall-clock interval) because
+    /// at plan level we measure what fraction of actual execution time was spent waiting.
+    /// </summary>
+    public static async Task<List<(long PlanId, WaitCategoryTotal Wait)>> FetchPlanWaitStatsAsync(
         string connectionString, DateTime startUtc, DateTime endUtc,
         CancellationToken ct = default)
     {


### PR DESCRIPTION
## Summary
- Fix tab indentation in `FetchPlanWaitStatsAsync` doc comments to match file convention (spaces)
- Rewrite doc comment to clearly explain why plan-level WTR uses a different denominator
- Use existing `_fetchCts` token instead of creating an untracked `CancellationTokenSource` in `OnWaitStatsCollapsedChanged`

Follow-up to PR #137.

## Test plan
- [x] Build succeeds with 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)