### PR TITLE
Add contextual schema lookup from query editor

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -95,6 +95,13 @@ public partial class QuerySessionControl : UserControl
         _textMateInstallation.SetGrammar(registryOptions.GetScopeByLanguageId("sql"));
     }
 
+    // Schema context menu items — stored as fields so we can toggle visibility on menu open
+    private MenuItem? _showIndexesItem;
+    private MenuItem? _showTableDefItem;
+    private MenuItem? _showObjectDefItem;
+    private Separator? _schemaSeparator;
+    private ResolvedSqlObject? _contextMenuObject;
+
     private void SetupEditorContextMenu()
     {
         var cutItem = new MenuItem { Header = "Cut" };
@@ -151,10 +158,436 @@ public partial class QuerySessionControl : UserControl
                 await CaptureAndShowPlan(estimated: false, queryTextOverride: text);
         };
 
-        QueryEditor.TextArea.ContextMenu = new ContextMenu
+        // Schema lookup items
+        _schemaSeparator = new Separator();
+
+        _showIndexesItem = new MenuItem { Header = "Show Indexes" };
+        _showIndexesItem.Click += async (_, _) => await ShowSchemaInfoAsync(SchemaInfoKind.Indexes);
+
+        _showTableDefItem = new MenuItem { Header = "Show Table Definition" };
+        _showTableDefItem.Click += async (_, _) => await ShowSchemaInfoAsync(SchemaInfoKind.TableDefinition);
+
+        _showObjectDefItem = new MenuItem { Header = "Show Object Definition" };
+        _showObjectDefItem.Click += async (_, _) => await ShowSchemaInfoAsync(SchemaInfoKind.ObjectDefinition);
+
+        var contextMenu = new ContextMenu
         {
-            Items = { cutItem, copyItem, pasteItem, new Separator(), selectAllItem, new Separator(), executeFromCursorItem, executeCurrentBatchItem }
+            Items =
+            {
+                cutItem, copyItem, pasteItem,
+                new Separator(), selectAllItem,
+                new Separator(), executeFromCursorItem, executeCurrentBatchItem,
+                _schemaSeparator,
+                _showIndexesItem, _showTableDefItem, _showObjectDefItem
+            }
         };
+
+        contextMenu.Opening += OnContextMenuOpening;
+        QueryEditor.TextArea.ContextMenu = contextMenu;
+
+        // Move caret to right-click position so schema lookup resolves the clicked object
+        QueryEditor.TextArea.PointerPressed += OnEditorPointerPressed;
+    }
+
+    private void OnEditorPointerPressed(object? sender, Avalonia.Input.PointerPressedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(QueryEditor.TextArea).Properties.IsRightButtonPressed)
+            return;
+
+        var pos = QueryEditor.GetPositionFromPoint(e.GetPosition(QueryEditor));
+        if (pos == null) return;
+
+        QueryEditor.TextArea.Caret.Position = pos.Value;
+    }
+
+    private void OnContextMenuOpening(object? sender, System.ComponentModel.CancelEventArgs e)
+    {
+        // Resolve what object is under the cursor
+        var sqlText = QueryEditor.Text;
+        var offset = QueryEditor.CaretOffset;
+        _contextMenuObject = SqlObjectResolver.Resolve(sqlText, offset);
+
+        var hasConnection = _connectionString != null;
+        var hasObject = _contextMenuObject != null && hasConnection;
+
+        _schemaSeparator!.IsVisible = hasObject;
+        _showIndexesItem!.IsVisible = hasObject && _contextMenuObject!.Kind is SqlObjectKind.Table or SqlObjectKind.Unknown;
+        _showTableDefItem!.IsVisible = hasObject && _contextMenuObject!.Kind is SqlObjectKind.Table or SqlObjectKind.Unknown;
+        _showObjectDefItem!.IsVisible = hasObject && _contextMenuObject!.Kind is SqlObjectKind.Function or SqlObjectKind.Procedure;
+
+        // Update headers to show the object name
+        if (hasObject)
+        {
+            var name = _contextMenuObject!.FullName;
+            _showIndexesItem.Header = $"Show Indexes — {name}";
+            _showTableDefItem.Header = $"Show Table Definition — {name}";
+            _showObjectDefItem.Header = $"Show Object Definition — {name}";
+        }
+    }
+
+    private enum SchemaInfoKind { Indexes, TableDefinition, ObjectDefinition }
+
+    private async Task ShowSchemaInfoAsync(SchemaInfoKind kind)
+    {
+        if (_contextMenuObject == null || _connectionString == null) return;
+
+        var objectName = _contextMenuObject.FullName;
+        SetStatus($"Fetching {kind} for {objectName}...", autoClear: false);
+
+        try
+        {
+            string content;
+            string tabLabel;
+
+            switch (kind)
+            {
+                case SchemaInfoKind.Indexes:
+                    var indexes = await SchemaQueryService.FetchIndexesAsync(_connectionString, objectName);
+                    content = FormatIndexes(objectName, indexes);
+                    tabLabel = $"Indexes — {objectName}";
+                    break;
+
+                case SchemaInfoKind.TableDefinition:
+                    var columns = await SchemaQueryService.FetchColumnsAsync(_connectionString, objectName);
+                    var tableIndexes = await SchemaQueryService.FetchIndexesAsync(_connectionString, objectName);
+                    content = FormatColumns(objectName, columns, tableIndexes);
+                    tabLabel = $"Table — {objectName}";
+                    break;
+
+                case SchemaInfoKind.ObjectDefinition:
+                    var definition = await SchemaQueryService.FetchObjectDefinitionAsync(_connectionString, objectName);
+                    content = definition ?? $"-- No definition found for {objectName}";
+                    tabLabel = $"Definition — {objectName}";
+                    break;
+
+                default:
+                    return;
+            }
+
+            AddSchemaTab(tabLabel, content, isSql: true);
+            SetStatus($"Loaded {kind} for {objectName}");
+        }
+        catch (Exception ex)
+        {
+            SetStatus($"Error: {ex.Message}", autoClear: false);
+            Debug.WriteLine($"Schema lookup error: {ex}");
+        }
+    }
+
+    private void AddSchemaTab(string label, string content, bool isSql)
+    {
+        var editor = new TextEditor
+        {
+            Text = content,
+            IsReadOnly = true,
+            FontFamily = new FontFamily("Consolas, Menlo, monospace"),
+            FontSize = 13,
+            ShowLineNumbers = true,
+            Background = (IBrush)this.FindResource("BackgroundBrush")!,
+            Foreground = (IBrush)this.FindResource("ForegroundBrush")!,
+            HorizontalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Auto,
+            VerticalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Auto,
+            Padding = new Avalonia.Thickness(4)
+        };
+
+        if (isSql)
+        {
+            var registryOptions = new RegistryOptions(ThemeName.DarkPlus);
+            var tm = editor.InstallTextMate(registryOptions);
+            tm.SetGrammar(registryOptions.GetScopeByLanguageId("sql"));
+        }
+
+        // Context menu for read-only schema tabs
+        var schemaCopy = new MenuItem { Header = "Copy" };
+        schemaCopy.Click += async (_, _) =>
+        {
+            var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+            if (clipboard == null) return;
+            var sel = editor.TextArea.Selection;
+            if (!sel.IsEmpty)
+                await clipboard.SetTextAsync(sel.GetText());
+        };
+        var schemaCopyAll = new MenuItem { Header = "Copy All" };
+        schemaCopyAll.Click += async (_, _) =>
+        {
+            var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+            if (clipboard == null) return;
+            await clipboard.SetTextAsync(editor.Text);
+        };
+        var schemaSelectAll = new MenuItem { Header = "Select All" };
+        schemaSelectAll.Click += (_, _) => editor.SelectAll();
+        editor.TextArea.ContextMenu = new ContextMenu
+        {
+            Items = { schemaCopy, schemaCopyAll, new Separator(), schemaSelectAll }
+        };
+
+        var headerText = new TextBlock
+        {
+            Text = label,
+            VerticalAlignment = VerticalAlignment.Center,
+            FontSize = 12
+        };
+
+        var closeBtn = new Button
+        {
+            Content = "\u2715",
+            MinWidth = 22, MinHeight = 22, Width = 22, Height = 22,
+            Padding = new Avalonia.Thickness(0),
+            FontSize = 11,
+            Margin = new Avalonia.Thickness(6, 0, 0, 0),
+            Background = Brushes.Transparent,
+            BorderThickness = new Avalonia.Thickness(0),
+            Foreground = new SolidColorBrush(Color.FromRgb(0xE4, 0xE6, 0xEB)),
+            VerticalAlignment = VerticalAlignment.Center,
+            HorizontalContentAlignment = HorizontalAlignment.Center,
+            VerticalContentAlignment = VerticalAlignment.Center
+        };
+
+        var header = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { headerText, closeBtn }
+        };
+
+        var tab = new TabItem { Header = header, Content = editor };
+        closeBtn.Tag = tab;
+        closeBtn.Click += (s, _) =>
+        {
+            if (s is Button btn && btn.Tag is TabItem t)
+                SubTabControl.Items.Remove(t);
+        };
+
+        SubTabControl.Items.Add(tab);
+        SubTabControl.SelectedItem = tab;
+    }
+
+    private static string FormatIndexes(string objectName, IReadOnlyList<IndexInfo> indexes)
+    {
+        if (indexes.Count == 0)
+            return $"-- No indexes found on {objectName}";
+
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine($"-- Indexes on {objectName}");
+        sb.AppendLine($"-- {indexes.Count} index(es), {indexes[0].RowCount:N0} rows");
+        sb.AppendLine();
+
+        foreach (var ix in indexes)
+        {
+            if (ix.IsDisabled)
+                sb.AppendLine("-- ** DISABLED **");
+
+            // Usage stats as a comment
+            sb.AppendLine($"-- {ix.SizeMB:N1} MB | Seeks: {ix.UserSeeks:N0} | Scans: {ix.UserScans:N0} | Lookups: {ix.UserLookups:N0} | Updates: {ix.UserUpdates:N0}");
+
+            var withOptions = BuildWithOptions(ix);
+
+            var onPartition = ix.PartitionScheme != null && ix.PartitionColumn != null
+                ? $"ON {BracketName(ix.PartitionScheme)}({BracketName(ix.PartitionColumn)})"
+                : null;
+
+            if (ix.IsPrimaryKey)
+            {
+                var clustered = ix.IndexType.Contains("CLUSTERED", System.StringComparison.OrdinalIgnoreCase)
+                    && !ix.IndexType.Contains("NONCLUSTERED", System.StringComparison.OrdinalIgnoreCase)
+                    ? "CLUSTERED" : "NONCLUSTERED";
+                sb.AppendLine($"ALTER TABLE {objectName}");
+                sb.AppendLine($"ADD CONSTRAINT {BracketName(ix.IndexName)}");
+                sb.Append($"    PRIMARY KEY {clustered} ({ix.KeyColumns})");
+                if (withOptions.Count > 0)
+                {
+                    sb.AppendLine();
+                    sb.Append($"    WITH ({string.Join(", ", withOptions)})");
+                }
+                if (onPartition != null)
+                {
+                    sb.AppendLine();
+                    sb.Append($"    {onPartition}");
+                }
+                sb.AppendLine(";");
+            }
+            else if (IsColumnstore(ix))
+            {
+                // Columnstore indexes: no key columns, no INCLUDE, no row/page lock or compression options
+                var clustered = ix.IndexType.Contains("NONCLUSTERED", System.StringComparison.OrdinalIgnoreCase)
+                    ? "NONCLUSTERED " : "CLUSTERED ";
+                sb.Append($"CREATE {clustered}COLUMNSTORE INDEX {BracketName(ix.IndexName)}");
+                sb.AppendLine($" ON {objectName}");
+
+                // Nonclustered columnstore can have a column list
+                if (ix.IndexType.Contains("NONCLUSTERED", System.StringComparison.OrdinalIgnoreCase)
+                    && !string.IsNullOrEmpty(ix.KeyColumns))
+                {
+                    sb.AppendLine($"({ix.KeyColumns})");
+                }
+
+                // Only emit non-default options that aren't inherent to columnstore
+                var csOptions = BuildColumnstoreWithOptions(ix);
+                if (csOptions.Count > 0)
+                    sb.AppendLine($"WITH ({string.Join(", ", csOptions)})");
+
+                if (onPartition != null)
+                    sb.AppendLine(onPartition);
+
+                // Remove trailing newline before semicolon
+                if (sb[sb.Length - 1] == '\n') sb.Length--;
+                if (sb[sb.Length - 1] == '\r') sb.Length--;
+                sb.AppendLine(";");
+            }
+            else
+            {
+                var unique = ix.IsUnique ? "UNIQUE " : "";
+                var clustered = ix.IndexType.Contains("CLUSTERED", System.StringComparison.OrdinalIgnoreCase)
+                    && !ix.IndexType.Contains("NONCLUSTERED", System.StringComparison.OrdinalIgnoreCase)
+                    ? "CLUSTERED " : "NONCLUSTERED ";
+                sb.Append($"CREATE {unique}{clustered}INDEX {BracketName(ix.IndexName)}");
+                sb.AppendLine($" ON {objectName}");
+                sb.Append($"(");
+                sb.Append(ix.KeyColumns);
+                sb.AppendLine(")");
+
+                if (!string.IsNullOrEmpty(ix.IncludeColumns))
+                    sb.AppendLine($"INCLUDE ({ix.IncludeColumns})");
+
+                if (!string.IsNullOrEmpty(ix.FilterDefinition))
+                    sb.AppendLine($"WHERE {ix.FilterDefinition}");
+
+                if (withOptions.Count > 0)
+                    sb.AppendLine($"WITH ({string.Join(", ", withOptions)})");
+
+                if (onPartition != null)
+                    sb.AppendLine(onPartition);
+
+                // Remove trailing newline before semicolon
+                if (sb[sb.Length - 1] == '\n') sb.Length--;
+                if (sb[sb.Length - 1] == '\r') sb.Length--;
+                sb.AppendLine(";");
+            }
+
+            sb.AppendLine();
+        }
+
+        return sb.ToString();
+    }
+
+    private static bool IsColumnstore(IndexInfo ix) =>
+        ix.IndexType.Contains("COLUMNSTORE", System.StringComparison.OrdinalIgnoreCase);
+
+    private static List<string> BuildWithOptions(IndexInfo ix)
+    {
+        var options = new List<string>();
+
+        if (ix.FillFactor > 0 && ix.FillFactor != 100)
+            options.Add($"FILLFACTOR = {ix.FillFactor}");
+        if (ix.IsPadded)
+            options.Add("PAD_INDEX = ON");
+        if (!ix.AllowRowLocks)
+            options.Add("ALLOW_ROW_LOCKS = OFF");
+        if (!ix.AllowPageLocks)
+            options.Add("ALLOW_PAGE_LOCKS = OFF");
+        if (!string.Equals(ix.DataCompression, "NONE", System.StringComparison.OrdinalIgnoreCase))
+            options.Add($"DATA_COMPRESSION = {ix.DataCompression}");
+
+        return options;
+    }
+
+    /// <summary>
+    /// For columnstore indexes, skip options that are inherent to the storage format
+    /// (row/page locks are always OFF, compression is always COLUMNSTORE).
+    /// Only emit fill factor and pad index if non-default.
+    /// </summary>
+    private static List<string> BuildColumnstoreWithOptions(IndexInfo ix)
+    {
+        var options = new List<string>();
+
+        if (ix.FillFactor > 0 && ix.FillFactor != 100)
+            options.Add($"FILLFACTOR = {ix.FillFactor}");
+        if (ix.IsPadded)
+            options.Add("PAD_INDEX = ON");
+
+        return options;
+    }
+
+    private static string FormatColumns(string objectName, IReadOnlyList<ColumnInfo> columns, IReadOnlyList<IndexInfo> indexes)
+    {
+        if (columns.Count == 0)
+            return $"-- No columns found for {objectName}";
+
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine($"CREATE TABLE {objectName}");
+        sb.AppendLine("(");
+
+        for (int i = 0; i < columns.Count; i++)
+        {
+            var col = columns[i];
+            var isLast = i == columns.Count - 1;
+
+            sb.Append($"    {BracketName(col.ColumnName)} ");
+
+            if (col.IsComputed && col.ComputedDefinition != null)
+            {
+                sb.Append($"AS {col.ComputedDefinition}");
+            }
+            else
+            {
+                sb.Append(col.DataType);
+
+                if (col.IsIdentity)
+                    sb.Append($" IDENTITY({col.IdentitySeed}, {col.IdentityIncrement})");
+
+                sb.Append(col.IsNullable ? " NULL" : " NOT NULL");
+
+                if (col.DefaultValue != null)
+                    sb.Append($" DEFAULT {col.DefaultValue}");
+            }
+
+            // Check if we need a PK constraint after all columns
+            var pk = indexes.FirstOrDefault(ix => ix.IsPrimaryKey);
+            var needsTrailingComma = !isLast || pk != null;
+
+            sb.AppendLine(needsTrailingComma ? "," : "");
+        }
+
+        // Add PK constraint
+        var pkIndex = indexes.FirstOrDefault(ix => ix.IsPrimaryKey);
+        if (pkIndex != null)
+        {
+            var clustered = pkIndex.IndexType.Contains("CLUSTERED", System.StringComparison.OrdinalIgnoreCase)
+                && !pkIndex.IndexType.Contains("NONCLUSTERED", System.StringComparison.OrdinalIgnoreCase)
+                ? "CLUSTERED " : "NONCLUSTERED ";
+            sb.AppendLine($"    CONSTRAINT {BracketName(pkIndex.IndexName)}");
+            sb.Append($"        PRIMARY KEY {clustered}({pkIndex.KeyColumns})");
+            var pkOptions = BuildWithOptions(pkIndex);
+            if (pkOptions.Count > 0)
+            {
+                sb.AppendLine();
+                sb.Append($"        WITH ({string.Join(", ", pkOptions)})");
+            }
+            sb.AppendLine();
+        }
+
+        sb.Append(")");
+
+        // Add partition scheme from the clustered index (determines table storage)
+        var clusteredIx = indexes.FirstOrDefault(ix =>
+            ix.IndexType.Contains("CLUSTERED", System.StringComparison.OrdinalIgnoreCase)
+            && !ix.IndexType.Contains("NONCLUSTERED", System.StringComparison.OrdinalIgnoreCase));
+        if (clusteredIx?.PartitionScheme != null && clusteredIx.PartitionColumn != null)
+        {
+            sb.AppendLine();
+            sb.Append($"ON {BracketName(clusteredIx.PartitionScheme)}({BracketName(clusteredIx.PartitionColumn)})");
+        }
+
+        sb.AppendLine(";");
+
+        return sb.ToString();
+    }
+
+    private static string BracketName(string name)
+    {
+        // Already bracketed
+        if (name.StartsWith('['))
+            return name;
+        return $"[{name}]";
     }
 
     private void OnKeyDown(object? sender, KeyEventArgs e)

--- a/src/PlanViewer.Core/PlanViewer.Core.csproj
+++ b/src/PlanViewer.Core/PlanViewer.Core.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.1" />
     <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="1.7.17" />
+    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="170.191.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PlanViewer.Core/Services/SchemaQueryService.cs
+++ b/src/PlanViewer.Core/Services/SchemaQueryService.cs
@@ -1,0 +1,237 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+
+namespace PlanViewer.Core.Services;
+
+public sealed class IndexInfo
+{
+    public required string IndexName { get; init; }
+    public required string IndexType { get; init; }
+    public required bool IsUnique { get; init; }
+    public required bool IsPrimaryKey { get; init; }
+    public required string KeyColumns { get; init; }
+    public required string IncludeColumns { get; init; }
+    public required string? FilterDefinition { get; init; }
+    public required long RowCount { get; init; }
+    public required double SizeMB { get; init; }
+    public long UserSeeks { get; init; }
+    public long UserScans { get; init; }
+    public long UserLookups { get; init; }
+    public long UserUpdates { get; init; }
+    public int FillFactor { get; init; }
+    public bool IsPadded { get; init; }
+    public bool AllowRowLocks { get; init; } = true;
+    public bool AllowPageLocks { get; init; } = true;
+    public bool IsDisabled { get; init; }
+    public required string DataCompression { get; init; }
+    public string? PartitionScheme { get; init; }
+    public string? PartitionColumn { get; init; }
+}
+
+public sealed class ColumnInfo
+{
+    public required int OrdinalPosition { get; init; }
+    public required string ColumnName { get; init; }
+    public required string DataType { get; init; }
+    public required bool IsNullable { get; init; }
+    public required bool IsIdentity { get; init; }
+    public required bool IsComputed { get; init; }
+    public required string? DefaultValue { get; init; }
+    public required string? ComputedDefinition { get; init; }
+    public required long IdentitySeed { get; init; }
+    public required long IdentityIncrement { get; init; }
+}
+
+/// <summary>
+/// Fetches schema information (indexes, columns, object definitions) from a connected SQL Server.
+/// </summary>
+public static class SchemaQueryService
+{
+    private const string IndexQuery = @"
+SELECT
+    i.name AS index_name,
+    i.type_desc AS index_type,
+    i.is_unique,
+    i.is_primary_key,
+    STUFF((
+        SELECT ', ' + c.name + CASE WHEN ic2.is_descending_key = 1 THEN ' DESC' ELSE '' END
+        FROM sys.index_columns AS ic2
+        JOIN sys.columns AS c ON c.object_id = ic2.object_id AND c.column_id = ic2.column_id
+        WHERE ic2.object_id = i.object_id AND ic2.index_id = i.index_id AND ic2.is_included_column = 0
+        ORDER BY ic2.key_ordinal
+        FOR XML PATH('')
+    ), 1, 2, '') AS key_columns,
+    ISNULL(STUFF((
+        SELECT ', ' + c.name
+        FROM sys.index_columns AS ic2
+        JOIN sys.columns AS c ON c.object_id = ic2.object_id AND c.column_id = ic2.column_id
+        WHERE ic2.object_id = i.object_id AND ic2.index_id = i.index_id AND ic2.is_included_column = 1
+        ORDER BY c.name
+        FOR XML PATH('')
+    ), 1, 2, ''), '') AS include_columns,
+    i.filter_definition,
+    p.row_count,
+    CAST(ROUND(p.reserved_page_count * 8.0 / 1024, 2) AS float) AS size_mb,
+    ISNULL(us.user_seeks, 0) AS user_seeks,
+    ISNULL(us.user_scans, 0) AS user_scans,
+    ISNULL(us.user_lookups, 0) AS user_lookups,
+    ISNULL(us.user_updates, 0) AS user_updates,
+    CAST(i.fill_factor AS int),
+    i.is_padded,
+    i.allow_row_locks,
+    i.allow_page_locks,
+    i.is_disabled,
+    ISNULL(p.data_compression_desc, 'NONE') AS data_compression,
+    psch.name AS partition_scheme,
+    pc.name AS partition_column
+FROM sys.indexes AS i
+CROSS APPLY (
+    SELECT SUM(ps.row_count) AS row_count,
+           SUM(ps.reserved_page_count) AS reserved_page_count,
+           MAX(pt.data_compression_desc) AS data_compression_desc
+    FROM sys.dm_db_partition_stats AS ps
+    JOIN sys.partitions AS pt ON pt.partition_id = ps.partition_id
+    WHERE ps.object_id = i.object_id AND ps.index_id = i.index_id
+) AS p
+LEFT JOIN sys.dm_db_index_usage_stats AS us
+    ON us.object_id = i.object_id AND us.index_id = i.index_id AND us.database_id = DB_ID()
+LEFT JOIN sys.partition_schemes AS psch
+    ON psch.data_space_id = i.data_space_id
+LEFT JOIN sys.index_columns AS pic
+    ON pic.object_id = i.object_id AND pic.index_id = i.index_id AND pic.partition_ordinal > 0
+LEFT JOIN sys.columns AS pc
+    ON pc.object_id = pic.object_id AND pc.column_id = pic.column_id
+WHERE i.object_id = OBJECT_ID(@objectName)
+    AND i.type > 0
+ORDER BY i.index_id;";
+
+    private const string ColumnQuery = @"
+SELECT
+    c.column_id AS ordinal_position,
+    c.name AS column_name,
+    tp.name +
+        CASE
+            WHEN tp.name IN ('varchar','nvarchar','char','nchar','binary','varbinary')
+                THEN '(' + CASE WHEN c.max_length = -1 THEN 'max' ELSE CAST(
+                    CASE WHEN tp.name IN ('nvarchar','nchar') THEN c.max_length / 2 ELSE c.max_length END
+                AS varchar) END + ')'
+            WHEN tp.name IN ('decimal','numeric')
+                THEN '(' + CAST(c.precision AS varchar) + ',' + CAST(c.scale AS varchar) + ')'
+            WHEN tp.name IN ('datetime2','datetimeoffset','time')
+                THEN '(' + CAST(c.scale AS varchar) + ')'
+            ELSE ''
+        END AS data_type,
+    c.is_nullable,
+    c.is_identity,
+    c.is_computed,
+    dc.definition AS default_value,
+    cc.definition AS computed_definition,
+    CAST(ISNULL(ic.seed_value, 0) AS bigint) AS identity_seed,
+    CAST(ISNULL(ic.increment_value, 0) AS bigint) AS identity_increment
+FROM sys.columns AS c
+JOIN sys.types AS tp ON tp.user_type_id = c.user_type_id
+LEFT JOIN sys.default_constraints AS dc ON dc.parent_object_id = c.object_id AND dc.parent_column_id = c.column_id
+LEFT JOIN sys.computed_columns AS cc ON cc.object_id = c.object_id AND cc.column_id = c.column_id
+LEFT JOIN sys.identity_columns AS ic ON ic.object_id = c.object_id AND ic.column_id = c.column_id
+WHERE c.object_id = OBJECT_ID(@objectName)
+ORDER BY c.column_id;";
+
+    private const string ObjectDefinitionQuery = @"
+SELECT OBJECT_DEFINITION(OBJECT_ID(@objectName));";
+
+    public static async Task<IReadOnlyList<IndexInfo>> FetchIndexesAsync(
+        string connectionString, string objectName, CancellationToken ct = default)
+    {
+        var results = new List<IndexInfo>();
+
+        await using var conn = new SqlConnection(connectionString);
+        await conn.OpenAsync(ct);
+
+        await using var cmd = new SqlCommand(IndexQuery, conn);
+        cmd.CommandTimeout = 10;
+        cmd.Parameters.AddWithValue("@objectName", objectName);
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+        while (await reader.ReadAsync(ct))
+        {
+            results.Add(new IndexInfo
+            {
+                IndexName = reader.GetString(0),
+                IndexType = reader.GetString(1),
+                IsUnique = reader.GetBoolean(2),
+                IsPrimaryKey = reader.GetBoolean(3),
+                KeyColumns = reader.IsDBNull(4) ? "" : reader.GetString(4),
+                IncludeColumns = reader.IsDBNull(5) ? "" : reader.GetString(5),
+                FilterDefinition = reader.IsDBNull(6) ? null : reader.GetString(6),
+                RowCount = reader.GetInt64(7),
+                SizeMB = reader.GetDouble(8),
+                UserSeeks = reader.GetInt64(9),
+                UserScans = reader.GetInt64(10),
+                UserLookups = reader.GetInt64(11),
+                UserUpdates = reader.GetInt64(12),
+                FillFactor = reader.GetInt32(13),
+                IsPadded = reader.GetBoolean(14),
+                AllowRowLocks = reader.GetBoolean(15),
+                AllowPageLocks = reader.GetBoolean(16),
+                IsDisabled = reader.GetBoolean(17),
+                DataCompression = reader.GetString(18),
+                PartitionScheme = reader.IsDBNull(19) ? null : reader.GetString(19),
+                PartitionColumn = reader.IsDBNull(20) ? null : reader.GetString(20)
+            });
+        }
+
+        return results;
+    }
+
+    public static async Task<IReadOnlyList<ColumnInfo>> FetchColumnsAsync(
+        string connectionString, string objectName, CancellationToken ct = default)
+    {
+        var results = new List<ColumnInfo>();
+
+        await using var conn = new SqlConnection(connectionString);
+        await conn.OpenAsync(ct);
+
+        await using var cmd = new SqlCommand(ColumnQuery, conn);
+        cmd.CommandTimeout = 10;
+        cmd.Parameters.AddWithValue("@objectName", objectName);
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+        while (await reader.ReadAsync(ct))
+        {
+            results.Add(new ColumnInfo
+            {
+                OrdinalPosition = reader.GetInt32(0),
+                ColumnName = reader.GetString(1),
+                DataType = reader.GetString(2),
+                IsNullable = reader.GetBoolean(3),
+                IsIdentity = reader.GetBoolean(4),
+                IsComputed = reader.GetBoolean(5),
+                DefaultValue = reader.IsDBNull(6) ? null : reader.GetString(6),
+                ComputedDefinition = reader.IsDBNull(7) ? null : reader.GetString(7),
+                IdentitySeed = reader.GetInt64(8),
+                IdentityIncrement = reader.GetInt64(9)
+            });
+        }
+
+        return results;
+    }
+
+    public static async Task<string?> FetchObjectDefinitionAsync(
+        string connectionString, string objectName, CancellationToken ct = default)
+    {
+        await using var conn = new SqlConnection(connectionString);
+        await conn.OpenAsync(ct);
+
+        await using var cmd = new SqlCommand(ObjectDefinitionQuery, conn);
+        cmd.CommandTimeout = 10;
+        cmd.Parameters.AddWithValue("@objectName", objectName);
+
+        var result = await cmd.ExecuteScalarAsync(ct);
+
+        return result as string;
+    }
+}

--- a/src/PlanViewer.Core/Services/SqlObjectResolver.cs
+++ b/src/PlanViewer.Core/Services/SqlObjectResolver.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+
+namespace PlanViewer.Core.Services;
+
+/// <summary>
+/// The kind of SQL object found at a cursor position.
+/// </summary>
+public enum SqlObjectKind
+{
+    Table,
+    View,
+    Function,
+    Procedure,
+    Unknown
+}
+
+/// <summary>
+/// Represents a resolved SQL object at a specific cursor position.
+/// </summary>
+public sealed class ResolvedSqlObject
+{
+    public required string SchemaName { get; init; }
+    public required string ObjectName { get; init; }
+    public required SqlObjectKind Kind { get; init; }
+
+    /// <summary>
+    /// Fully qualified [schema].[object] name.
+    /// </summary>
+    public string FullName => string.IsNullOrEmpty(SchemaName)
+        ? ObjectName
+        : $"{SchemaName}.{ObjectName}";
+}
+
+/// <summary>
+/// Parses T-SQL text using ScriptDom and resolves what object is at a given cursor offset.
+/// </summary>
+public static class SqlObjectResolver
+{
+    /// <summary>
+    /// Resolve the SQL object at the given zero-based character offset in the SQL text.
+    /// Returns null if no recognizable object is at that position.
+    /// </summary>
+    public static ResolvedSqlObject? Resolve(string sqlText, int offset)
+    {
+        if (string.IsNullOrWhiteSpace(sqlText) || offset < 0 || offset >= sqlText.Length)
+            return null;
+
+        var parser = new TSql160Parser(initialQuotedIdentifiers: false);
+
+        using var reader = new StringReader(sqlText);
+        var fragment = parser.Parse(reader, out var errors);
+
+        if (fragment == null)
+            return null;
+
+        var visitor = new ObjectAtOffsetVisitor(offset);
+        fragment.Accept(visitor);
+
+        return visitor.Result;
+    }
+
+    /// <summary>
+    /// Resolve all distinct SQL objects referenced in the text.
+    /// </summary>
+    public static IReadOnlyList<ResolvedSqlObject> ResolveAll(string sqlText)
+    {
+        if (string.IsNullOrWhiteSpace(sqlText))
+            return Array.Empty<ResolvedSqlObject>();
+
+        var parser = new TSql160Parser(initialQuotedIdentifiers: false);
+
+        using var reader = new StringReader(sqlText);
+        var fragment = parser.Parse(reader, out var errors);
+
+        if (fragment == null)
+            return Array.Empty<ResolvedSqlObject>();
+
+        var visitor = new AllObjectsVisitor();
+        fragment.Accept(visitor);
+
+        return visitor.Results;
+    }
+
+    /// <summary>
+    /// Walks the AST to find the object reference whose token span covers the given offset.
+    /// </summary>
+    private sealed class ObjectAtOffsetVisitor : TSqlFragmentVisitor
+    {
+        private readonly int _offset;
+
+        public ResolvedSqlObject? Result { get; private set; }
+
+        public ObjectAtOffsetVisitor(int offset) => _offset = offset;
+
+        public override void Visit(NamedTableReference node)
+        {
+            if (Covers(node.SchemaObject, _offset))
+            {
+                Result = FromSchemaObjectName(node.SchemaObject, SqlObjectKind.Table);
+            }
+        }
+
+        public override void Visit(FunctionCall node)
+        {
+            if (node.CallTarget is MultiPartIdentifierCallTarget target)
+            {
+                if (CoversIdentifier(target.MultiPartIdentifier, _offset) ||
+                    CoversToken(node.FunctionName, _offset))
+                {
+                    Result = FromFunctionCall(target.MultiPartIdentifier, node.FunctionName.Value, SqlObjectKind.Function);
+                }
+            }
+            else if (CoversToken(node.FunctionName, _offset))
+            {
+                // Standalone function name — could be a scalar UDF or built-in
+                Result = new ResolvedSqlObject
+                {
+                    SchemaName = "",
+                    ObjectName = node.FunctionName.Value,
+                    Kind = SqlObjectKind.Function
+                };
+            }
+        }
+
+        public override void Visit(SchemaObjectFunctionTableReference node)
+        {
+            if (Covers(node.SchemaObject, _offset))
+            {
+                Result = FromSchemaObjectName(node.SchemaObject, SqlObjectKind.Function);
+            }
+        }
+
+        public override void Visit(ExecutableProcedureReference node)
+        {
+            if (node.ProcedureReference?.ProcedureReference != null &&
+                Covers(node.ProcedureReference.ProcedureReference.Name, _offset))
+            {
+                Result = FromSchemaObjectName(
+                    node.ProcedureReference.ProcedureReference.Name,
+                    SqlObjectKind.Procedure);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Collects all distinct object references in the SQL text.
+    /// </summary>
+    private sealed class AllObjectsVisitor : TSqlFragmentVisitor
+    {
+        private readonly HashSet<string> _seen = new(StringComparer.OrdinalIgnoreCase);
+        private readonly List<ResolvedSqlObject> _results = new();
+
+        public IReadOnlyList<ResolvedSqlObject> Results => _results;
+
+        public override void Visit(NamedTableReference node)
+        {
+            Add(FromSchemaObjectName(node.SchemaObject, SqlObjectKind.Table));
+        }
+
+        public override void Visit(SchemaObjectFunctionTableReference node)
+        {
+            Add(FromSchemaObjectName(node.SchemaObject, SqlObjectKind.Function));
+        }
+
+        public override void Visit(ExecutableProcedureReference node)
+        {
+            if (node.ProcedureReference?.ProcedureReference?.Name != null)
+            {
+                Add(FromSchemaObjectName(
+                    node.ProcedureReference.ProcedureReference.Name,
+                    SqlObjectKind.Procedure));
+            }
+        }
+
+        private void Add(ResolvedSqlObject obj)
+        {
+            if (_seen.Add(obj.FullName))
+                _results.Add(obj);
+        }
+    }
+
+    // --- Helpers ---
+
+    private static ResolvedSqlObject FromSchemaObjectName(SchemaObjectName name, SqlObjectKind kind)
+    {
+        return new ResolvedSqlObject
+        {
+            SchemaName = name.SchemaIdentifier?.Value ?? "",
+            ObjectName = name.BaseIdentifier?.Value ?? "",
+            Kind = kind
+        };
+    }
+
+    private static ResolvedSqlObject FromFunctionCall(
+        MultiPartIdentifier identifier, string functionName, SqlObjectKind kind)
+    {
+        // e.g., dbo.MyFunction() → schema = "dbo", object = "MyFunction"
+        var parts = identifier.Identifiers;
+        var schema = parts.Count > 0 ? parts[parts.Count - 1].Value : "";
+
+        return new ResolvedSqlObject
+        {
+            SchemaName = schema,
+            ObjectName = functionName,
+            Kind = kind
+        };
+    }
+
+    /// <summary>
+    /// Check if a SchemaObjectName's token range covers the given offset.
+    /// </summary>
+    private static bool Covers(SchemaObjectName name, int offset)
+    {
+        if (name == null) return false;
+
+        int start = name.StartOffset;
+        int end = start + name.FragmentLength;
+        return offset >= start && offset < end;
+    }
+
+    /// <summary>
+    /// Check if a MultiPartIdentifier's token range covers the given offset.
+    /// </summary>
+    private static bool CoversIdentifier(MultiPartIdentifier identifier, int offset)
+    {
+        if (identifier == null) return false;
+
+        int start = identifier.StartOffset;
+        int end = start + identifier.FragmentLength;
+        return offset >= start && offset < end;
+    }
+
+    /// <summary>
+    /// Check if a single Identifier token covers the given offset.
+    /// </summary>
+    private static bool CoversToken(Identifier token, int offset)
+    {
+        if (token == null) return false;
+
+        int start = token.StartOffset;
+        int end = start + token.FragmentLength;
+        return offset >= start && offset < end;
+    }
+}

--- a/tests/PlanViewer.Core.Tests/SqlObjectResolverTests.cs
+++ b/tests/PlanViewer.Core.Tests/SqlObjectResolverTests.cs
@@ -1,0 +1,143 @@
+using PlanViewer.Core.Services;
+
+namespace PlanViewer.Core.Tests;
+
+public class SqlObjectResolverTests
+{
+    [Fact]
+    public void Resolve_TableInSelect_ReturnsTable()
+    {
+        var sql = "SELECT * FROM dbo.Posts";
+        //                       ^--- offset 14 = start of "dbo.Posts"
+        var offset = sql.IndexOf("dbo.Posts");
+
+        var result = SqlObjectResolver.Resolve(sql, offset);
+
+        Assert.NotNull(result);
+        Assert.Equal("dbo", result.SchemaName);
+        Assert.Equal("Posts", result.ObjectName);
+        Assert.Equal(SqlObjectKind.Table, result.Kind);
+    }
+
+    [Fact]
+    public void Resolve_TableInJoin_ReturnsTable()
+    {
+        var sql = "SELECT p.Id FROM dbo.Posts AS p JOIN dbo.Users AS u ON p.OwnerUserId = u.Id";
+        var offset = sql.IndexOf("dbo.Users");
+
+        var result = SqlObjectResolver.Resolve(sql, offset);
+
+        Assert.NotNull(result);
+        Assert.Equal("Users", result.ObjectName);
+        Assert.Equal(SqlObjectKind.Table, result.Kind);
+    }
+
+    [Fact]
+    public void Resolve_ClickOnObjectName_ReturnsTable()
+    {
+        var sql = "SELECT * FROM dbo.Posts";
+        // Click on "Posts" part specifically
+        var offset = sql.IndexOf("Posts");
+
+        var result = SqlObjectResolver.Resolve(sql, offset);
+
+        Assert.NotNull(result);
+        Assert.Equal("Posts", result.ObjectName);
+        Assert.Equal(SqlObjectKind.Table, result.Kind);
+    }
+
+    [Fact]
+    public void Resolve_UnqualifiedTable_ReturnsEmptySchema()
+    {
+        var sql = "SELECT * FROM Posts";
+        var offset = sql.IndexOf("Posts");
+
+        var result = SqlObjectResolver.Resolve(sql, offset);
+
+        Assert.NotNull(result);
+        Assert.Equal("", result.SchemaName);
+        Assert.Equal("Posts", result.ObjectName);
+    }
+
+    [Fact]
+    public void Resolve_ClickOnKeyword_ReturnsNull()
+    {
+        var sql = "SELECT * FROM dbo.Posts";
+        var offset = sql.IndexOf("SELECT");
+
+        var result = SqlObjectResolver.Resolve(sql, offset);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Resolve_Procedure_ReturnsProcedure()
+    {
+        var sql = "EXEC dbo.sp_MyProc @param = 1";
+        var offset = sql.IndexOf("dbo.sp_MyProc");
+
+        var result = SqlObjectResolver.Resolve(sql, offset);
+
+        Assert.NotNull(result);
+        Assert.Equal("sp_MyProc", result.ObjectName);
+        Assert.Equal(SqlObjectKind.Procedure, result.Kind);
+    }
+
+    [Fact]
+    public void Resolve_TableValuedFunction_ReturnsFunction()
+    {
+        var sql = "SELECT * FROM dbo.MyFunction(1, 2)";
+        var offset = sql.IndexOf("dbo.MyFunction");
+
+        var result = SqlObjectResolver.Resolve(sql, offset);
+
+        Assert.NotNull(result);
+        Assert.Equal("MyFunction", result.ObjectName);
+        Assert.Equal(SqlObjectKind.Function, result.Kind);
+    }
+
+    [Fact]
+    public void ResolveAll_MultipleObjects_ReturnsAll()
+    {
+        var sql = @"
+SELECT p.Id, u.DisplayName
+FROM dbo.Posts AS p
+JOIN dbo.Users AS u ON p.OwnerUserId = u.Id
+WHERE p.PostTypeId = 1";
+
+        var results = SqlObjectResolver.ResolveAll(sql);
+
+        Assert.Equal(2, results.Count);
+        Assert.Contains(results, r => r.ObjectName == "Posts");
+        Assert.Contains(results, r => r.ObjectName == "Users");
+    }
+
+    [Fact]
+    public void ResolveAll_DuplicateTable_ReturnsDistinct()
+    {
+        var sql = @"
+SELECT * FROM dbo.Posts
+UNION ALL
+SELECT * FROM dbo.Posts";
+
+        var results = SqlObjectResolver.ResolveAll(sql);
+
+        Assert.Single(results);
+        Assert.Equal("Posts", results[0].ObjectName);
+    }
+
+    [Fact]
+    public void Resolve_EmptyText_ReturnsNull()
+    {
+        Assert.Null(SqlObjectResolver.Resolve("", 0));
+        Assert.Null(SqlObjectResolver.Resolve("   ", 0));
+    }
+
+    [Fact]
+    public void Resolve_InvalidOffset_ReturnsNull()
+    {
+        var sql = "SELECT * FROM dbo.Posts";
+        Assert.Null(SqlObjectResolver.Resolve(sql, -1));
+        Assert.Null(SqlObjectResolver.Resolve(sql, sql.Length));
+    }
+}


### PR DESCRIPTION
## Summary
- Right-click a table, procedure, or function name in the query editor to view indexes, table definitions, or object definitions from the connected server
- Uses Microsoft.SqlServer.TransactSql.ScriptDom to parse SQL and resolve the object under the cursor
- Outputs proper CREATE TABLE/CREATE INDEX DDL with partition schemes, non-default index options, columnstore support, identity, computed columns, and PK constraints
- Right-click moves caret to click position for intuitive context menus
- Copy/Copy All/Select All context menu on schema result tabs

Addresses issue #1 (query editor half).

## Test plan
- [x] Right-click table name in editor → Show Indexes, Show Table Definition appear
- [x] Right-click keyword (SELECT, FROM) → schema items hidden
- [x] Right-click with no connection → schema items hidden
- [x] Show Indexes produces correct CREATE INDEX DDL with usage stats
- [x] Show Table Definition produces correct CREATE TABLE DDL
- [x] Partitioned tables include ON partition_scheme(column)
- [x] Non-default index options (fill factor, compression, lock settings) emitted
- [x] Clustered columnstore indexes scripted correctly (no empty parens, no inherent options)
- [x] PK constraint in CREATE TABLE includes WITH options when non-default
- [x] Schema result tabs have Copy/Copy All/Select All context menu
- [x] 11 unit tests pass for SqlObjectResolver

🤖 Generated with [Claude Code](https://claude.com/claude-code)