### PR TITLE
Add maximum benefit scoring for plan analysis findings

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -275,6 +275,7 @@ public partial class PlanViewerControl : UserControl
 
         _currentPlan = ShowPlanParser.Parse(planXml);
         PlanAnalyzer.Analyze(_currentPlan, ConfigLoader.Load());
+        BenefitScorer.Score(_currentPlan);
 
         var allStatements = _currentPlan.Batches
             .SelectMany(b => b.Statements)
@@ -1725,14 +1726,21 @@ public partial class PlanViewerControl : UserControl
             if (s.PlanWarnings.Count > 0)
             {
                 var planWarningsPanel = new StackPanel();
-                foreach (var w in s.PlanWarnings)
+                var sortedPlanWarnings = s.PlanWarnings
+                    .OrderByDescending(w => w.MaxBenefitPercent ?? -1)
+                    .ThenByDescending(w => w.Severity)
+                    .ThenBy(w => w.WarningType);
+                foreach (var w in sortedPlanWarnings)
                 {
                     var warnColor = w.Severity == PlanWarningSeverity.Critical ? "#E57373"
                         : w.Severity == PlanWarningSeverity.Warning ? "#FFB347" : "#6BB5FF";
                     var warnPanel = new StackPanel { Margin = new Thickness(10, 2, 10, 2) };
+                    var planWarnHeader = w.MaxBenefitPercent.HasValue
+                        ? $"\u26A0 {w.WarningType} \u2014 up to {w.MaxBenefitPercent:N0}% benefit"
+                        : $"\u26A0 {w.WarningType}";
                     warnPanel.Children.Add(new TextBlock
                     {
-                        Text = $"\u26A0 {w.WarningType}",
+                        Text = planWarnHeader,
                         FontWeight = FontWeight.SemiBold,
                         FontSize = 11,
                         Foreground = new SolidColorBrush(Color.Parse(warnColor))
@@ -1788,14 +1796,21 @@ public partial class PlanViewerControl : UserControl
         if (node.HasWarnings)
         {
             var warningsPanel = new StackPanel();
-            foreach (var w in node.Warnings)
+            var sortedNodeWarnings = node.Warnings
+                .OrderByDescending(w => w.MaxBenefitPercent ?? -1)
+                .ThenByDescending(w => w.Severity)
+                .ThenBy(w => w.WarningType);
+            foreach (var w in sortedNodeWarnings)
             {
                 var warnColor = w.Severity == PlanWarningSeverity.Critical ? "#E57373"
                     : w.Severity == PlanWarningSeverity.Warning ? "#FFB347" : "#6BB5FF";
                 var warnPanel = new StackPanel { Margin = new Thickness(10, 2, 10, 2) };
+                var nodeWarnHeader = w.MaxBenefitPercent.HasValue
+                    ? $"\u26A0 {w.WarningType} \u2014 up to {w.MaxBenefitPercent:N0}% benefit"
+                    : $"\u26A0 {w.WarningType}";
                 warnPanel.Children.Add(new TextBlock
                 {
-                    Text = $"\u26A0 {w.WarningType}",
+                    Text = nodeWarnHeader,
                     FontWeight = FontWeight.SemiBold,
                     FontSize = 11,
                     Foreground = new SolidColorBrush(Color.Parse(warnColor))
@@ -2140,18 +2155,21 @@ public partial class PlanViewerControl : UserControl
 
             if (allWarnings != null)
             {
-                // Root node: show distinct warning type names only
+                // Root node: show distinct warning type names only, sorted by max benefit
                 var distinct = warnings
                     .GroupBy(w => w.WarningType)
-                    .Select(g => (Type: g.Key, MaxSeverity: g.Max(w => w.Severity), Count: g.Count()))
-                    .OrderByDescending(g => g.MaxSeverity)
+                    .Select(g => (Type: g.Key, MaxSeverity: g.Max(w => w.Severity), Count: g.Count(),
+                                  MaxBenefit: g.Max(w => w.MaxBenefitPercent ?? -1)))
+                    .OrderByDescending(g => g.MaxBenefit)
+                    .ThenByDescending(g => g.MaxSeverity)
                     .ThenBy(g => g.Type);
 
-                foreach (var (type, severity, count) in distinct)
+                foreach (var (type, severity, count, maxBenefit) in distinct)
                 {
                     var warnColor = severity == PlanWarningSeverity.Critical ? "#E57373"
                         : severity == PlanWarningSeverity.Warning ? "#FFB347" : "#6BB5FF";
-                    var label = count > 1 ? $"\u26A0 {type} ({count})" : $"\u26A0 {type}";
+                    var benefitSuffix = maxBenefit >= 0 ? $" \u2014 up to {maxBenefit:N0}%" : "";
+                    var label = count > 1 ? $"\u26A0 {type} ({count}){benefitSuffix}" : $"\u26A0 {type}{benefitSuffix}";
                     stack.Children.Add(new TextBlock
                     {
                         Text = label,

--- a/src/PlanViewer.App/Mcp/McpQueryStoreTools.cs
+++ b/src/PlanViewer.App/Mcp/McpQueryStoreTools.cs
@@ -124,6 +124,7 @@ public sealed class McpQueryStoreTools
                         .Replace("encoding=\"utf-16\"", "encoding=\"utf-8\"");
                     var parsed = ShowPlanParser.Parse(xml);
                     PlanAnalyzer.Analyze(parsed);
+                    BenefitScorer.Score(parsed);
 
                     var allStatements = parsed.Batches.SelectMany(b => b.Statements).ToList();
 

--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -6,7 +6,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>EDD.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>1.4.3</Version>
+    <Version>1.5.0</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Cli/Commands/AnalyzeCommand.cs
+++ b/src/PlanViewer.Cli/Commands/AnalyzeCommand.cs
@@ -207,6 +207,7 @@ public static class AnalyzeCommand
 
         var plan = ShowPlanParser.Parse(planXml);
         PlanAnalyzer.Analyze(plan, analyzerConfig);
+        BenefitScorer.Score(plan);
 
         if (plan.Batches.Count == 0)
         {
@@ -400,6 +401,7 @@ public static class AnalyzeCommand
                 // Parse, analyze, map result
                 var plan = ShowPlanParser.Parse(planXml);
                 PlanAnalyzer.Analyze(plan, analyzerConfig);
+                BenefitScorer.Score(plan);
                 var result = ResultMapper.Map(plan, $"{name}.sql");
 
                 if (warningsOnly)

--- a/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
+++ b/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
@@ -273,6 +273,7 @@ public static class QueryStoreCommand
                 // Parse, analyze, map
                 var plan = ShowPlanParser.Parse(qsPlan.PlanXml);
                 PlanAnalyzer.Analyze(plan, analyzerConfig);
+                BenefitScorer.Score(plan);
                 var result = ResultMapper.Map(plan, $"{label}.sqlplan");
 
                 if (warningsOnly)

--- a/src/PlanViewer.Core/Models/PlanModels.cs
+++ b/src/PlanViewer.Core/Models/PlanModels.cs
@@ -373,6 +373,17 @@ public class PlanWarning
     public string Message { get; set; } = "";
     public PlanWarningSeverity Severity { get; set; }
     public SpillDetail? SpillDetails { get; set; }
+
+    /// <summary>
+    /// Maximum percentage of elapsed time that could be saved by addressing this finding.
+    /// null = not quantifiable, 0 = calculated as negligible.
+    /// </summary>
+    public double? MaxBenefitPercent { get; set; }
+
+    /// <summary>
+    /// Short actionable fix suggestion (e.g., "Add INCLUDE (columns) to index").
+    /// </summary>
+    public string? ActionableFix { get; set; }
 }
 
 public enum PlanWarningSeverity { Info, Warning, Critical }

--- a/src/PlanViewer.Core/Output/AnalysisResult.cs
+++ b/src/PlanViewer.Core/Output/AnalysisResult.cs
@@ -208,6 +208,12 @@ public class WarningResult
 
     [JsonPropertyName("node_id")]
     public int? NodeId { get; set; }
+
+    [JsonPropertyName("max_benefit_percent")]
+    public double? MaxBenefitPercent { get; set; }
+
+    [JsonPropertyName("actionable_fix")]
+    public string? ActionableFix { get; set; }
 }
 
 public class MissingIndexResult

--- a/src/PlanViewer.Core/Output/HtmlExporter.cs
+++ b/src/PlanViewer.Core/Output/HtmlExporter.cs
@@ -185,6 +185,7 @@ pre.mi-create {
 .sev-info { color: var(--info); }
 .warn-op { font-size: 0.75rem; font-weight: 500; color: var(--text-secondary); }
 .warn-type { font-size: 0.75rem; font-weight: 600; }
+.warn-benefit { font-size: 0.7rem; font-weight: 600; color: var(--text-muted); padding: 0.05rem 0.3rem; border-radius: 3px; background: rgba(0,0,0,0.04); }
 .warn-msg { font-size: 0.8rem; color: var(--text); flex-basis: 100%; }
 
 /* Query text */
@@ -428,7 +429,13 @@ pre.query-text, pre.text-output {
         if (infoCount > 0) sb.Append($" <span class=\"warn-badge info\">{infoCount}</span>");
         sb.AppendLine("</h3>");
 
-        foreach (var w in allWarnings)
+        // Sort by benefit descending (nulls last), then severity, then type
+        var sorted = allWarnings
+            .OrderByDescending(w => w.MaxBenefitPercent ?? -1)
+            .ThenBy(w => w.Severity switch { "Critical" => 0, "Warning" => 1, _ => 2 })
+            .ThenBy(w => w.Type);
+
+        foreach (var w in sorted)
         {
             var sevLower = w.Severity.ToLower();
             sb.AppendLine($"<div class=\"warning-item {sevLower}\">");
@@ -436,6 +443,8 @@ pre.query-text, pre.text-output {
             if (w.Operator != null)
                 sb.AppendLine($"<span class=\"warn-op\">{Encode(w.Operator)}</span>");
             sb.AppendLine($"<span class=\"warn-type\">{Encode(w.Type)}</span>");
+            if (w.MaxBenefitPercent.HasValue)
+                sb.AppendLine($"<span class=\"warn-benefit\">up to {w.MaxBenefitPercent:N0}% benefit</span>");
             sb.AppendLine($"<span class=\"warn-msg\">{Encode(w.Message)}</span>");
             sb.AppendLine("</div>");
         }

--- a/src/PlanViewer.Core/Output/ResultMapper.cs
+++ b/src/PlanViewer.Core/Output/ResultMapper.cs
@@ -158,7 +158,9 @@ public static class ResultMapper
             {
                 Type = w.WarningType,
                 Severity = w.Severity.ToString(),
-                Message = w.Message
+                Message = w.Message,
+                MaxBenefitPercent = w.MaxBenefitPercent,
+                ActionableFix = w.ActionableFix
             });
         }
 
@@ -259,7 +261,9 @@ public static class ResultMapper
                 Severity = w.Severity.ToString(),
                 Message = w.Message,
                 Operator = $"{node.PhysicalOp} (Node {node.NodeId})",
-                NodeId = node.NodeId
+                NodeId = node.NodeId,
+                MaxBenefitPercent = w.MaxBenefitPercent,
+                ActionableFix = w.ActionableFix
             });
         }
 

--- a/src/PlanViewer.Core/Output/TextFormatter.cs
+++ b/src/PlanViewer.Core/Output/TextFormatter.cs
@@ -151,12 +151,17 @@ public static class TextFormatter
                 writer.WriteLine("Plan warnings:");
                 var hasDetailedMemoryGrant = stmt.Warnings.Any(w =>
                     w.Type == "Excessive Memory Grant" || w.Type == "Large Memory Grant");
-                foreach (var w in stmt.Warnings)
+                var sortedWarnings = stmt.Warnings
+                    .Where(w => !(w.Type == "Memory Grant" && hasDetailedMemoryGrant))
+                    .OrderByDescending(w => w.MaxBenefitPercent ?? -1)
+                    .ThenBy(w => w.Severity switch { "Critical" => 0, "Warning" => 1, _ => 2 })
+                    .ThenBy(w => w.Type);
+                foreach (var w in sortedWarnings)
                 {
-                    // Skip raw XML "Memory Grant" when analyzer provides better context
-                    if (w.Type == "Memory Grant" && hasDetailedMemoryGrant)
-                        continue;
-                    writer.WriteLine($"  [{w.Severity}] {w.Type}: {EscapeNewlines(w.Message)}");
+                    var benefitTag = w.MaxBenefitPercent.HasValue
+                        ? $" (up to {w.MaxBenefitPercent:N0}% benefit)"
+                        : "";
+                    writer.WriteLine($"  [{w.Severity}] {w.Type}{benefitTag}: {EscapeNewlines(w.Message)}");
                 }
             }
 
@@ -272,10 +277,17 @@ public static class TextFormatter
 
     private static void WriteGroupedOperatorWarnings(List<WarningResult> warnings, TextWriter writer)
     {
+        // Sort by benefit descending (nulls last), then severity, then type
+        var sorted = warnings
+            .OrderByDescending(w => w.MaxBenefitPercent ?? -1)
+            .ThenBy(w => w.Severity switch { "Critical" => 0, "Warning" => 1, _ => 2 })
+            .ThenBy(w => w.Type)
+            .ToList();
+
         // Split each message into "data | explanation" at the last sentence boundary
         // that starts with "The " (the harm assessment). Group by shared explanation.
-        var entries = new List<(string Severity, string Operator, string Data, string? Explanation)>();
-        foreach (var w in warnings)
+        var entries = new List<(string Severity, string Operator, string Data, string? Explanation, double? Benefit)>();
+        foreach (var w in sorted)
         {
             var msg = w.Message;
             string data;
@@ -293,14 +305,13 @@ public static class TextFormatter
                 data = msg;
             }
 
-            entries.Add((w.Severity, w.Operator ?? "?", data, explanation));
+            entries.Add((w.Severity, w.Operator ?? "?", data, explanation, w.MaxBenefitPercent));
         }
 
         // Group entries that share the same severity, type, and explanation
-        // Sort criticals before warnings before info
+        // Preserve the pre-sorted order (benefit desc, severity, type)
         var grouped = entries
             .GroupBy(e => (e.Severity, e.Explanation ?? ""))
-            .OrderBy(g => g.Key.Item1 switch { "Critical" => 0, "Warning" => 1, _ => 2 })
             .ToList();
 
         foreach (var group in grouped)
@@ -310,7 +321,10 @@ public static class TextFormatter
             {
                 // Multiple operators with the same explanation — list compactly
                 foreach (var item in items)
-                    writer.WriteLine($"  [{item.Severity}] {item.Operator}: {EscapeNewlines(item.Data)}");
+                {
+                    var benefitTag = item.Benefit.HasValue ? $" (up to {item.Benefit:N0}% benefit)" : "";
+                    writer.WriteLine($"  [{item.Severity}] {item.Operator}{benefitTag}: {EscapeNewlines(item.Data)}");
+                }
                 writer.WriteLine($"  -> {group.Key.Item2}");
             }
             else
@@ -319,7 +333,8 @@ public static class TextFormatter
                 foreach (var item in items)
                 {
                     var full = item.Explanation != null ? $"{item.Data}. {item.Explanation}" : item.Data;
-                    writer.WriteLine($"  [{item.Severity}] {item.Operator}: {EscapeNewlines(full)}");
+                    var benefitTag = item.Benefit.HasValue ? $" (up to {item.Benefit:N0}% benefit)" : "";
+                    writer.WriteLine($"  [{item.Severity}] {item.Operator}{benefitTag}: {EscapeNewlines(full)}");
                 }
             }
         }

--- a/src/PlanViewer.Core/Services/BenefitScorer.cs
+++ b/src/PlanViewer.Core/Services/BenefitScorer.cs
@@ -1,0 +1,379 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PlanViewer.Core.Models;
+
+namespace PlanViewer.Core.Services;
+
+/// <summary>
+/// Second-pass analysis that calculates MaxBenefitPercent for each PlanWarning.
+/// Runs after PlanAnalyzer.Analyze() — the analyzer creates findings, the scorer quantifies them.
+/// Benefit = maximum % of elapsed time that could be saved by addressing the finding.
+/// </summary>
+public static class BenefitScorer
+{
+    // Warning types that map to specific scoring strategies
+    private static readonly HashSet<string> OperatorTimeRules = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Filter Operator",      // Rule 1
+        "Eager Index Spool",    // Rule 2
+        "Spill",                // Rule 7
+        "Key Lookup",           // Rule 10
+        "RID Lookup",           // Rule 10 variant
+        "Scan With Predicate",  // Rule 11
+        "Non-SARGable Predicate", // Rule 12
+        "Scan Cardinality Misestimate", // Rule 32
+    };
+
+    public static void Score(ParsedPlan plan)
+    {
+        foreach (var batch in plan.Batches)
+        {
+            foreach (var stmt in batch.Statements)
+            {
+                ScoreStatementWarnings(stmt);
+
+                if (stmt.RootNode != null)
+                    ScoreNodeTree(stmt.RootNode, stmt);
+            }
+        }
+    }
+
+    private static void ScoreStatementWarnings(PlanStatement stmt)
+    {
+        var elapsedMs = stmt.QueryTimeStats?.ElapsedTimeMs ?? 0;
+
+        foreach (var warning in stmt.PlanWarnings)
+        {
+            switch (warning.WarningType)
+            {
+                case "Ineffective Parallelism":   // Rule 25
+                case "Parallel Wait Bottleneck":  // Rule 31
+                    // These are meta-findings about parallelism efficiency.
+                    // The benefit is the gap between actual and ideal elapsed time.
+                    if (elapsedMs > 0 && stmt.QueryTimeStats != null)
+                    {
+                        var cpu = stmt.QueryTimeStats.CpuTimeMs;
+                        var dop = stmt.DegreeOfParallelism;
+                        if (dop > 1 && cpu > 0)
+                        {
+                            // Ideal elapsed = CPU / DOP. Benefit = (actual - ideal) / actual
+                            var idealElapsed = (double)cpu / dop;
+                            var benefit = Math.Max(0, (elapsedMs - idealElapsed) / elapsedMs * 100);
+                            warning.MaxBenefitPercent = Math.Min(100, Math.Round(benefit, 1));
+                        }
+                    }
+                    break;
+
+                case "Serial Plan": // Rule 3
+                    // Can't know how fast a parallel plan would be, but estimate:
+                    // CPU-bound: benefit up to (1 - 1/maxDOP) * 100%
+                    if (elapsedMs > 0 && stmt.QueryTimeStats != null)
+                    {
+                        var cpu = stmt.QueryTimeStats.CpuTimeMs;
+                        // Assume server max DOP — use a conservative 4 if unknown
+                        var potentialDop = 4;
+                        if (cpu >= elapsedMs)
+                        {
+                            // CPU-bound: parallelism could help significantly
+                            var benefit = (1.0 - 1.0 / potentialDop) * 100;
+                            warning.MaxBenefitPercent = Math.Round(benefit, 1);
+                        }
+                        else
+                        {
+                            // Not CPU-bound: parallelism helps less
+                            var cpuRatio = (double)cpu / elapsedMs;
+                            var benefit = cpuRatio * (1.0 - 1.0 / potentialDop) * 100;
+                            warning.MaxBenefitPercent = Math.Round(Math.Min(50, benefit), 1);
+                        }
+                    }
+                    break;
+
+                case "Memory Grant": // Rule 9
+                    // Grant wait is the only part that affects this query's elapsed time
+                    if (elapsedMs > 0 && stmt.MemoryGrant?.GrantWaitTimeMs > 0)
+                    {
+                        var benefit = (double)stmt.MemoryGrant.GrantWaitTimeMs / elapsedMs * 100;
+                        warning.MaxBenefitPercent = Math.Round(Math.Min(100, benefit), 1);
+                    }
+                    break;
+
+                case "High Compile CPU": // Rule 19
+                    if (elapsedMs > 0 && stmt.CompileCPUMs > 0)
+                    {
+                        var benefit = (double)stmt.CompileCPUMs / elapsedMs * 100;
+                        warning.MaxBenefitPercent = Math.Round(Math.Min(100, benefit), 1);
+                    }
+                    break;
+
+                // Rules that cannot be quantified: leave MaxBenefitPercent as null
+                // Rule 18 (Compile Memory Exceeded), Rule 20 (Local Variables),
+                // Rule 27 (Optimize For Unknown)
+            }
+        }
+    }
+
+    private static void ScoreNodeTree(PlanNode node, PlanStatement stmt)
+    {
+        ScoreNodeWarnings(node, stmt);
+
+        foreach (var child in node.Children)
+            ScoreNodeTree(child, stmt);
+    }
+
+    private static void ScoreNodeWarnings(PlanNode node, PlanStatement stmt)
+    {
+        var elapsedMs = stmt.QueryTimeStats?.ElapsedTimeMs ?? 0;
+
+        foreach (var warning in node.Warnings)
+        {
+            // Already scored (e.g., by a different pass)
+            if (warning.MaxBenefitPercent != null)
+                continue;
+
+            if (warning.WarningType == "UDF Execution") // Rule 4
+            {
+                ScoreUdfWarning(warning, node, elapsedMs);
+            }
+            else if (warning.WarningType == "Filter Operator") // Rule 1
+            {
+                ScoreFilterWarning(warning, node, stmt);
+            }
+            else if (warning.WarningType == "Nested Loops High Executions") // Rule 16
+            {
+                ScoreNestedLoopsWarning(warning, node, stmt);
+            }
+            else if (warning.SpillDetails != null) // Rule 7
+            {
+                ScoreSpillWarning(warning, node, stmt);
+            }
+            else if (OperatorTimeRules.Contains(warning.WarningType))
+            {
+                ScoreByOperatorTime(warning, node, stmt);
+            }
+            else if (warning.WarningType == "Row Estimate Mismatch") // Rule 5
+            {
+                ScoreEstimateMismatchWarning(warning, node, stmt);
+            }
+            // Rules that stay null: Scalar UDF (Rule 6, informational reference),
+            // Parallel Skew (Rule 8), Data Type Mismatch (Rule 13),
+            // Lazy Spool Ineffective (Rule 14), Join OR Clause (Rule 15),
+            // Many-to-Many Merge Join (Rule 17), CTE Multiple References (Rule 21),
+            // Table Variable (Rule 22), Table-Valued Function (Rule 23),
+            // Top Above Scan (Rule 24), Row Goal (Rule 26),
+            // NOT IN with Nullable Column (Rule 28), Implicit Conversion (Rule 29),
+            // Wide Index Suggestion (Rule 30), Estimated Plan CE Guess (Rule 33)
+        }
+    }
+
+    /// <summary>
+    /// Rule 4: UDF Execution — benefit is UDF elapsed time / statement elapsed.
+    /// </summary>
+    private static void ScoreUdfWarning(PlanWarning warning, PlanNode node, long stmtElapsedMs)
+    {
+        if (stmtElapsedMs > 0 && node.UdfElapsedTimeMs > 0)
+        {
+            var benefit = (double)node.UdfElapsedTimeMs / stmtElapsedMs * 100;
+            warning.MaxBenefitPercent = Math.Round(Math.Min(100, benefit), 1);
+        }
+    }
+
+    /// <summary>
+    /// Rule 1: Filter Operator — benefit is child subtree elapsed / statement elapsed.
+    /// The filter discards rows late; eliminating it means the child subtree work was unnecessary.
+    /// </summary>
+    private static void ScoreFilterWarning(PlanWarning warning, PlanNode node, PlanStatement stmt)
+    {
+        var stmtMs = stmt.QueryTimeStats?.ElapsedTimeMs ?? 0;
+
+        if (node.HasActualStats && stmtMs > 0 && node.Children.Count > 0)
+        {
+            var childElapsed = node.Children.Max(c => c.ActualElapsedMs);
+            var benefit = (double)childElapsed / stmtMs * 100;
+            warning.MaxBenefitPercent = Math.Round(Math.Min(100, benefit), 1);
+        }
+        else if (!node.HasActualStats && stmt.StatementSubTreeCost > 0 && node.Children.Count > 0)
+        {
+            // Estimated plan fallback: child subtree cost / statement cost
+            var childCost = node.Children.Sum(c => c.EstimatedTotalSubtreeCost);
+            var benefit = childCost / stmt.StatementSubTreeCost * 100;
+            warning.MaxBenefitPercent = Math.Round(Math.Min(100, benefit), 1);
+        }
+    }
+
+    /// <summary>
+    /// Rule 16: Nested Loops High Executions — benefit is inner-side elapsed / statement elapsed.
+    /// </summary>
+    private static void ScoreNestedLoopsWarning(PlanWarning warning, PlanNode node, PlanStatement stmt)
+    {
+        var stmtMs = stmt.QueryTimeStats?.ElapsedTimeMs ?? 0;
+
+        if (node.Children.Count >= 2)
+        {
+            var innerChild = node.Children[1];
+
+            if (innerChild.HasActualStats && stmtMs > 0 && innerChild.ActualElapsedMs > 0)
+            {
+                var benefit = (double)innerChild.ActualElapsedMs / stmtMs * 100;
+                warning.MaxBenefitPercent = Math.Round(Math.Min(100, benefit), 1);
+            }
+            else if (!innerChild.HasActualStats && stmt.StatementSubTreeCost > 0)
+            {
+                var benefit = innerChild.EstimatedTotalSubtreeCost / stmt.StatementSubTreeCost * 100;
+                warning.MaxBenefitPercent = Math.Round(Math.Min(100, benefit), 1);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Rule 7: Spill — benefit is the spilling operator's self-time / statement elapsed.
+    /// Exchange spills use the parallelism operator time (unreliable but best we have).
+    /// </summary>
+    private static void ScoreSpillWarning(PlanWarning warning, PlanNode node, PlanStatement stmt)
+    {
+        var stmtMs = stmt.QueryTimeStats?.ElapsedTimeMs ?? 0;
+        if (stmtMs <= 0) return;
+
+        long operatorMs;
+        if (warning.SpillDetails?.SpillType == "Exchange")
+            operatorMs = GetParallelismOperatorElapsedMs(node);
+        else
+            operatorMs = PlanAnalyzer.GetOperatorOwnElapsedMs(node);
+
+        if (operatorMs > 0)
+        {
+            var benefit = (double)operatorMs / stmtMs * 100;
+            warning.MaxBenefitPercent = Math.Round(Math.Min(100, benefit), 1);
+        }
+    }
+
+    /// <summary>
+    /// Generic operator-time scoring for rules where the fix would eliminate or
+    /// drastically reduce the operator's work: Key Lookup, RID Lookup,
+    /// Scan With Predicate, Non-SARGable Predicate, Eager Index Spool,
+    /// Scan Cardinality Misestimate.
+    /// </summary>
+    private static void ScoreByOperatorTime(PlanWarning warning, PlanNode node, PlanStatement stmt)
+    {
+        var stmtMs = stmt.QueryTimeStats?.ElapsedTimeMs ?? 0;
+
+        if (node.HasActualStats && stmtMs > 0)
+        {
+            var operatorMs = PlanAnalyzer.GetOperatorOwnElapsedMs(node);
+            if (operatorMs > 0)
+            {
+                var benefit = (double)operatorMs / stmtMs * 100;
+                warning.MaxBenefitPercent = Math.Round(Math.Min(100, benefit), 1);
+            }
+            else
+            {
+                // Operator self-time is 0 — negligible benefit
+                warning.MaxBenefitPercent = 0;
+            }
+        }
+        else if (!node.HasActualStats && stmt.StatementSubTreeCost > 0)
+        {
+            // Estimated plan fallback: use operator cost percentage
+            var benefit = (double)node.CostPercent;
+            warning.MaxBenefitPercent = Math.Round(Math.Min(100, benefit), 1);
+        }
+    }
+
+    /// <summary>
+    /// Rule 5: Row Estimate Mismatch — benefit is the harmed operator's time.
+    /// If the mismatch caused a spill, benefit = spilling operator time.
+    /// If it caused a bad join choice, benefit = join operator time.
+    /// Otherwise, benefit is the misestimated operator's own time (conservative).
+    /// </summary>
+    private static void ScoreEstimateMismatchWarning(PlanWarning warning, PlanNode node, PlanStatement stmt)
+    {
+        var stmtMs = stmt.QueryTimeStats?.ElapsedTimeMs ?? 0;
+        if (stmtMs <= 0 || !node.HasActualStats) return;
+
+        // Walk up to find the harmed operator (same logic as AssessEstimateHarm)
+        var harmedNode = FindHarmedOperator(node);
+        if (harmedNode != null)
+        {
+            var operatorMs = PlanAnalyzer.GetOperatorOwnElapsedMs(harmedNode);
+            if (operatorMs > 0)
+            {
+                var benefit = (double)operatorMs / stmtMs * 100;
+                warning.MaxBenefitPercent = Math.Round(Math.Min(100, benefit), 1);
+                return;
+            }
+        }
+
+        // Fallback: use the misestimated node's own time
+        var ownMs = PlanAnalyzer.GetOperatorOwnElapsedMs(node);
+        if (ownMs > 0)
+        {
+            var benefit = (double)ownMs / stmtMs * 100;
+            warning.MaxBenefitPercent = Math.Round(Math.Min(100, benefit), 1);
+        }
+    }
+
+    /// <summary>
+    /// Walks up from a node with a bad row estimate to find the operator that was
+    /// harmed by it (spilling sort/hash, or join that chose the wrong strategy).
+    /// Returns null if no specific harm can be attributed.
+    /// </summary>
+    private static PlanNode? FindHarmedOperator(PlanNode node)
+    {
+        // The node itself has a spill — it harmed itself
+        if (node.Warnings.Any(w => w.SpillDetails != null))
+            return node;
+
+        // Walk up through transparent operators
+        var ancestor = node.Parent;
+        while (ancestor != null)
+        {
+            if (ancestor.PhysicalOp == "Parallelism" ||
+                ancestor.PhysicalOp == "Compute Scalar" ||
+                ancestor.PhysicalOp == "Segment" ||
+                ancestor.PhysicalOp == "Sequence Project" ||
+                ancestor.PhysicalOp == "Top" ||
+                ancestor.PhysicalOp == "Filter")
+            {
+                ancestor = ancestor.Parent;
+                continue;
+            }
+
+            // Parent join — bad row count from below caused wrong join choice
+            if (ancestor.LogicalOp.Contains("Join", StringComparison.OrdinalIgnoreCase))
+            {
+                if (ancestor.IsAdaptive)
+                    return null; // Adaptive join self-corrects
+                return ancestor;
+            }
+
+            // Parent Sort/Hash that spilled
+            if (ancestor.Warnings.Any(w => w.SpillDetails != null))
+                return ancestor;
+
+            // Parent Sort/Hash with no spill — benign
+            if (ancestor.PhysicalOp.Contains("Sort", StringComparison.OrdinalIgnoreCase) ||
+                ancestor.PhysicalOp.Contains("Hash", StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            break;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Calculates a Parallelism (exchange) operator's own elapsed time.
+    /// Mirrors PlanAnalyzer.GetParallelismOperatorElapsedMs but accessible here.
+    /// </summary>
+    private static long GetParallelismOperatorElapsedMs(PlanNode node)
+    {
+        if (node.Children.Count == 0)
+            return node.ActualElapsedMs;
+
+        if (node.PerThreadStats.Count > 1)
+            return PlanAnalyzer.GetOperatorOwnElapsedMs(node);
+
+        var maxChildElapsed = node.Children.Max(c => c.ActualElapsedMs);
+        return Math.Max(0, node.ActualElapsedMs - maxChildElapsed);
+    }
+}

--- a/src/PlanViewer.Web/Pages/Index.razor
+++ b/src/PlanViewer.Web/Pages/Index.razor
@@ -1713,6 +1713,7 @@ else
             }
 
             PlanAnalyzer.Analyze(parsedPlan);
+            BenefitScorer.Score(parsedPlan);
 
             foreach (var batch in parsedPlan.Batches)
             {

--- a/src/PlanViewer.Web/PlanViewer.Web.csproj
+++ b/src/PlanViewer.Web/PlanViewer.Web.csproj
@@ -25,6 +25,7 @@
     <Compile Include="..\PlanViewer.Core\Models\ServerMetadata.cs" Link="Core\Models\ServerMetadata.cs" />
     <Compile Include="..\PlanViewer.Core\Services\ShowPlanParser.cs" Link="Core\Services\ShowPlanParser.cs" />
     <Compile Include="..\PlanViewer.Core\Services\PlanAnalyzer.cs" Link="Core\Services\PlanAnalyzer.cs" />
+    <Compile Include="..\PlanViewer.Core\Services\BenefitScorer.cs" Link="Core\Services\BenefitScorer.cs" />
     <Compile Include="..\PlanViewer.Core\Services\PlanIconMapper.cs" Link="Core\Services\PlanIconMapper.cs" />
     <Compile Include="..\PlanViewer.Core\Services\PlanLayoutEngine.cs" Link="Core\Services\PlanLayoutEngine.cs" />
     <Compile Include="..\PlanViewer.Core\Services\TimeDisplayHelper.cs" Link="Core\Services\TimeDisplayHelper.cs" />

--- a/tests/PlanViewer.Core.Tests/PlanTestHelper.cs
+++ b/tests/PlanViewer.Core.Tests/PlanTestHelper.cs
@@ -24,6 +24,7 @@ public static class PlanTestHelper
         xml = xml.Replace("encoding=\"utf-16\"", "encoding=\"utf-8\"");
         var plan = ShowPlanParser.Parse(xml);
         PlanAnalyzer.Analyze(plan);
+        BenefitScorer.Score(plan);
         return plan;
     }
 
@@ -99,6 +100,7 @@ public static class PlanTestHelper
         xml = xml.Replace("encoding=\"utf-16\"", "encoding=\"utf-8\"");
         var plan = ShowPlanParser.Parse(xml);
         PlanAnalyzer.Analyze(plan);
+        BenefitScorer.Score(plan);
         return plan;
     }
 


### PR DESCRIPTION
## Summary
- Introduces `BenefitScorer` — a second-pass analysis that calculates the maximum % of elapsed time each finding could save if addressed (#215)
- Findings are now sorted by benefit descending across all outputs (CLI text/HTML, JSON API, desktop app Properties panel, tooltips)
- Stage 1 scores operator-level rules (Filter, Spill, Key Lookup, Scan, UDF, Nested Loops) using operator self-time, with CostPercent fallback for estimated plans
- Bumps version to 1.5.0

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 75/75 pass
- [ ] Load actual plan in desktop app, verify benefit % shown in Properties panel warnings
- [ ] Load estimated plan, verify CostPercent fallback works
- [ ] Check CLI `planview analyze` output shows `(up to N% benefit)` tags
- [ ] Verify HTML export includes benefit badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)