### PR TITLE
Add 'Open in Query Editor' to plan viewer statements grid

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml
@@ -228,6 +228,7 @@
                         <DataGrid.ContextMenu>
                             <ContextMenu>
                                 <MenuItem Header="Copy Query Text" Click="CopyStatementText_Click"/>
+                                <MenuItem Header="Open in Query Editor" Click="OpenInEditor_Click"/>
                             </ContextMenu>
                         </DataGrid.ContextMenu>
                     </DataGrid>

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -171,6 +171,7 @@ public partial class PlanViewerControl : UserControl
     public event EventHandler? HumanAdviceRequested;
     public event EventHandler? RobotAdviceRequested;
     public event EventHandler? CopyReproRequested;
+    public event EventHandler<string>? OpenInEditorRequested;
 
     /// <summary>
     /// Navigates to a specific plan node by ID: selects it, zooms to show it,
@@ -3267,6 +3268,15 @@ public partial class PlanViewerControl : UserControl
         var topLevel = TopLevel.GetTopLevel(this);
         if (topLevel?.Clipboard != null)
             await topLevel.Clipboard.SetTextAsync(text);
+    }
+
+    private void OpenInEditor_Click(object? sender, RoutedEventArgs e)
+    {
+        if (StatementsGrid.SelectedItem is not StatementRow row) return;
+        var text = row.Statement.StatementText;
+        if (string.IsNullOrEmpty(text)) return;
+
+        OpenInEditorRequested?.Invoke(this, text);
     }
 
     private static void CollectNodeWarnings(PlanNode node, List<PlanWarning> warnings)

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -590,6 +590,13 @@ public partial class QuerySessionControl : UserControl
         return $"[{name}]";
     }
 
+    private void OnOpenInEditorRequested(object? sender, string queryText)
+    {
+        QueryEditor.Text = queryText;
+        SubTabControl.SelectedIndex = 0; // Switch to the editor tab
+        QueryEditor.Focus();
+    }
+
     private void OnKeyDown(object? sender, KeyEventArgs e)
     {
         // F5 or Ctrl+E → Execute (actual plan)
@@ -1067,6 +1074,7 @@ public partial class QuerySessionControl : UserControl
             SetStatus($"{planType} plan captured ({sw.Elapsed.TotalSeconds:F1}s)");
             var viewer = new PlanViewerControl();
             viewer.Metadata = _serverMetadata;
+            viewer.OpenInEditorRequested += OnOpenInEditorRequested;
             viewer.LoadPlan(planXml, tabLabel, queryText);
             loadingTab.Content = viewer;
             HumanAdviceButton.IsEnabled = true;
@@ -1148,6 +1156,7 @@ public partial class QuerySessionControl : UserControl
 
         var viewer = new PlanViewerControl();
         viewer.Metadata = _serverMetadata;
+        viewer.OpenInEditorRequested += OnOpenInEditorRequested;
         viewer.LoadPlan(planXml, label, queryText);
 
         // Build tab header with close button and right-click rename
@@ -1836,6 +1845,7 @@ public partial class QuerySessionControl : UserControl
             SetStatus($"Actual plan captured ({sw.Elapsed.TotalSeconds:F1}s)");
             var actualViewer = new PlanViewerControl();
             actualViewer.Metadata = _serverMetadata;
+            actualViewer.OpenInEditorRequested += OnOpenInEditorRequested;
             actualViewer.LoadPlan(actualPlanXml, tabLabel, queryText);
             loadingTab.Content = actualViewer;
         }

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -530,6 +530,16 @@ public partial class MainWindow : Window
         viewer.HumanAdviceRequested += (_, _) => showHumanAdvice();
         viewer.RobotAdviceRequested += (_, _) => showRobotAdvice();
         viewer.CopyReproRequested += async (_, _) => await copyRepro();
+        viewer.OpenInEditorRequested += (_, queryText) =>
+        {
+            _queryCounter++;
+            var session = new QuerySessionControl(_credentialService, _connectionStore);
+            session.QueryEditor.Text = queryText;
+            var tab = CreateTab($"Query {_queryCounter}", session);
+            MainTabControl.Items.Add(tab);
+            MainTabControl.SelectedItem = tab;
+            UpdateEmptyOverlay();
+        };
 
         var getActualPlanBtn = new Button
         {


### PR DESCRIPTION
## Summary
- Adds "Open in Query Editor" to the statements grid right-click context menu
- From file mode (MainWindow): creates a new query session tab with the statement text
- From editor mode (QuerySessionControl): loads text into the existing editor and switches to it
- Works for all plan sources: file open, query capture, Query Store

Closes #165.

## Test plan
- [x] File mode: open .sqlplan, right-click statement → Open in Query Editor → new query tab with text
- [x] Editor mode: capture plan, right-click statement → switches to editor tab with text
- [x] Query Store plan: right-click statement → loads text into editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)