### PR TITLE
Replace parallelism efficiency warnings with CPU:Elapsed ratio

### DIFF
--- a/src/PlanViewer.Core/Output/HtmlExporter.cs
+++ b/src/PlanViewer.Core/Output/HtmlExporter.cs
@@ -300,6 +300,11 @@ pre.query-text, pre.text-output {
         {
             WriteRow(sb, "Elapsed", $"{stmt.QueryTime.ElapsedTimeMs:N0} ms");
             WriteRow(sb, "CPU", $"{stmt.QueryTime.CpuTimeMs:N0} ms");
+            if (stmt.QueryTime.ElapsedTimeMs > 0)
+            {
+                var ratio = (double)stmt.QueryTime.CpuTimeMs / stmt.QueryTime.ElapsedTimeMs;
+                WriteRow(sb, "CPU:Elapsed", ratio.ToString("N2"));
+            }
         }
         if (stmt.DegreeOfParallelism > 0)
             WriteRow(sb, "DOP", stmt.DegreeOfParallelism.ToString());

--- a/src/PlanViewer.Core/Services/BenefitScorer.cs
+++ b/src/PlanViewer.Core/Services/BenefitScorer.cs
@@ -49,24 +49,6 @@ public static class BenefitScorer
         {
             switch (warning.WarningType)
             {
-                case "Ineffective Parallelism":   // Rule 25
-                case "Parallel Wait Bottleneck":  // Rule 31
-                    // These are meta-findings about parallelism efficiency.
-                    // The benefit is the gap between actual and ideal elapsed time.
-                    if (elapsedMs > 0 && stmt.QueryTimeStats != null)
-                    {
-                        var cpu = stmt.QueryTimeStats.CpuTimeMs;
-                        var dop = stmt.DegreeOfParallelism;
-                        if (dop > 1 && cpu > 0)
-                        {
-                            // Ideal elapsed = CPU / DOP. Benefit = (actual - ideal) / actual
-                            var idealElapsed = (double)cpu / dop;
-                            var benefit = Math.Max(0, (elapsedMs - idealElapsed) / elapsedMs * 100);
-                            warning.MaxBenefitPercent = Math.Min(100, Math.Round(benefit, 1));
-                        }
-                    }
-                    break;
-
                 case "Serial Plan": // Rule 3
                     // Can't know how fast a parallel plan would be, but estimate:
                     // CPU-bound: benefit up to (1 - 1/maxDOP) * 100%

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.cs
@@ -378,53 +378,9 @@ public static class PlanAnalyzer
             });
         }
 
-        // Rule 25: Ineffective parallelism — DOP-aware efficiency scoring
-        // Efficiency = (speedup - 1) / (DOP - 1) * 100
-        // where speedup = CPU / Elapsed. At DOP 1 speedup=1 (0%), at DOP=speedup (100%).
-        // Rule 31: Parallel wait bottleneck — elapsed >> CPU means threads waiting, not working.
-        if (!cfg.IsRuleDisabled(25) && stmt.DegreeOfParallelism > 1 && stmt.QueryTimeStats != null)
-        {
-            var cpu = stmt.QueryTimeStats.CpuTimeMs;
-            var elapsed = stmt.QueryTimeStats.ElapsedTimeMs;
-            var dop = stmt.DegreeOfParallelism;
-
-            if (elapsed >= 1000 && cpu > 0)
-            {
-                var speedup = (double)cpu / elapsed;
-                var efficiency = Math.Max(0.0, Math.Min(100.0, (speedup - 1.0) / (dop - 1.0) * 100.0));
-
-                // Build targeted advice from wait stats if available
-                var waitAdvice = GetWaitStatsAdvice(stmt.WaitStats);
-
-                if (speedup < 0.5 && !cfg.IsRuleDisabled(31))
-                {
-                    // CPU well below Elapsed: threads are waiting, not doing CPU work
-                    var waitPct = (1.0 - speedup) * 100;
-                    var advice = waitAdvice ?? "Common causes include spills to tempdb, physical I/O reads, lock or latch contention, and memory grant waits.";
-                    stmt.PlanWarnings.Add(new PlanWarning
-                    {
-                        WarningType = "Parallel Wait Bottleneck",
-                        Message = $"Parallel plan (DOP {dop}, {efficiency:N0}% efficient) with elapsed time ({elapsed:N0}ms) exceeding CPU time ({cpu:N0}ms). " +
-                                  $"Approximately {waitPct:N0}% of elapsed time was spent waiting rather than on CPU. " +
-                                  advice,
-                        Severity = PlanWarningSeverity.Warning
-                    });
-                }
-                else if (efficiency < 40)
-                {
-                    // CPU >= Elapsed but well below DOP potential — parallelism is ineffective
-                    var advice = waitAdvice ?? "Look for parallel thread skew, blocking exchanges, or serial zones in the plan that prevent effective parallel execution.";
-                    stmt.PlanWarnings.Add(new PlanWarning
-                    {
-                        WarningType = "Ineffective Parallelism",
-                        Message = $"Parallel plan (DOP {dop}) is only {efficiency:N0}% efficient — CPU time ({cpu:N0}ms) vs elapsed time ({elapsed:N0}ms). " +
-                                  $"At DOP {dop}, ideal CPU time would be ~{elapsed * dop:N0}ms. " +
-                                  advice,
-                        Severity = efficiency < 20 ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning
-                    });
-                }
-            }
-        }
+        // Rules 25 (Ineffective Parallelism) and 31 (Parallel Wait Bottleneck) were removed.
+        // The CPU:Elapsed ratio is now shown in the runtime summary, and wait stats speak
+        // for themselves — no need for meta-warnings guessing at causes.
 
         // Rule 30: Missing index quality evaluation
         if (!cfg.IsRuleDisabled(30))
@@ -1767,94 +1723,6 @@ public static class PlanAnalyzer
             _ when wt == "ASYNC_NETWORK_IO" => "network — client not consuming results",
             _ when wt == "SOS_PHYS_PAGE_CACHE" => "physical page cache contention",
             _ => ""
-        };
-    }
-
-    private static string? GetWaitStatsAdvice(List<WaitStatInfo> waits)
-    {
-        if (waits.Count == 0)
-            return null;
-
-        var totalMs = waits.Sum(w => w.WaitTimeMs);
-        if (totalMs == 0)
-            return null;
-
-        var top = waits.OrderByDescending(w => w.WaitTimeMs).First();
-        var topPct = (double)top.WaitTimeMs / totalMs * 100;
-
-        // Single dominant wait — give targeted advice
-        if (topPct >= 80)
-            return DescribeWaitType(top.WaitType, topPct);
-
-        // Multiple waits — summarize the top contributors instead of guessing
-        var topWaits = waits.OrderByDescending(w => w.WaitTimeMs).Take(3)
-            .Select(w => $"{w.WaitType} ({(double)w.WaitTimeMs / totalMs * 100:N0}%)")
-            .ToList();
-        return $"Top waits: {string.Join(", ", topWaits)}.";
-    }
-
-    /// <summary>
-    /// Maps a wait type to a human-readable description with percentage context.
-    /// Covers all wait types observed in real execution plan files.
-    /// </summary>
-    private static string DescribeWaitType(string rawWaitType, double topPct)
-    {
-        var waitType = rawWaitType.ToUpperInvariant();
-        return waitType switch
-        {
-            // I/O: reading/writing data pages from disk
-            _ when waitType.StartsWith("PAGEIOLATCH") =>
-                $"I/O bound — {topPct:N0}% of wait time is {rawWaitType}. Data is being read from disk rather than memory. Consider adding indexes to reduce I/O, or investigate memory pressure.",
-            _ when waitType.Contains("IO_COMPLETION") =>
-                $"I/O bound — {topPct:N0}% of wait time is {rawWaitType}. Non-buffer I/O such as sort/hash spills to TempDB or eager writes.",
-
-            // CPU: thread yielding its scheduler quantum
-            _ when waitType == "SOS_SCHEDULER_YIELD" =>
-                $"CPU bound — {topPct:N0}% of wait time is {rawWaitType}. The query is consuming significant CPU. Look for expensive operators (scans, sorts, hash builds) that could be eliminated or reduced.",
-
-            // Parallelism: exchange and synchronization waits
-            _ when waitType.StartsWith("CXPACKET") || waitType.StartsWith("CXCONSUMER") =>
-                $"Parallel thread skew — {topPct:N0}% of wait time is {rawWaitType}. Work is unevenly distributed across parallel threads.",
-            _ when waitType.StartsWith("CXSYNC") =>
-                $"Parallel synchronization — {topPct:N0}% of wait time is {rawWaitType}. Threads are waiting at exchange operators to synchronize parallel execution.",
-
-            // Hash operations
-            _ when waitType.StartsWith("HT") =>
-                $"Hash operation — {topPct:N0}% of wait time is {rawWaitType}. Time spent building, repartitioning, or cleaning up hash tables. Large hash builds may indicate missing indexes or bad row estimates.",
-
-            // Sort/bitmap batch operations
-            _ when waitType == "BPSORT" =>
-                $"Batch sort — {topPct:N0}% of wait time is {rawWaitType}. Time spent in batch-mode sort operations.",
-            _ when waitType == "BMPBUILD" =>
-                $"Bitmap build — {topPct:N0}% of wait time is {rawWaitType}. Time spent building bitmap filters for hash joins.",
-
-            // Memory allocation
-            _ when waitType.Contains("MEMORY_ALLOCATION_EXT") =>
-                $"Memory allocation — {topPct:N0}% of wait time is {rawWaitType}. Frequent memory allocations during query execution.",
-
-            // Latch contention (non-I/O)
-            _ when waitType.StartsWith("PAGELATCH") =>
-                $"Page latch contention — {topPct:N0}% of wait time is {rawWaitType}. In-memory page contention, often on TempDB or hot pages.",
-            _ when waitType.StartsWith("LATCH_") =>
-                $"Latch contention — {topPct:N0}% of wait time is {rawWaitType}.",
-
-            // Lock contention
-            _ when waitType.StartsWith("LCK_") =>
-                $"Lock contention — {topPct:N0}% of wait time is {rawWaitType}. Other sessions are holding locks that this query needs.",
-
-            // Log writes
-            _ when waitType == "LOGBUFFER" =>
-                $"Log write — {topPct:N0}% of wait time is {rawWaitType}. Waiting for transaction log buffer flushes, typically from data modifications.",
-
-            // Network
-            _ when waitType == "ASYNC_NETWORK_IO" =>
-                $"Network bound — {topPct:N0}% of wait time is {rawWaitType}. The client application is not consuming results fast enough.",
-
-            // Physical page cache
-            _ when waitType == "SOS_PHYS_PAGE_CACHE" =>
-                $"Physical page cache — {topPct:N0}% of wait time is {rawWaitType}. Contention on the physical memory page allocator.",
-
-            _ => $"Dominant wait is {rawWaitType} ({topPct:N0}% of wait time)."
         };
     }
 

--- a/src/PlanViewer.Web/Pages/Index.razor
+++ b/src/PlanViewer.Web/Pages/Index.razor
@@ -160,6 +160,14 @@ else
                         <span class="insight-label">CPU</span>
                         <span class="insight-value">@ActiveStmt!.QueryTime.CpuTimeMs.ToString("N0") ms</span>
                     </div>
+                    @if (ActiveStmt!.QueryTime.ElapsedTimeMs > 0)
+                    {
+                        var ratio = (double)ActiveStmt!.QueryTime.CpuTimeMs / ActiveStmt!.QueryTime.ElapsedTimeMs;
+                        <div class="insight-row">
+                            <span class="insight-label">CPU:Elapsed</span>
+                            <span class="insight-value">@ratio.ToString("N2")</span>
+                        </div>
+                    }
                 }
                 @if (ActiveStmt!.DegreeOfParallelism > 0)
                 {

--- a/tests/PlanViewer.Core.Tests/PlanAnalyzerTests.cs
+++ b/tests/PlanViewer.Core.Tests/PlanAnalyzerTests.cs
@@ -573,32 +573,8 @@ public class PlanAnalyzerTests
         Assert.Contains(warnings, w => w.Message.Contains("prevented an index seek"));
     }
 
-    // ---------------------------------------------------------------
-    // Rule 25: Ineffective Parallelism
-    // ---------------------------------------------------------------
-
-    [Fact]
-    public void Rule25_IneffectiveParallelism_DetectedWhenCpuEqualsElapsed()
-    {
-        // serially-parallel: DOP 8 but CPU 17,110ms ≈ elapsed 17,112ms (efficiency ~0%)
-        var plan = PlanTestHelper.LoadAndAnalyze("serially-parallel.sqlplan");
-        var warnings = PlanTestHelper.WarningsOfType(plan, "Ineffective Parallelism");
-
-        Assert.Single(warnings);
-        Assert.Contains("DOP 8", warnings[0].Message);
-        Assert.Contains("% efficient", warnings[0].Message);
-    }
-
-    [Fact]
-    public void Rule25_IneffectiveParallelism_NotFiredOnEffectiveParallelPlan()
-    {
-        // parallel-skew: DOP 4, CPU 28,634ms vs elapsed 9,417ms (ratio ~3.0)
-        // This is effective parallelism — Rule 25 should NOT fire
-        var plan = PlanTestHelper.LoadAndAnalyze("parallel-skew.sqlplan");
-        var warnings = PlanTestHelper.WarningsOfType(plan, "Ineffective Parallelism");
-
-        Assert.Empty(warnings);
-    }
+    // Rules 25 and 31 were removed — CPU:Elapsed ratio is shown in the runtime
+    // summary instead, and wait stats speak for themselves.
 
     // ---------------------------------------------------------------
     // Rule 28: NOT IN with Nullable Column (Row Count Spool)
@@ -640,25 +616,6 @@ public class PlanAnalyzerTests
             // At minimum, the rule ran without errors
             Assert.True(true);
         }
-    }
-
-    // ---------------------------------------------------------------
-    // Rule 31: Parallel Wait Bottleneck
-    // ---------------------------------------------------------------
-
-    [Fact]
-    public void Rule31_ParallelWaitBottleneck_DetectedWhenElapsedExceedsCpu()
-    {
-        // excellent-parallel-spill: DOP 4, CPU 172,222ms vs elapsed 225,870ms
-        // speedup ~0.76 — CPU < Elapsed but >= 0.5, so fires as Ineffective Parallelism
-        // (wait bottleneck only fires when speedup < 0.5 — extreme waiting)
-        var plan = PlanTestHelper.LoadAndAnalyze("excellent-parallel-spill.sqlplan");
-
-        // At DOP 4 with speedup 0.76, efficiency ≈ 0% — fires Ineffective Parallelism
-        var warnings = PlanTestHelper.WarningsOfType(plan, "Ineffective Parallelism");
-        Assert.NotEmpty(warnings);
-        Assert.Contains("DOP 4", warnings[0].Message);
-        Assert.Contains("% efficient", warnings[0].Message);
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary
Per Joe's feedback on #215: the Parallel Wait Bottleneck and Ineffective Parallelism warnings (Rules 25/31) were meta-findings that guessed at causes when wait stats already told the story. Replace them with a simple CPU:Elapsed ratio in the runtime summary.

### What changed
- **PlanAnalyzer**: removed Rules 25/31 block; dropped `GetWaitStatsAdvice` and `DescribeWaitType` helpers (only used by those rules)
- **BenefitScorer**: dropped scoring cases for those warnings
- **Web viewer**: added `CPU:Elapsed` row to the Runtime insight card (shown when elapsed > 0)
- **HTML export**: same addition to the runtime card
- **Tests**: removed 3 tests that asserted on the removed rules

### How to interpret the ratio
- Serial plan (DOP 1): ratio ~1.0 = CPU-bound, << 1.0 = waiting
- Parallel plan (DOP N): ratio close to N = parallelism fully effective, ~1.0 = no benefit, << 1.0 = threads waiting

With DOP shown right next to it, the user has all the info and can cross-reference the wait stats card for specifics.

## Test plan
- [x] 72 tests pass (3 removed for deleted rules)
- [ ] Load Joe's plan and verify CPU:Elapsed ratio shows in Runtime card
- [ ] Verify no more "Parallel Wait Bottleneck" or "Ineffective Parallelism" warnings appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)