### PR TITLE
Bump to v1.3.0

### DIFF
--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -6,7 +6,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>EDD.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>1.2.5</Version>
+    <Version>1.3.0</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Cli/PlanViewer.Cli.csproj
+++ b/src/PlanViewer.Cli/PlanViewer.Cli.csproj
@@ -11,7 +11,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>PlanViewer.Cli</RootNamespace>
     <AssemblyName>planview</AssemblyName>
-    <Version>1.2.5</Version>
+    <Version>1.3.0</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Core/PlanViewer.Core.csproj
+++ b/src/PlanViewer.Core/PlanViewer.Core.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>PlanViewer.Core</RootNamespace>
-    <Version>1.2.5</Version>
+    <Version>1.3.0</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>SQL Performance Studio</Product>

--- a/src/PlanViewer.Ssms.Installer/PlanViewer.Ssms.Installer.csproj
+++ b/src/PlanViewer.Ssms.Installer/PlanViewer.Ssms.Installer.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>InstallSsmsExtension</AssemblyName>
     <RootNamespace>PlanViewer.Ssms.Installer</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <Version>1.2.5</Version>
+    <Version>1.3.0</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>SQL Performance Studio</Product>


### PR DESCRIPTION
Bumps version from 1.2.5 → 1.3.0 across all four projects in preparation for the v1.3.0 release.

## Changes
- `PlanViewer.App` → 1.3.0
- `PlanViewer.Cli` → 1.3.0
- `PlanViewer.Core` → 1.3.0
- `PlanViewer.Ssms.Installer` → 1.3.0

## Test plan
- [ ] CI passes
- [ ] Merge into `dev`, then PR `dev` → `main` to trigger the release workflow and publish v1.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)