### PR TITLE
Fix search filter not applied and slicer reset on Fetch (#147)

### DIFF
--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
@@ -151,9 +151,9 @@ public partial class QueryStoreGridControl : UserControl
 
         try
         {
-            // Load slicer data first — LoadData sets a default 24h selection and
-            // fires RangeChanged which triggers FetchPlansForRangeAsync.
-            await LoadTimeSlicerDataAsync(orderBy, ct);
+            // Load slicer data, preserving the current selection if one exists.
+            // Without this, LoadData defaults to last 24h and the user's range is lost.
+            await LoadTimeSlicerDataAsync(orderBy, ct, _slicerStartUtc, _slicerEndUtc);
         }
         catch (OperationCanceledException)
         {
@@ -195,7 +195,7 @@ public partial class QueryStoreGridControl : UserControl
         try
         {
             var plans = await QueryStoreService.FetchTopPlansAsync(
-                _connectionString, topN, orderBy, ct: ct,
+                _connectionString, topN, orderBy, filter: filter, ct: ct,
                 startUtc: _slicerStartUtc, endUtc: _slicerEndUtc);
 
             GridLoadingOverlay.IsVisible = false;
@@ -363,7 +363,9 @@ public partial class QueryStoreGridControl : UserControl
         SearchValueBox.Text = "";
     }
 
-    private async System.Threading.Tasks.Task LoadTimeSlicerDataAsync(string metric, CancellationToken ct)
+    private async System.Threading.Tasks.Task LoadTimeSlicerDataAsync(
+        string metric, CancellationToken ct,
+        DateTime? preserveStart = null, DateTime? preserveEnd = null)
     {
         try
         {
@@ -371,7 +373,7 @@ public partial class QueryStoreGridControl : UserControl
                 _connectionString, metric, _slicerDaysBack, ct);
             if (ct.IsCancellationRequested) return;
             if (sliceData.Count > 0)
-                TimeRangeSlicer.LoadData(sliceData, metric);
+                TimeRangeSlicer.LoadData(sliceData, metric, preserveStart, preserveEnd);
             else
                 StatusText.Text = "No time-slicer data available.";
         }


### PR DESCRIPTION
## Summary
Two regressions from the time slicer PR (#114), both in `FetchPlansForRangeAsync`:

1. **Search filter dropped** — `BuildSearchFilter()` result was never passed to `FetchTopPlansAsync`. The call switched to named params for `startUtc`/`endUtc` and `filter:` was lost in the process.

2. **Slicer resets to 24h on Fetch** — `Fetch_Click` reloads slicer data via `LoadTimeSlicerDataAsync`, which calls `LoadData` without the current selection. `LoadData` defaults to last 24h. Now passes `_slicerStartUtc`/`_slicerEndUtc` through to preserve the user's range.

Fixes #147

## Test plan
- [x] Build succeeds (0 errors)
- [ ] Search by Module with a stored procedure name — grid shows only that proc's plans
- [ ] Search by Query ID / Plan ID / Query Hash / Plan Hash — correct filtering
- [ ] Drag slicer to custom range, click Fetch — range is preserved
- [ ] First load (no prior selection) — defaults to last 24h as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)