### PR TITLE
Joe feedback b2, b3, b6, b7 from #215

### DIFF
--- a/src/PlanViewer.Core/Services/BenefitScorer.cs
+++ b/src/PlanViewer.Core/Services/BenefitScorer.cs
@@ -50,25 +50,17 @@ public static class BenefitScorer
             switch (warning.WarningType)
             {
                 case "Serial Plan": // Rule 3
-                    // Can't know how fast a parallel plan would be, but estimate:
-                    // CPU-bound: benefit up to (1 - 1/maxDOP) * 100%
-                    if (elapsedMs > 0 && stmt.QueryTimeStats != null)
+                    // Per Joe's formula: (cpu * (DOP - 1) / DOP) / elapsed * 100
+                    // Assumes DOP 4 when the plan doesn't tell us. No benefit when cost < 1
+                    // (trivial plans don't gain from parallelism).
+                    if (elapsedMs > 0 && stmt.QueryTimeStats != null && stmt.StatementSubTreeCost >= 1.0)
                     {
                         var cpu = stmt.QueryTimeStats.CpuTimeMs;
-                        // Assume server max DOP — use a conservative 4 if unknown
                         var potentialDop = 4;
-                        if (cpu >= elapsedMs)
+                        if (cpu > 0)
                         {
-                            // CPU-bound: parallelism could help significantly
-                            var benefit = (1.0 - 1.0 / potentialDop) * 100;
-                            warning.MaxBenefitPercent = Math.Round(benefit, 1);
-                        }
-                        else
-                        {
-                            // Not CPU-bound: parallelism helps less
-                            var cpuRatio = (double)cpu / elapsedMs;
-                            var benefit = cpuRatio * (1.0 - 1.0 / potentialDop) * 100;
-                            warning.MaxBenefitPercent = Math.Round(Math.Min(50, benefit), 1);
+                            var benefit = ((double)cpu * (potentialDop - 1) / potentialDop) / elapsedMs * 100;
+                            warning.MaxBenefitPercent = Math.Round(Math.Min(100, benefit), 1);
                         }
                     }
                     break;

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.cs
@@ -212,7 +212,7 @@ public static class PlanAnalyzer
                     stmt.PlanWarnings.Add(new PlanWarning
                     {
                         WarningType = "Serial Plan",
-                        Message = $"Query running serially: {reason}.",
+                        Message = "Query running serially: MAXDOP is set to 1 using a query hint.",
                         Severity = PlanWarningSeverity.Warning
                     });
                 }
@@ -624,7 +624,13 @@ public static class PlanAnalyzer
         }
 
         // Rule 6: Scalar UDF references (works on estimated plans too)
-        if (!cfg.IsRuleDisabled(6))
+        // Suppress when Serial Plan warning is already firing for a UDF-related reason —
+        // the Serial Plan warning already explains the issue, this would be redundant.
+        var serialPlanCoversUdf = stmt.NonParallelPlanReason is
+            "TSQLUserDefinedFunctionsNotParallelizable"
+            or "CLRUserDefinedFunctionRequiresDataAccess"
+            or "CouldNotGenerateValidParallelPlan";
+        if (!cfg.IsRuleDisabled(6) && !serialPlanCoversUdf)
         foreach (var udf in node.ScalarUdfs)
         {
             var type = udf.IsClrFunction ? "CLR" : "T-SQL";

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.cs
@@ -252,10 +252,17 @@ public static class PlanAnalyzer
                 {
                     var grantMB = grant.GrantedMemoryKB / 1024.0;
                     var usedMB = grant.MaxUsedMemoryKB / 1024.0;
+                    var message = $"Granted {grantMB:N0} MB but only used {usedMB:N0} MB ({wasteRatio:F0}x overestimate). The unused memory is reserved and unavailable to other queries.";
+
+                    // Note adaptive joins that chose Nested Loops at runtime — the grant
+                    // was sized for a hash join that never happened.
+                    if (stmt.RootNode != null && HasAdaptiveJoinChoseNestedLoop(stmt.RootNode))
+                        message += " An adaptive join in this plan executed as a Nested Loop at runtime — the memory grant was sized for the hash join alternative that wasn't used.";
+
                     stmt.PlanWarnings.Add(new PlanWarning
                     {
                         WarningType = "Excessive Memory Grant",
-                        Message = $"Granted {grantMB:N0} MB but only used {usedMB:N0} MB ({wasteRatio:F0}x overestimate). The unused memory is reserved and unavailable to other queries.",
+                        Message = message,
                         Severity = PlanWarningSeverity.Warning
                     });
                 }
@@ -1437,6 +1444,23 @@ public static class PlanAnalyzer
     /// <summary>
     /// Finds Sort and Hash Match operators in the tree that consume memory.
     /// </summary>
+    /// <summary>
+    /// Returns true if the plan contains an adaptive join that executed as a Nested Loop.
+    /// Indicates a memory grant was sized for the hash alternative but never needed.
+    /// </summary>
+    private static bool HasAdaptiveJoinChoseNestedLoop(PlanNode node)
+    {
+        if (node.IsAdaptive && node.ActualJoinType != null
+            && node.ActualJoinType.Contains("Nested", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        foreach (var child in node.Children)
+            if (HasAdaptiveJoinChoseNestedLoop(child))
+                return true;
+
+        return false;
+    }
+
     private static void FindMemoryConsumers(PlanNode node, List<string> consumers)
     {
         // Collect all consumers first, then sort by row count descending

--- a/tests/PlanViewer.Core.Tests/PlanAnalyzerTests.cs
+++ b/tests/PlanViewer.Core.Tests/PlanAnalyzerTests.cs
@@ -94,13 +94,18 @@ public class PlanAnalyzerTests
     // ---------------------------------------------------------------
 
     [Fact]
-    public void Rule06_ScalarUdfReference_DetectsUdfInPlan()
+    public void Rule06_ScalarUdfReference_SuppressedWhenSerialPlanCoversIt()
     {
+        // The udf_plan has NonParallelPlanReason = TSQLUserDefinedFunctionsNotParallelizable,
+        // so the Serial Plan warning already explains why the plan is serial and Rule 6
+        // would be redundant (per Joe's b6 feedback on #215).
         var plan = PlanTestHelper.LoadAndAnalyze("udf_plan.sqlplan");
-        var warnings = PlanTestHelper.WarningsOfType(plan, "Scalar UDF");
+        var udfWarnings = PlanTestHelper.WarningsOfType(plan, "Scalar UDF");
+        var serialWarnings = PlanTestHelper.WarningsOfType(plan, "Serial Plan");
 
-        Assert.NotEmpty(warnings);
-        Assert.Contains(warnings, w => w.Message.Contains("once per row"));
+        Assert.Empty(udfWarnings);
+        Assert.NotEmpty(serialWarnings);
+        Assert.Contains(serialWarnings, w => w.Message.Contains("UDF"));
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary
Four items from Joe's latest feedback on issue #215:

- **b3**: Serial Plan message now says "MAXDOP is set to 1 using a query hint" when the user explicitly wrote MAXDOP 1 in the query
- **b6**: Rule 6 (Scalar UDF) is now suppressed when Serial Plan fires for a UDF-related reason — the Serial Plan warning already explains the issue
- **b2**: Rework Serial Plan benefit formula per Joe: `(cpu * (DOP-1) / DOP) / elapsed * 100`, DOP=4 assumed, no benefit below cost 1. Removed the unnecessary CPU-bound branch and the 50% cap
- **b7**: Excessive Memory Grant warning now notes when an adaptive join executed as Nested Loops at runtime — the grant was sized for the hash alternative

## Test plan
- [x] 72 tests pass (Rule 6 test updated for new suppression behavior)
- [ ] Load Joe's plan (ALa237EaOO) and verify MAXDOP 1 wording + benefit math
- [ ] Load plan (cUPI3Dkit3) and verify Scalar UDF warning is suppressed when Serial Plan covers it

Remaining items from Joe's comment (not in this PR): b1 (bare scan benefit), b4/b5 (surface significant waits as actionable items — overlaps with a1 in the per-operator consolidation design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)