### PR TITLE
Joe feedback b1: Rule 34 — bare scan with narrow output

### DIFF
--- a/src/PlanViewer.Core/Services/BenefitScorer.cs
+++ b/src/PlanViewer.Core/Services/BenefitScorer.cs
@@ -22,6 +22,7 @@ public static class BenefitScorer
         "Scan With Predicate",  // Rule 11
         "Non-SARGable Predicate", // Rule 12
         "Scan Cardinality Misestimate", // Rule 32
+        "Bare Scan",            // Rule 34
     };
 
     public static void Score(ParsedPlan plan)

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.cs
@@ -892,6 +892,40 @@ public static class PlanAnalyzer
             }
         }
 
+        // Rule 34: Bare scan with narrow output — NC index or columnstore candidate.
+        // When a Clustered Index Scan or heap Table Scan reads the full table with no
+        // predicate but only outputs a few columns, a narrower nonclustered index could
+        // cover the query with far less I/O. For analytical workloads, columnstore may
+        // be a better fit.
+        var isBareScanCandidate = (node.PhysicalOp == "Clustered Index Scan" || node.PhysicalOp == "Table Scan")
+            && !node.Lookup
+            && string.IsNullOrEmpty(node.Predicate)
+            && !string.IsNullOrEmpty(node.OutputColumns);
+        if (!cfg.IsRuleDisabled(34) && isBareScanCandidate)
+        {
+            var colCount = node.OutputColumns!.Split(',').Length;
+            var isSignificant = node.HasActualStats
+                ? GetOperatorOwnElapsedMs(node) > 0
+                : node.CostPercent >= 20;
+
+            if (colCount <= 3 && isSignificant)
+            {
+                var scanKind = node.PhysicalOp == "Clustered Index Scan"
+                    ? "Clustered index scan"
+                    : "Heap table scan";
+                var indexAdvice = node.PhysicalOp == "Clustered Index Scan"
+                    ? "Consider a nonclustered index on the output columns (as key or INCLUDE) so SQL Server can read a narrower structure."
+                    : "Consider a clustered or nonclustered index on the output columns so SQL Server can read a narrower structure.";
+
+                node.Warnings.Add(new PlanWarning
+                {
+                    WarningType = "Bare Scan",
+                    Message = $"{scanKind} reads the full table with no predicate, outputting {colCount} column(s): {Truncate(node.OutputColumns, 200)}. {indexAdvice} For analytical workloads, a columnstore index may be a better fit.",
+                    Severity = PlanWarningSeverity.Warning
+                });
+            }
+        }
+
         // Rule 13: Mismatched data types (GetRangeWithMismatchedTypes / GetRangeThroughConvert)
         if (!cfg.IsRuleDisabled(13) && node.PhysicalOp == "Compute Scalar" && !string.IsNullOrEmpty(node.DefinedValues))
         {


### PR DESCRIPTION
## Summary
New Rule 34 addressing Joe's b1 feedback: when a Clustered Index Scan or heap Table Scan has no predicate and outputs only a few columns, suggest adding a nonclustered index that could cover the query with less I/O (or columnstore for analytical workloads).

### Criteria
- `PhysicalOp` is "Clustered Index Scan" or "Table Scan"
- No predicate
- Output column count ≤ 3
- Actual plans: operator has non-zero own elapsed time
- Estimated plans: operator `CostPercent >= 20`

### Benefit scoring
Added "Bare Scan" to `OperatorTimeRules` — benefit = operator's own elapsed time / statement elapsed, same pattern as other scan rules.

## Test plan
- [x] 72 tests pass
- [ ] Load Joe's plan (ALa237EaOO) and verify the clustered index scan now gets a benefit % in the warnings list
- [ ] Verify the rule does NOT fire on scans with predicates (Rule 11 territory) or wide output lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)