### PR TITLE
Gate XML MemoryGrantWarning at 1 GB threshold

### DIFF
--- a/src/PlanViewer.Core/Services/ShowPlanParser.cs
+++ b/src/PlanViewer.Core/Services/ShowPlanParser.cs
@@ -1665,7 +1665,8 @@ public static class ShowPlanParser
             });
         }
 
-        // Memory grant warning
+        // Memory grant warning (from plan XML) — gate at 1 GB to avoid noise on small grants
+        // All values are in KB, consistent with MemoryGrantInfo element
         var memWarnEl = warningsEl.Element(Ns + "MemoryGrantWarning");
         if (memWarnEl != null)
         {
@@ -1673,12 +1674,17 @@ public static class ShowPlanParser
             var requested = ParseLong(memWarnEl.Attribute("RequestedMemory")?.Value);
             var granted = ParseLong(memWarnEl.Attribute("GrantedMemory")?.Value);
             var maxUsed = ParseLong(memWarnEl.Attribute("MaxUsedMemory")?.Value);
-            result.Add(new PlanWarning
+            if (granted >= 1048576) // 1 GB in KB
             {
-                WarningType = "Memory Grant",
-                Message = $"{kind}: Requested {requested:N0} KB, Granted {granted:N0} KB, Used {maxUsed:N0} KB",
-                Severity = PlanWarningSeverity.Warning
-            });
+                var grantedMB = granted / 1024.0;
+                var usedMB = maxUsed / 1024.0;
+                result.Add(new PlanWarning
+                {
+                    WarningType = "Memory Grant",
+                    Message = $"{kind}: Granted {grantedMB:N0} MB, Used {usedMB:N0} MB",
+                    Severity = PlanWarningSeverity.Warning
+                });
+            }
         }
 
         // Implicit conversions

--- a/tests/PlanViewer.Core.Tests/PlanAnalyzerTests.cs
+++ b/tests/PlanViewer.Core.Tests/PlanAnalyzerTests.cs
@@ -173,14 +173,15 @@ public class PlanAnalyzerTests
     // ---------------------------------------------------------------
 
     [Fact]
-    public void Rule09a_ExcessiveMemoryGrant_DetectedInLazySpoolPlan()
+    public void Rule09a_ExcessiveMemoryGrant_SmallGrantSuppressed()
     {
+        // lazy_spool_plan has a 1 MB grant — well under the 1 GB threshold.
+        // The XML MemoryGrantWarning should be suppressed (not worth surfacing).
         var plan = PlanTestHelper.LoadAndAnalyze("lazy_spool_plan.sqlplan");
-        // The parser may surface this as a plan-level warning from XML
         var allWarnings = PlanTestHelper.AllWarnings(plan);
 
-        Assert.Contains(allWarnings, w =>
-            w.WarningType.Contains("Memory Grant") || w.WarningType == "Excessive Memory Grant");
+        Assert.DoesNotContain(allWarnings, w =>
+            w.WarningType == "Memory Grant");
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary
- XML `MemoryGrantWarning` element now gated at 1 GB, matching Rule 9's threshold
- All example plans confirmed KB units — 3 small grants (1 MB, 1 MB, 65 MB) suppressed, only 1.9 GB grant fires
- Test updated to verify small grants are correctly suppressed

## Test plan
- [x] 64/64 tests pass
- [x] Verified all 4 example plans with MemoryGrantWarning — units consistent (KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)