### PR TITLE
Gate Query Store wait stats for SQL 2017+ with capture mode check

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -1021,11 +1021,26 @@ public partial class QuerySessionControl : UserControl
 
         SetStatus("");
 
+        // Check if wait stats are supported (SQL 2017+ / Azure) and capture is enabled
+        var supportsWaitStats = _serverMetadata?.SupportsQueryStoreWaitStats ?? false;
+        if (supportsWaitStats)
+        {
+            try
+            {
+                var connStr = _serverConnection!.GetConnectionString(_credentialService, _selectedDatabase!);
+                supportsWaitStats = await QueryStoreService.IsWaitStatsCaptureEnabledAsync(connStr);
+            }
+            catch
+            {
+                supportsWaitStats = false;
+            }
+        }
+
         // Build database list from the current DatabaseBox
         var databases = DatabaseBox.Items.OfType<string>().ToList();
 
         var grid = new QueryStoreGridControl(_serverConnection!, _credentialService,
-            _selectedDatabase!, databases);
+            _selectedDatabase!, databases, supportsWaitStats);
         grid.PlansSelected += OnQueryStorePlansSelected;
 
         var headerText = new TextBlock

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
@@ -41,6 +41,7 @@ public partial class QueryStoreGridControl : UserControl
     private bool _initialOrderByLoaded;
     private bool _suppressRangeChanged;
     private string? _waitHighlightCategory;
+    private bool _waitStatsSupported;  // false until version + capture mode confirmed
     private bool _waitStatsEnabled = true;
     private bool _waitPercentMode;
 
@@ -50,12 +51,13 @@ public partial class QueryStoreGridControl : UserControl
     public string Database => _database;
 
     public QueryStoreGridControl(ServerConnection serverConnection, ICredentialService credentialService,
-        string initialDatabase, List<string> databases)
+        string initialDatabase, List<string> databases, bool supportsWaitStats = false)
     {
         _serverConnection = serverConnection;
         _credentialService = credentialService;
         _database = initialDatabase;
         _connectionString = serverConnection.GetConnectionString(credentialService, initialDatabase);
+        _waitStatsSupported = supportsWaitStats;
         _slicerDaysBack = AppSettingsService.Load().QueryStoreSlicerDays;
         InitializeComponent();
         ResultsGrid.ItemsSource = _filteredRows;
@@ -68,6 +70,19 @@ public partial class QueryStoreGridControl : UserControl
         WaitStatsProfile.CategoryClicked += OnWaitCategoryClicked;
         WaitStatsProfile.CategoryDoubleClicked += OnWaitCategoryDoubleClicked;
         WaitStatsProfile.CollapsedChanged += OnWaitStatsCollapsedChanged;
+
+        if (!_waitStatsSupported)
+        {
+            // Hide wait stats panel and column when server doesn't support it
+            WaitStatsProfile.Collapse();
+            WaitStatsChevronButton.IsVisible = false;
+            WaitStatsSplitter.IsVisible = false;
+            SlicerRow.ColumnDefinitions[2].Width = new GridLength(0);
+            var waitProfileCol = ResultsGrid.Columns
+                .FirstOrDefault(c => c.SortMemberPath == "WaitGrandTotalSort");
+            if (waitProfileCol != null)
+                waitProfileCol.IsVisible = false;
+        }
 
         // Auto-fetch with default settings on connect
         Avalonia.Threading.Dispatcher.UIThread.Post(() =>
@@ -192,7 +207,7 @@ public partial class QueryStoreGridControl : UserControl
             SelectToggleButton.Content = "Select None";
 
             // Fetch wait stats in parallel (non-blocking for plan display)
-            if (_waitStatsEnabled && _slicerStartUtc.HasValue && _slicerEndUtc.HasValue)
+            if (_waitStatsSupported && _waitStatsEnabled && _slicerStartUtc.HasValue && _slicerEndUtc.HasValue)
                 _ = FetchWaitStatsAsync(_slicerStartUtc.Value, _slicerEndUtc.Value, ct);
         }
         catch (OperationCanceledException)
@@ -460,7 +475,7 @@ public partial class QueryStoreGridControl : UserControl
         if (waitProfileCol != null)
             waitProfileCol.IsVisible = !collapsed;
 
-        if (!collapsed && _slicerStartUtc.HasValue && _slicerEndUtc.HasValue)
+        if (!collapsed && _waitStatsSupported && _slicerStartUtc.HasValue && _slicerEndUtc.HasValue)
         {
             // Re-fetch wait stats when expanding — reuse the shared CTS
             var ct = _fetchCts?.Token ?? CancellationToken.None;

--- a/src/PlanViewer.Core/Models/ServerMetadata.cs
+++ b/src/PlanViewer.Core/Models/ServerMetadata.cs
@@ -28,6 +28,12 @@ public class ServerMetadata
     /// </summary>
     public bool SupportsScopedConfigs =>
         IsAzure || (int.TryParse(ProductVersion?.Split('.')[0], out var major) && major >= 13);
+
+    /// <summary>
+    /// Whether sys.query_store_wait_stats is available (SQL 2017+ or Azure).
+    /// </summary>
+    public bool SupportsQueryStoreWaitStats =>
+        IsAzure || (int.TryParse(ProductVersion?.Split('.')[0], out var major) && major >= 14);
 }
 
 public class DatabaseMetadata

--- a/src/PlanViewer.Core/Services/QueryStoreService.cs
+++ b/src/PlanViewer.Core/Services/QueryStoreService.cs
@@ -427,6 +427,36 @@ ORDER BY bucket_hour DESC;";
 
     // ── Wait stats ─────────────────────────────────────────────────────────
 
+    /// <summary>
+    /// Checks whether Query Store wait stats capture is enabled for the connected database.
+    /// Returns false on SQL Server 2016 (where the option doesn't exist) or when capture is OFF.
+    /// </summary>
+    public static async Task<bool> IsWaitStatsCaptureEnabledAsync(
+        string connectionString, CancellationToken ct = default)
+    {
+        const string sql = @"
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+SELECT CASE
+    WHEN EXISTS (
+        SELECT 1 FROM sys.database_query_store_options
+        WHERE wait_stats_capture_mode_desc = 'ON'
+    ) THEN 1 ELSE 0 END;";
+
+        try
+        {
+            await using var conn = new SqlConnection(connectionString);
+            await conn.OpenAsync(ct);
+            await using var cmd = new SqlCommand(sql, conn) { CommandTimeout = 10 };
+            var result = await cmd.ExecuteScalarAsync(ct);
+            return result is int i && i == 1;
+        }
+        catch
+        {
+            // Column doesn't exist on SQL 2016, or query store not enabled
+            return false;
+        }
+    }
+
     // Excluded: 11 = Idle, 18 = User Wait
     private const string WaitCategoryExclusion = "AND ws.wait_category NOT IN (11, 18)";
 


### PR DESCRIPTION
## Summary
`sys.query_store_wait_stats` only exists on SQL Server 2017+ and Azure SQL DB. Additionally, wait stats capture can be disabled per database via `WAIT_STATS_CAPTURE_MODE = OFF`. Without this gate, the wait stats queries from PR #137 would fail on SQL 2016 or when capture is disabled.

**Changes:**
- Add `SupportsQueryStoreWaitStats` property to `ServerMetadata` (major version >= 14 or Azure)
- Add `IsWaitStatsCaptureEnabledAsync()` to `QueryStoreService` — checks `wait_stats_capture_mode_desc` in `sys.database_query_store_options`
- `QueryStoreGridControl` accepts a `supportsWaitStats` constructor parameter — when `false`, hides the wait stats panel, splitter, chevron, and Wait Profile column
- Both fetch call sites gated on `_waitStatsSupported && _waitStatsEnabled`
- `QuerySessionControl` wires both checks (version + capture mode) before constructing the grid

**Behavior on SQL 2016 or capture OFF:** No wait stats queries issued, panel collapsed, column hidden. No errors.

## Test plan
- [x] Build succeeds (0 errors)
- [ ] Connect to SQL 2017+ with wait stats capture ON — wait stats panel visible and functional
- [ ] Connect to SQL 2016 — wait stats panel hidden, no errors
- [ ] Connect to database with `WAIT_STATS_CAPTURE_MODE = OFF` — wait stats panel hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)