### PR TITLE
Post-merge cleanup for PR #148

### DIFF
--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -190,9 +189,8 @@ public partial class QueryStoreGridControl : UserControl
         _filteredRows.Clear();
 
         // Start global + ribbon wait stats early (they don't depend on plan results)
-        System.Threading.Tasks.Task? globalWaitTask = null;
         if (_waitStatsSupported && _waitStatsEnabled && _slicerStartUtc.HasValue && _slicerEndUtc.HasValue)
-            globalWaitTask = FetchGlobalWaitStatsOnlyAsync(_slicerStartUtc.Value, _slicerEndUtc.Value, ct);
+            _ = FetchGlobalWaitStatsOnlyAsync(_slicerStartUtc.Value, _slicerEndUtc.Value, ct);
 
         try
         {
@@ -417,7 +415,8 @@ public partial class QueryStoreGridControl : UserControl
             if (ct.IsCancellationRequested) { return; }
             WaitStatsProfile.SetRibbonData(ribbonData);
         }
-        catch (Exception ex) { Debug.WriteLine($"[WAITSTATS] FetchGlobalWaitStatsOnlyAsync EXCEPTION: {ex}"); }
+        catch (OperationCanceledException) { }
+        catch (Exception) { }
         finally
         {
             WaitStatsProfile.SetLoading(false);
@@ -450,7 +449,8 @@ public partial class QueryStoreGridControl : UserControl
             }
             UpdateWaitBarMode();
         }
-        catch (Exception ex) { Debug.WriteLine($"[WAITSTATS] FetchPerPlanWaitStatsAsync EXCEPTION: {ex}"); }
+        catch (OperationCanceledException) { }
+        catch (Exception) { }
     }
 
     /// <summary>

--- a/src/PlanViewer.Core/Services/QueryStoreService.cs
+++ b/src/PlanViewer.Core/Services/QueryStoreService.cs
@@ -56,14 +56,14 @@ FROM sys.database_query_store_options;";
         // avg- variants still rank by total CPU (most impactful plan).
         var orderClause = key switch
         {
-            "cpu"              => "total_cpu_us",
-            "duration"         => "total_duration_us",
-            "reads"            => "total_reads",
-            "writes"           => "total_writes",
-            "physical-reads"   => "total_physical_reads",
-            "memory"           => "total_memory_pages",
-            "executions"       => "total_executions",
-            _ => "total_cpu_us"
+            "cpu"              => "ps.total_cpu_us",
+            "duration"         => "ps.total_duration_us",
+            "reads"            => "ps.total_reads",
+            "writes"           => "ps.total_writes",
+            "physical-reads"   => "ps.total_physical_reads",
+            "memory"           => "ps.total_memory_pages",
+            "executions"       => "ps.total_executions",
+            _ => "ps.total_cpu_us"
         };
 
         // Final ORDER BY — either a total or avg column from ranked CTE.


### PR DESCRIPTION
## Summary
- Fix fire-and-forget: `globalWaitTask` variable replaced with `_ =` discard
- Remove `Debug.WriteLines` from wait stats catch blocks, add separate `OperationCanceledException` handler
- Remove unused `using System.Diagnostics`
- Restore `ps.` prefix on `orderClause` — it's used in the ranked CTE where `ps` is the correct alias for `#plan_stats`

## Test plan
- [x] Build succeeds (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)