### PR TITLE
Wire up wait stats benefit in web plan viewer

### DIFF
--- a/src/PlanViewer.Web/Pages/Index.razor
+++ b/src/PlanViewer.Web/Pages/Index.razor
@@ -280,15 +280,23 @@ else
                 @if (ActiveStmt!.WaitStats.Count > 0)
                 {
                     var maxWait = ActiveStmt!.WaitStats.Max(w => w.WaitTimeMs);
+                    var benefitLookup = ActiveStmt!.WaitBenefits.ToDictionary(wb => wb.WaitType, wb => wb.MaxBenefitPercent, StringComparer.OrdinalIgnoreCase);
                     @foreach (var w in ActiveStmt!.WaitStats.OrderByDescending(w => w.WaitTimeMs))
                     {
                         var barPct = maxWait > 0 ? (double)w.WaitTimeMs / maxWait * 100 : 0;
+                        benefitLookup.TryGetValue(w.WaitType, out var benefitPct);
                         <div class="wait-row">
                             <span class="wait-type">@w.WaitType</span>
                             <div class="wait-bar-container">
                                 <div class="wait-bar" style="width: @barPct.ToString("F0")%"></div>
                             </div>
-                            <span class="wait-ms">@w.WaitTimeMs.ToString("N0") ms</span>
+                            <span class="wait-ms">
+                                @w.WaitTimeMs.ToString("N0") ms
+                                @if (benefitPct > 0)
+                                {
+                                    <span class="wait-benefit">up to @benefitPct.ToString("N0")%</span>
+                                }
+                            </span>
                         </div>
                     }
                 }

--- a/src/PlanViewer.Web/wwwroot/css/app.css
+++ b/src/PlanViewer.Web/wwwroot/css/app.css
@@ -717,6 +717,16 @@ textarea::placeholder {
     font-size: 0.7rem;
 }
 
+.wait-benefit {
+    font-size: 0.65rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+    background: rgba(0, 0, 0, 0.04);
+    margin-left: 0.25rem;
+}
+
 /* === Warnings Strip === */
 .warnings-strip {
     margin-bottom: 0.75rem;


### PR DESCRIPTION
## Summary
- Wait benefit percentages were calculated by `BenefitScorer` and shown in HTML export, but missing from the Blazor web viewer
- Adds "up to N%" badge next to each wait type's ms value in the Wait Stats insight card
- Adds `.wait-benefit` CSS class matching the HTML export's styling

## Test plan
- [ ] Load an actual execution plan with wait stats in the web viewer
- [ ] Verify benefit badges appear next to wait types that have non-zero benefit
- [ ] Verify no badge appears for wait types with 0% benefit
- [ ] Compare output with HTML export to confirm parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)