### PR TITLE
Add powered-by line on landing page

### DIFF
--- a/src/PlanViewer.Web/Pages/Index.razor
+++ b/src/PlanViewer.Web/Pages/Index.razor
@@ -6,6 +6,7 @@
         <div class="landing-content">
             <h2>Free SQL Server Query Plan Analysis</h2>
             <p class="privacy">Paste or upload a .sqlplan file. Your plan XML never leaves your browser.</p>
+            <p class="powered-by">Powered by the same analysis engine in the <a href="https://github.com/erikdarlingdata/PerformanceStudio" target="_blank" rel="noopener">Performance Studio</a> app.</p>
 
             @if (errorMessage != null)
             {

--- a/src/PlanViewer.Web/wwwroot/css/app.css
+++ b/src/PlanViewer.Web/wwwroot/css/app.css
@@ -168,7 +168,23 @@ main {
     font-family: 'Montserrat', sans-serif;
     font-size: 1.05rem;
     font-weight: 600;
+    margin-bottom: 0.4rem;
+}
+
+.powered-by {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
     margin-bottom: 1.5rem;
+}
+
+.powered-by a {
+    color: var(--accent);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.powered-by a:hover {
+    text-decoration: underline;
 }
 
 /* === Input Area === */


### PR DESCRIPTION
Adds 'Powered by the same analysis engine in the Performance Studio app' below the privacy text, with link to the GitHub repo.