### PR TITLE
Fix: Query Editor losing syntax highlighting on tab switch

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -68,10 +68,21 @@ public partial class QuerySessionControl : UserControl
         QueryEditor.TextArea.TextEntered += OnTextEntered;
 
         // Focus the editor when the control is attached to the visual tree
+        // Re-install TextMate if it was disposed on detach (tab switching disposes it)
         AttachedToVisualTree += (_, _) =>
         {
+            if (_textMateInstallation == null)
+                SetupSyntaxHighlighting();
+
             QueryEditor.Focus();
             QueryEditor.TextArea.Focus();
+        };
+
+        // Dispose TextMate when detached (e.g. tab switch) to release renderers/transformers
+        DetachedFromVisualTree += (_, _) =>
+        {
+            _textMateInstallation?.Dispose();
+            _textMateInstallation = null;
         };
 
         // Focus the editor when the Editor tab is selected; toggle plan-dependent buttons

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -74,8 +74,6 @@ public partial class QuerySessionControl : UserControl
             QueryEditor.TextArea.Focus();
         };
 
-        DetachedFromVisualTree += (_, _) => _textMateInstallation?.Dispose();
-
         // Focus the editor when the Editor tab is selected; toggle plan-dependent buttons
         SubTabControl.SelectionChanged += (_, _) =>
         {


### PR DESCRIPTION
## What does this PR do?

Fixes #233 

## Which component(s) does this affect?

- [x] Desktop App (PlanViewer.App)
- [ ] Core Library (PlanViewer.Core)
- [ ] CLI Tool (PlanViewer.Cli)
- [ ] SSMS Extension (PlanViewer.Ssms)
- [ ] Tests
- [ ] Documentation

## How was this tested?

https://github.com/user-attachments/assets/dd4296c4-05d9-4c96-8747-982535d4fd25


## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceStudio/blob/main/CONTRIBUTING.md)
- [X] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] All tests pass (`dotnet test`)
- [x] I have not introduced any hardcoded credentials or server names
