### PR TITLE
Feature/query editor sql formater

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,35 @@
+# Third-Party Notices
+
+This project incorporates material from the projects listed below.
+
+---
+
+## SqlFormatter
+
+- **Source:** https://github.com/madskristensen/SqlFormatter
+- **License:** MIT (Apache-2.0 per repository; individual files carry MIT terms)
+- **Copyright:** Copyright (c) Mads Kristensen
+
+The `SqlFormattingService` in this project was inspired by and partially derived
+from the SqlFormatter extension for Visual Studio by Mads Kristensen. It uses
+`Microsoft.SqlServer.TransactSql.ScriptDom` for T-SQL parsing and formatting.
+
+### MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml
@@ -69,6 +69,16 @@
                             Height="28" Padding="10,0" FontSize="12" IsEnabled="False"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Execute the repro script and capture actual plan with runtime stats"/>
+                    <TextBlock Text="|" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="4,0"/>
+                    <Button x:Name="FormatButton" Content="&#x1F4DD; Format" Click="Format_Click"
+                            Height="28" Padding="10,0" FontSize="12"
+                            Theme="{StaticResource AppButton}"
+                            ToolTip.Tip="Format the SQL query (Ctrl+K, Ctrl+D)"/>
+                    <Button x:Name="FormatOptionsButton" Content="&#x2699; Format Options" Click="FormatOptions_Click"
+                            Height="28" Padding="10,0" FontSize="12"
+                            Theme="{StaticResource AppButton}"
+                            ToolTip.Tip="Configure SQL formatting options"/>
                 </StackPanel>
                 <TextBlock x:Name="StatusText" DockPanel.Dock="Right"
                            HorizontalAlignment="Right" VerticalAlignment="Center"

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml
@@ -74,7 +74,7 @@
                     <Button x:Name="FormatButton" Content="&#x1F4DD; Format" Click="Format_Click"
                             Height="28" Padding="10,0" FontSize="12"
                             Theme="{StaticResource AppButton}"
-                            ToolTip.Tip="Format the SQL query (Ctrl+K, Ctrl+D)"/>
+                            ToolTip.Tip="Format the SQL query"/>
                     <Button x:Name="FormatOptionsButton" Content="&#x2699; Format Options" Click="FormatOptions_Click"
                             Height="28" Padding="10,0" FontSize="12"
                             Theme="{StaticResource AppButton}"

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -2017,7 +2017,10 @@ public partial class QuerySessionControl : UserControl
 
         try
         {
-            var settings = SqlFormatSettingsService.Load();
+            var settings = SqlFormatSettingsService.Load(out var loadError);
+            if (loadError != null)
+                SetStatus("Warning: using default format settings (load failed)");
+
             var (formatted, errors) = await Task.Run(() => SqlFormattingService.Format(sql, settings));
 
             if (errors != null && errors.Count > 0)

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -2022,7 +2022,41 @@ public partial class QuerySessionControl : UserControl
 
             if (errors != null && errors.Count > 0)
             {
-                SetStatus($"Format: {errors.Count} parse warning(s) — {errors[0].Message}");
+                var errorMessages = string.Join("\n", errors.Select(err => $"Line {err.Line}: {err.Message}"));
+                var dialog = new Window
+                {
+                    Title = "SQL Format Error",
+                    Width = 500,
+                    Height = 250,
+                    WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                    Icon = GetParentWindow().Icon,
+                    Background = new SolidColorBrush(Color.Parse("#1A1D23")),
+                    Foreground = new SolidColorBrush(Color.Parse("#E4E6EB")),
+                    Content = new StackPanel
+                    {
+                        Margin = new Avalonia.Thickness(20),
+                        Children =
+                        {
+                            new TextBlock
+                            {
+                                Text = $"Could not format: {errors.Count} parse error(s)",
+                                FontWeight = Avalonia.Media.FontWeight.Bold,
+                                FontSize = 14,
+                                Margin = new Avalonia.Thickness(0, 0, 0, 10)
+                            },
+                            new TextBlock
+                            {
+                                Text = errorMessages,
+                                TextWrapping = TextWrapping.Wrap,
+                                FontSize = 12,
+                                Foreground = new SolidColorBrush(Color.Parse("#E4E6EB"))
+                            }
+                        }
+                    }
+                };
+                dialog.ShowDialog(GetParentWindow());
+                SetStatus($"Format failed: {errors.Count} error(s)");
+                return;
             }
 
             var caretOffset = QueryEditor.CaretOffset;
@@ -2038,9 +2072,7 @@ public partial class QuerySessionControl : UserControl
             }
 
             QueryEditor.CaretOffset = Math.Min(caretOffset, QueryEditor.Document.TextLength);
-
-            if (errors == null || errors.Count == 0)
-                SetStatus("Formatted");
+            SetStatus("Formatted");
         }
         finally
         {

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -2005,4 +2005,29 @@ public partial class QuerySessionControl : UserControl
         var parent = this.VisualRoot;
         return parent as Window ?? throw new InvalidOperationException("No parent window");
     }
+
+    private void Format_Click(object? sender, RoutedEventArgs e)
+    {
+        var sql = QueryEditor.Text;
+        if (string.IsNullOrWhiteSpace(sql))
+            return;
+
+        var settings = SqlFormatSettingsService.Load();
+        var (formatted, errors) = SqlFormattingService.Format(sql, settings);
+
+        if (errors != null && errors.Count > 0)
+        {
+            SetStatus($"Format: {errors.Count} parse error(s) — {errors[0].Message}");
+            return;
+        }
+
+        QueryEditor.Text = formatted;
+        SetStatus("Formatted");
+    }
+
+    private void FormatOptions_Click(object? sender, RoutedEventArgs e)
+    {
+        var dialog = new Dialogs.FormatOptionsWindow();
+        dialog.ShowDialog(GetParentWindow());
+    }
 }

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -2030,8 +2030,8 @@ public partial class QuerySessionControl : UserControl
                     Height = 250,
                     WindowStartupLocation = WindowStartupLocation.CenterOwner,
                     Icon = GetParentWindow().Icon,
-                    Background = new SolidColorBrush(Color.Parse("#1A1D23")),
-                    Foreground = new SolidColorBrush(Color.Parse("#E4E6EB")),
+                    Background = (IBrush)this.FindResource("BackgroundBrush")!,
+                    Foreground = (IBrush)this.FindResource("ForegroundBrush")!,
                     Content = new StackPanel
                     {
                         Margin = new Avalonia.Thickness(20),
@@ -2048,8 +2048,7 @@ public partial class QuerySessionControl : UserControl
                             {
                                 Text = errorMessages,
                                 TextWrapping = TextWrapping.Wrap,
-                                FontSize = 12,
-                                Foreground = new SolidColorBrush(Color.Parse("#E4E6EB"))
+                                FontSize = 12
                             }
                         }
                     }

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -2021,7 +2021,15 @@ public partial class QuerySessionControl : UserControl
             return;
         }
 
-        QueryEditor.Text = formatted;
+        QueryEditor.Document.BeginUpdate();
+        try
+        {
+            QueryEditor.Document.Replace(0, QueryEditor.Document.TextLength, formatted);
+        }
+        finally
+        {
+            QueryEditor.Document.EndUpdate();
+        }
         SetStatus("Formatted");
     }
 

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -2006,34 +2006,46 @@ public partial class QuerySessionControl : UserControl
         return parent as Window ?? throw new InvalidOperationException("No parent window");
     }
 
-    private void Format_Click(object? sender, RoutedEventArgs e)
+    private async void Format_Click(object? sender, RoutedEventArgs e)
     {
         var sql = QueryEditor.Text;
         if (string.IsNullOrWhiteSpace(sql))
             return;
 
-        var settings = SqlFormatSettingsService.Load();
-        var (formatted, errors) = SqlFormattingService.Format(sql, settings);
+        FormatButton.IsEnabled = false;
+        SetStatus("Formatting...");
 
-        if (errors != null && errors.Count > 0)
-        {
-            SetStatus($"Format: {errors.Count} parse warning(s) — {errors[0].Message}");
-        }
-
-        var caretOffset = QueryEditor.CaretOffset;
-
-        QueryEditor.Document.BeginUpdate();
         try
         {
-            QueryEditor.Document.Replace(0, QueryEditor.Document.TextLength, formatted);
+            var settings = SqlFormatSettingsService.Load();
+            var (formatted, errors) = await Task.Run(() => SqlFormattingService.Format(sql, settings));
+
+            if (errors != null && errors.Count > 0)
+            {
+                SetStatus($"Format: {errors.Count} parse warning(s) — {errors[0].Message}");
+            }
+
+            var caretOffset = QueryEditor.CaretOffset;
+
+            QueryEditor.Document.BeginUpdate();
+            try
+            {
+                QueryEditor.Document.Replace(0, QueryEditor.Document.TextLength, formatted);
+            }
+            finally
+            {
+                QueryEditor.Document.EndUpdate();
+            }
+
+            QueryEditor.CaretOffset = Math.Min(caretOffset, QueryEditor.Document.TextLength);
+
+            if (errors == null || errors.Count == 0)
+                SetStatus("Formatted");
         }
         finally
         {
-            QueryEditor.Document.EndUpdate();
+            FormatButton.IsEnabled = true;
         }
-
-        QueryEditor.CaretOffset = Math.Min(caretOffset, QueryEditor.Document.TextLength);
-        SetStatus("Formatted");
     }
 
     private void FormatOptions_Click(object? sender, RoutedEventArgs e)

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -2017,9 +2017,10 @@ public partial class QuerySessionControl : UserControl
 
         if (errors != null && errors.Count > 0)
         {
-            SetStatus($"Format: {errors.Count} parse error(s) — {errors[0].Message}");
-            return;
+            SetStatus($"Format: {errors.Count} parse warning(s) — {errors[0].Message}");
         }
+
+        var caretOffset = QueryEditor.CaretOffset;
 
         QueryEditor.Document.BeginUpdate();
         try
@@ -2030,6 +2031,8 @@ public partial class QuerySessionControl : UserControl
         {
             QueryEditor.Document.EndUpdate();
         }
+
+        QueryEditor.CaretOffset = Math.Min(caretOffset, QueryEditor.Document.TextLength);
         SetStatus("Formatted");
     }
 

--- a/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml
+++ b/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml
@@ -1,0 +1,41 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dialogs="using:PlanViewer.App.Dialogs"
+        x:Class="PlanViewer.App.Dialogs.FormatOptionsWindow"
+        Title="SQL Format Options"
+        Width="620" Height="550"
+        MinWidth="500" MinHeight="400"
+        Background="#1A1D23"
+        Foreground="#E4E6EB"
+        WindowStartupLocation="CenterOwner">
+    <Grid RowDefinitions="*,Auto" Margin="12">
+        <DataGrid x:Name="OptionsGrid" Grid.Row="0"
+                  x:DataType="dialogs:FormatOptionRow"
+                  AutoGenerateColumns="False"
+                  CanUserReorderColumns="False"
+                  CanUserSortColumns="False"
+                  HeadersVisibility="Column"
+                  GridLinesVisibility="Horizontal"
+                  IsReadOnly="False"
+                  Background="#1A1D23"
+                  Foreground="#E4E6EB"
+                  Margin="0,0,0,12">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Parameter" Binding="{Binding Name}" IsReadOnly="True" Width="2*"/>
+                <DataGridTextColumn Header="Current Value" Binding="{Binding CurrentValue}" Width="*"/>
+                <DataGridTextColumn Header="Default Value" Binding="{Binding DefaultValue}" IsReadOnly="True" Width="*"/>
+            </DataGrid.Columns>
+        </DataGrid>
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+            <Button x:Name="RevertButton" Content="Revert to Default" Click="Revert_Click"
+                    Height="32" Padding="16,0" FontSize="12"
+                    Theme="{StaticResource AppButton}"/>
+            <Button x:Name="SaveButton" Content="Save" Click="Save_Click"
+                    Height="32" Padding="16,0" FontSize="12"
+                    Theme="{StaticResource AppButton}"/>
+            <Button x:Name="CloseButton" Content="Close" Click="Close_Click"
+                    Height="32" Padding="16,0" FontSize="12"
+                    Theme="{StaticResource AppButton}"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml
+++ b/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml
@@ -5,8 +5,8 @@
         Title="SQL Format Options"
         Width="650" Height="580"
         MinWidth="520" MinHeight="400"
-        Background="#1A1D23"
-        Foreground="#E4E6EB"
+        Background="{DynamicResource BackgroundBrush}"
+        Foreground="{DynamicResource ForegroundBrush}"
         WindowStartupLocation="CenterOwner">
 
     <Window.Styles>

--- a/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml
+++ b/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml
@@ -3,11 +3,33 @@
         xmlns:dialogs="using:PlanViewer.App.Dialogs"
         x:Class="PlanViewer.App.Dialogs.FormatOptionsWindow"
         Title="SQL Format Options"
-        Width="620" Height="550"
-        MinWidth="500" MinHeight="400"
+        Width="650" Height="580"
+        MinWidth="520" MinHeight="400"
         Background="#1A1D23"
         Foreground="#E4E6EB"
         WindowStartupLocation="CenterOwner">
+
+    <Window.Styles>
+        <Style Selector="ToggleSwitch">
+            <Setter Property="OnContent" Value=""/>
+            <Setter Property="OffContent" Value=""/>
+            <Setter Property="MinWidth" Value="0"/>
+            <Setter Property="MinHeight" Value="0"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="Margin" Value="0"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="RenderTransformOrigin" Value="0%,50%"/>
+            <Setter Property="RenderTransform" Value="scale(0.75)"/>
+        </Style>
+        <Style Selector="ToggleSwitch:checked /template/ Border#SwitchKnobBounds">
+            <Setter Property="Background" Value="#00D4FF"/>
+            <Setter Property="BorderBrush" Value="#00D4FF"/>
+        </Style>
+        <Style Selector="ToggleSwitch:checked /template/ Border#OuterBorder">
+            <Setter Property="BorderBrush" Value="#00D4FF"/>
+        </Style>
+    </Window.Styles>
+
     <Grid RowDefinitions="*,Auto" Margin="12">
         <DataGrid x:Name="OptionsGrid" Grid.Row="0"
                   x:DataType="dialogs:FormatOptionRow"
@@ -22,8 +44,66 @@
                   Margin="0,0,0,12">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Parameter" Binding="{Binding Name}" IsReadOnly="True" Width="2*"/>
-                <DataGridTextColumn Header="Current Value" Binding="{Binding CurrentValue}" Width="*"/>
-                <DataGridTextColumn Header="Default Value" Binding="{Binding DefaultValue}" IsReadOnly="True" Width="*"/>
+                <DataGridTemplateColumn Header="Current Value" Width="*">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate x:DataType="dialogs:FormatOptionRow">
+                            <Panel>
+                                <ToggleSwitch IsChecked="{Binding BoolValue}"
+                                              IsVisible="{Binding IsBool}"
+                                              VerticalAlignment="Center"
+                                              Margin="4,0"/>
+                                <ComboBox ItemsSource="{Binding ChoiceOptions}"
+                                          SelectedItem="{Binding CurrentValue}"
+                                          IsVisible="{Binding IsChoice}"
+                                          VerticalAlignment="Center"
+                                          MinHeight="0" Height="26" FontSize="12"
+                                          Margin="4,0"/>
+                                <TextBlock Text="{Binding CurrentValue}"
+                                           IsVisible="{Binding IsText}"
+                                           VerticalAlignment="Center"
+                                           Margin="8,0"/>
+                            </Panel>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                    <DataGridTemplateColumn.CellEditingTemplate>
+                        <DataTemplate x:DataType="dialogs:FormatOptionRow">
+                            <Panel>
+                                <ToggleSwitch IsChecked="{Binding BoolValue}"
+                                              IsVisible="{Binding IsBool}"
+                                              VerticalAlignment="Center"
+                                              Margin="4,0"/>
+                                <ComboBox ItemsSource="{Binding ChoiceOptions}"
+                                          SelectedItem="{Binding CurrentValue}"
+                                          IsVisible="{Binding IsChoice}"
+                                          VerticalAlignment="Center"
+                                          MinHeight="0" Height="26" FontSize="12"
+                                          Margin="4,0"/>
+                                <TextBox Text="{Binding CurrentValue}"
+                                         IsVisible="{Binding IsText}"
+                                         VerticalAlignment="Center"
+                                         Margin="4,0"/>
+                            </Panel>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellEditingTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTemplateColumn Header="Default Value" IsReadOnly="True" Width="*">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate x:DataType="dialogs:FormatOptionRow">
+                            <Panel>
+                                <ToggleSwitch IsChecked="{Binding DefaultBoolValue}"
+                                              IsVisible="{Binding IsBool}"
+                                              IsEnabled="False"
+                                              VerticalAlignment="Center"
+                                              Margin="4,0"/>
+                                <TextBlock Text="{Binding DefaultValue}"
+                                           IsVisible="{Binding !IsBool}"
+                                           VerticalAlignment="Center"
+                                           Margin="8,0"/>
+                                <!-- Choice defaults shown as text -->
+                            </Panel>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
             </DataGrid.Columns>
         </DataGrid>
         <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">

--- a/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml
+++ b/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml
@@ -22,11 +22,11 @@
             <Setter Property="RenderTransform" Value="scale(0.75)"/>
         </Style>
         <Style Selector="ToggleSwitch:checked /template/ Border#SwitchKnobBounds">
-            <Setter Property="Background" Value="#00D4FF"/>
-            <Setter Property="BorderBrush" Value="#00D4FF"/>
+            <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
         </Style>
         <Style Selector="ToggleSwitch:checked /template/ Border#OuterBorder">
-            <Setter Property="BorderBrush" Value="#00D4FF"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
         </Style>
     </Window.Styles>
 
@@ -39,8 +39,8 @@
                   HeadersVisibility="Column"
                   GridLinesVisibility="Horizontal"
                   IsReadOnly="False"
-                  Background="#1A1D23"
-                  Foreground="#E4E6EB"
+                  Background="{DynamicResource BackgroundBrush}"
+                  Foreground="{DynamicResource ForegroundBrush}"
                   Margin="0,0,0,12">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Parameter" Binding="{Binding Name}" IsReadOnly="True" Width="2*"/>

--- a/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml.cs
+++ b/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml.cs
@@ -30,12 +30,21 @@ public partial class FormatOptionsWindow : Window
         {
             var currentVal = prop.GetValue(current);
             var defaultVal = prop.GetValue(_defaults);
+            var isBool = prop.PropertyType == typeof(bool);
+
+            string[]? choiceOptions = null;
+            if (prop.Name == "KeywordCasing")
+                choiceOptions = ["Uppercase", "Lowercase", "PascalCase"];
 
             _rows.Add(new FormatOptionRow
             {
                 Name = prop.Name,
                 CurrentValue = currentVal?.ToString() ?? "",
                 DefaultValue = defaultVal?.ToString() ?? "",
+                IsBool = isBool,
+                BoolValue = isBool && currentVal is true,
+                DefaultBoolValue = isBool && defaultVal is true,
+                ChoiceOptions = choiceOptions,
                 PropertyInfo = prop
             });
         }
@@ -55,7 +64,7 @@ public partial class FormatOptionsWindow : Window
                 object? value;
 
                 if (prop.PropertyType == typeof(bool))
-                    value = bool.Parse(row.CurrentValue);
+                    value = row.BoolValue;
                 else if (prop.PropertyType == typeof(int))
                     value = int.Parse(row.CurrentValue);
                 else
@@ -70,6 +79,7 @@ public partial class FormatOptionsWindow : Window
         }
 
         SqlFormatSettingsService.Save(settings);
+        Close();
     }
 
     private void Revert_Click(object? sender, RoutedEventArgs e)
@@ -77,9 +87,10 @@ public partial class FormatOptionsWindow : Window
         foreach (var row in _rows)
         {
             row.CurrentValue = row.DefaultValue;
+            if (row.IsBool)
+                row.BoolValue = row.DefaultBoolValue;
         }
 
-        // Refresh the grid
         OptionsGrid.ItemsSource = null;
         OptionsGrid.ItemsSource = _rows;
     }
@@ -93,8 +104,35 @@ public partial class FormatOptionsWindow : Window
 public class FormatOptionRow : INotifyPropertyChanged
 {
     private string _currentValue = "";
+    private bool _boolValue;
 
     public string Name { get; set; } = "";
+
+    public bool IsBool { get; set; }
+
+    public bool BoolValue
+    {
+        get => _boolValue;
+        set
+        {
+            _boolValue = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(BoolValue)));
+            // Keep CurrentValue in sync for serialization
+            if (IsBool)
+            {
+                _currentValue = value.ToString();
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CurrentValue)));
+            }
+        }
+    }
+
+    public bool DefaultBoolValue { get; set; }
+
+    public string[]? ChoiceOptions { get; set; }
+
+    public bool IsChoice => ChoiceOptions != null;
+
+    public bool IsText => !IsBool && !IsChoice;
 
     public string CurrentValue
     {

--- a/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml.cs
+++ b/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
@@ -20,20 +22,48 @@ public partial class FormatOptionsWindow : Window
         LoadSettings();
     }
 
+    // Explicit ordering — reflection doesn't guarantee declaration order
+    private static readonly string[] PropertyOrder =
+    [
+        "KeywordCasing", "SqlVersion", "IndentationSize",
+        "AlignClauseBodies", "AlignColumnDefinitionFields", "AlignSetClauseItem",
+        "AsKeywordOnOwnLine", "IncludeSemicolons",
+        "IndentSetClause", "IndentViewBody",
+        "MultilineInsertSourcesList", "MultilineInsertTargetsList",
+        "MultilineSelectElementsList", "MultilineSetClauseItems",
+        "MultilineViewColumnsList", "MultilineWherePredicatesList",
+        "NewLineBeforeCloseParenthesisInMultilineList",
+        "NewLineBeforeFromClause", "NewLineBeforeGroupByClause",
+        "NewLineBeforeHavingClause", "NewLineBeforeJoinClause",
+        "NewLineBeforeOffsetClause", "NewLineBeforeOpenParenthesisInMultilineList",
+        "NewLineBeforeOrderByClause", "NewLineBeforeOutputClause",
+        "NewLineBeforeWhereClause", "NewLineBeforeWindowClause",
+    ];
+
+    private static readonly Dictionary<string, string[]> ChoiceOptionsMap = new()
+    {
+        ["KeywordCasing"] = ["Uppercase", "Lowercase", "PascalCase"],
+        ["SqlVersion"] = ["80", "90", "100", "110", "120", "130", "140", "150", "160", "170"],
+    };
+
     private void LoadSettings()
     {
         var current = SqlFormatSettingsService.Load();
         _rows.Clear();
 
-        foreach (var prop in typeof(SqlFormatSettings).GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        var props = typeof(SqlFormatSettings).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .ToDictionary(p => p.Name);
+
+        foreach (var name in PropertyOrder)
         {
+            if (!props.TryGetValue(name, out var prop))
+                continue;
+
             var currentVal = prop.GetValue(current);
             var defaultVal = prop.GetValue(_defaults);
             var isBool = prop.PropertyType == typeof(bool);
 
-            string[]? choiceOptions = null;
-            if (prop.Name == "KeywordCasing")
-                choiceOptions = ["Uppercase", "Lowercase", "PascalCase"];
+            ChoiceOptionsMap.TryGetValue(prop.Name, out var choiceOptions);
 
             _rows.Add(new FormatOptionRow
             {

--- a/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml.cs
+++ b/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using PlanViewer.App.Services;
+
+namespace PlanViewer.App.Dialogs;
+
+public partial class FormatOptionsWindow : Window
+{
+    private readonly ObservableCollection<FormatOptionRow> _rows = new();
+    private readonly SqlFormatSettings _defaults = new();
+
+    public FormatOptionsWindow()
+    {
+        InitializeComponent();
+        LoadSettings();
+    }
+
+    private void LoadSettings()
+    {
+        var current = SqlFormatSettingsService.Load();
+        _rows.Clear();
+
+        foreach (var prop in typeof(SqlFormatSettings).GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            var currentVal = prop.GetValue(current);
+            var defaultVal = prop.GetValue(_defaults);
+
+            _rows.Add(new FormatOptionRow
+            {
+                Name = prop.Name,
+                CurrentValue = currentVal?.ToString() ?? "",
+                DefaultValue = defaultVal?.ToString() ?? "",
+                PropertyInfo = prop
+            });
+        }
+
+        OptionsGrid.ItemsSource = _rows;
+    }
+
+    private void Save_Click(object? sender, RoutedEventArgs e)
+    {
+        var settings = new SqlFormatSettings();
+
+        foreach (var row in _rows)
+        {
+            try
+            {
+                var prop = row.PropertyInfo;
+                object? value;
+
+                if (prop.PropertyType == typeof(bool))
+                    value = bool.Parse(row.CurrentValue);
+                else if (prop.PropertyType == typeof(int))
+                    value = int.Parse(row.CurrentValue);
+                else
+                    value = row.CurrentValue;
+
+                prop.SetValue(settings, value);
+            }
+            catch
+            {
+                // Skip invalid values — keep default
+            }
+        }
+
+        SqlFormatSettingsService.Save(settings);
+    }
+
+    private void Revert_Click(object? sender, RoutedEventArgs e)
+    {
+        foreach (var row in _rows)
+        {
+            row.CurrentValue = row.DefaultValue;
+        }
+
+        // Refresh the grid
+        OptionsGrid.ItemsSource = null;
+        OptionsGrid.ItemsSource = _rows;
+    }
+
+    private void Close_Click(object? sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+}
+
+public class FormatOptionRow : INotifyPropertyChanged
+{
+    private string _currentValue = "";
+
+    public string Name { get; set; } = "";
+
+    public string CurrentValue
+    {
+        get => _currentValue;
+        set
+        {
+            _currentValue = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CurrentValue)));
+        }
+    }
+
+    public string DefaultValue { get; set; } = "";
+
+    internal PropertyInfo PropertyInfo { get; set; } = null!;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+}

--- a/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml.cs
+++ b/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml.cs
@@ -52,7 +52,9 @@ public partial class FormatOptionsWindow : Window
 
     private void LoadSettings()
     {
-        var current = SqlFormatSettingsService.Load();
+        var current = SqlFormatSettingsService.Load(out var loadError);
+        if (loadError != null)
+            ShowErrorPopup("Load Error", loadError);
         _rows.Clear();
 
         var props = typeof(SqlFormatSettings).GetProperties(BindingFlags.Public | BindingFlags.Instance)
@@ -122,7 +124,11 @@ public partial class FormatOptionsWindow : Window
             }
         }
 
-        SqlFormatSettingsService.Save(settings);
+        if (!SqlFormatSettingsService.Save(settings, out var saveError))
+        {
+            ShowErrorPopup("Save Error", saveError!);
+            return;
+        }
         _isDirty = false;
         Close();
     }
@@ -135,6 +141,33 @@ public partial class FormatOptionsWindow : Window
             if (row.IsBool)
                 row.BoolValue = row.DefaultBoolValue;
         }
+    }
+
+    private void ShowErrorPopup(string title, string message)
+    {
+        var dialog = new Window
+        {
+            Title = title,
+            Width = 480,
+            Height = 220,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            Background = (IBrush)this.FindResource("BackgroundBrush")!,
+            Foreground = (IBrush)this.FindResource("ForegroundBrush")!,
+            Content = new StackPanel
+            {
+                Margin = new Avalonia.Thickness(20),
+                Children =
+                {
+                    new TextBlock
+                    {
+                        Text = message,
+                        TextWrapping = TextWrapping.Wrap,
+                        FontSize = 13
+                    }
+                }
+            }
+        };
+        dialog.ShowDialog(this);
     }
 
     private void Close_Click(object? sender, RoutedEventArgs e)

--- a/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml.cs
+++ b/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml.cs
@@ -5,8 +5,10 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Avalonia.Media;
 using PlanViewer.App.Services;
 
 namespace PlanViewer.App.Dialogs;
@@ -15,6 +17,8 @@ public partial class FormatOptionsWindow : Window
 {
     private readonly ObservableCollection<FormatOptionRow> _rows = new();
     private readonly SqlFormatSettings _defaults = new();
+
+    private bool _isDirty;
 
     public FormatOptionsWindow()
     {
@@ -79,6 +83,10 @@ public partial class FormatOptionsWindow : Window
         }
 
         OptionsGrid.ItemsSource = _rows;
+
+        // Track changes for dirty-state prompt
+        foreach (var row in _rows)
+            row.PropertyChanged += (_, _) => _isDirty = true;
     }
 
     private void Save_Click(object? sender, RoutedEventArgs e)
@@ -115,6 +123,7 @@ public partial class FormatOptionsWindow : Window
         }
 
         SqlFormatSettingsService.Save(settings);
+        _isDirty = false;
         Close();
     }
 
@@ -130,7 +139,106 @@ public partial class FormatOptionsWindow : Window
 
     private void Close_Click(object? sender, RoutedEventArgs e)
     {
-        Close();
+        TryClose();
+    }
+
+    protected override void OnClosing(WindowClosingEventArgs e)
+    {
+        if (_isDirty)
+        {
+            e.Cancel = true;
+            TryClose();
+            return;
+        }
+        base.OnClosing(e);
+    }
+
+    private async void TryClose()
+    {
+        if (!_isDirty)
+        {
+            _isDirty = false; // prevent re-entry
+            Close();
+            return;
+        }
+
+        var result = await ShowDiscardDialog();
+        if (result)
+        {
+            _isDirty = false;
+            Close();
+        }
+    }
+
+    private async Task<bool> ShowDiscardDialog()
+    {
+        var tcs = new TaskCompletionSource<bool>();
+
+        var dialog = new Window
+        {
+            Title = "Unsaved Changes",
+            Width = 360,
+            Height = 160,
+            MinWidth = 360,
+            MinHeight = 160,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            Background = (IBrush)this.FindResource("BackgroundBrush")!,
+            Foreground = (IBrush)this.FindResource("ForegroundBrush")!,
+            Content = new StackPanel
+            {
+                Margin = new Avalonia.Thickness(20),
+                Children =
+                {
+                    new TextBlock
+                    {
+                        Text = "You have unsaved changes. Discard them?",
+                        FontSize = 13,
+                        TextWrapping = TextWrapping.Wrap,
+                        Margin = new Avalonia.Thickness(0, 0, 0, 16)
+                    }
+                }
+            }
+        };
+
+        var discardBtn = new Button
+        {
+            Content = "Discard",
+            Height = 32, Width = 90,
+            Padding = new Avalonia.Thickness(16, 0),
+            FontSize = 12,
+            HorizontalContentAlignment = Avalonia.Layout.HorizontalAlignment.Center,
+            VerticalContentAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            Theme = (Avalonia.Styling.ControlTheme)this.FindResource("AppButton")!
+        };
+
+        var cancelBtn = new Button
+        {
+            Content = "Cancel",
+            Height = 32, Width = 90,
+            Padding = new Avalonia.Thickness(16, 0),
+            FontSize = 12,
+            Margin = new Avalonia.Thickness(8, 0, 0, 0),
+            HorizontalContentAlignment = Avalonia.Layout.HorizontalAlignment.Center,
+            VerticalContentAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            Theme = (Avalonia.Styling.ControlTheme)this.FindResource("AppButton")!
+        };
+
+        var buttonPanel = new StackPanel
+        {
+            Orientation = Avalonia.Layout.Orientation.Horizontal,
+            HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Right
+        };
+        buttonPanel.Children.Add(discardBtn);
+        buttonPanel.Children.Add(cancelBtn);
+
+        ((StackPanel)dialog.Content!).Children.Add(buttonPanel);
+
+        discardBtn.Click += (_, _) => { tcs.TrySetResult(true); dialog.Close(); };
+        cancelBtn.Click += (_, _) => { tcs.TrySetResult(false); dialog.Close(); };
+        dialog.Closing += (_, _) => tcs.TrySetResult(false);
+
+        await dialog.ShowDialog(this);
+        return await tcs.Task;
     }
 }
 

--- a/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml.cs
+++ b/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml.cs
@@ -1,8 +1,5 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Linq;
 using System.Reflection;
 using Avalonia.Controls;
 using Avalonia.Interactivity;

--- a/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml.cs
+++ b/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Reflection;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
@@ -63,15 +65,22 @@ public partial class FormatOptionsWindow : Window
                 if (prop.PropertyType == typeof(bool))
                     value = row.BoolValue;
                 else if (prop.PropertyType == typeof(int))
-                    value = int.Parse(row.CurrentValue);
+                {
+                    if (!int.TryParse(row.CurrentValue, out var intVal))
+                    {
+                        Debug.WriteLine($"FormatOptions: invalid int value '{row.CurrentValue}' for {row.Name}, using default");
+                        continue;
+                    }
+                    value = intVal;
+                }
                 else
                     value = row.CurrentValue;
 
                 prop.SetValue(settings, value);
             }
-            catch
+            catch (Exception ex)
             {
-                // Skip invalid values — keep default
+                Debug.WriteLine($"FormatOptions: failed to set {row.Name}: {ex.Message}");
             }
         }
 
@@ -87,9 +96,6 @@ public partial class FormatOptionsWindow : Window
             if (row.IsBool)
                 row.BoolValue = row.DefaultBoolValue;
         }
-
-        OptionsGrid.ItemsSource = null;
-        OptionsGrid.ItemsSource = _rows;
     }
 
     private void Close_Click(object? sender, RoutedEventArgs e)

--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="ModelContextProtocol" Version="0.7.0-preview.1" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.7.0-preview.1" />
     <PackageReference Include="TextMateSharp.Grammars" Version="2.0.3" />
+    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="170.191.0" />
     <PackageReference Include="Velopack" Version="0.0.1298" />
 
     <!-- Pin SkiaSharp native assets to match SkiaSharp 3.119.0.

--- a/src/PlanViewer.App/Services/SqlFormatSettingsService.cs
+++ b/src/PlanViewer.App/Services/SqlFormatSettingsService.cs
@@ -97,8 +97,9 @@ internal static class SqlFormatSettingsService
         WriteIndented = true
     };
 
-    public static SqlFormatSettings Load()
+    public static SqlFormatSettings Load(out string? error)
     {
+        error = null;
         try
         {
             if (!File.Exists(SettingsPath))
@@ -110,21 +111,26 @@ internal static class SqlFormatSettingsService
         catch (Exception ex)
         {
             Debug.WriteLine($"SqlFormatSettings: failed to load settings: {ex.Message}");
+            error = $"Could not load format settings from:\n{SettingsPath}\n\n{ex.Message}\n\nUsing defaults. Delete or fix the file to clear this error.";
             return new SqlFormatSettings();
         }
     }
 
-    public static void Save(SqlFormatSettings settings)
+    public static bool Save(SqlFormatSettings settings, out string? error)
     {
+        error = null;
         try
         {
             Directory.CreateDirectory(SettingsDir);
             var json = JsonSerializer.Serialize(settings, JsonOptions);
             File.WriteAllText(SettingsPath, json);
+            return true;
         }
         catch (Exception ex)
         {
             Debug.WriteLine($"SqlFormatSettings: failed to save settings: {ex.Message}");
+            error = $"Could not save format settings to:\n{SettingsPath}\n\n{ex.Message}\n\nCheck that the folder is writable and not locked by another process.";
+            return false;
         }
     }
 }

--- a/src/PlanViewer.App/Services/SqlFormatSettingsService.cs
+++ b/src/PlanViewer.App/Services/SqlFormatSettingsService.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+
+namespace PlanViewer.App.Services;
+
+/// <summary>
+/// Formatting options that map to <see cref="SqlScriptGeneratorOptions"/> properties.
+/// Persisted as a JSON file in the app's local data directory.
+/// </summary>
+public sealed class SqlFormatSettings
+{
+    public bool AlignClauseBodies { get; set; } = true;
+    public bool AlignColumnDefinitionFields { get; set; } = true;
+    public bool AlignSetClauseItem { get; set; } = true;
+    public bool AsKeywordOnOwnLine { get; set; } = true;
+    public bool IncludeSemicolons { get; set; } = false;
+    public bool IndentSetClause { get; set; } = false;
+    public bool IndentViewBody { get; set; } = false;
+    public int IndentationSize { get; set; } = 4;
+    public string KeywordCasing { get; set; } = "Uppercase";
+    public bool MultilineInsertSourcesList { get; set; } = true;
+    public bool MultilineInsertTargetsList { get; set; } = true;
+    public bool MultilineSelectElementsList { get; set; } = true;
+    public bool MultilineSetClauseItems { get; set; } = true;
+    public bool MultilineViewColumnsList { get; set; } = true;
+    public bool MultilineWherePredicatesList { get; set; } = true;
+    public bool NewLineBeforeCloseParenthesisInMultilineList { get; set; } = true;
+    public bool NewLineBeforeFromClause { get; set; } = true;
+    public bool NewLineBeforeGroupByClause { get; set; } = true;
+    public bool NewLineBeforeHavingClause { get; set; } = true;
+    public bool NewLineBeforeJoinClause { get; set; } = true;
+    public bool NewLineBeforeOffsetClause { get; set; } = true;
+    public bool NewLineBeforeOpenParenthesisInMultilineList { get; set; } = false;
+    public bool NewLineBeforeOrderByClause { get; set; } = true;
+    public bool NewLineBeforeOutputClause { get; set; } = true;
+    public bool NewLineBeforeWhereClause { get; set; } = true;
+    public bool NewLineBeforeWindowClause { get; set; } = true;
+    public int SqlVersion { get; set; } = 170;
+
+    /// <summary>
+    /// Applies these settings to a <see cref="SqlScriptGeneratorOptions"/> instance.
+    /// </summary>
+    public SqlScriptGeneratorOptions ToGeneratorOptions()
+    {
+        var opts = new SqlScriptGeneratorOptions
+        {
+            AlignClauseBodies = AlignClauseBodies,
+            AlignColumnDefinitionFields = AlignColumnDefinitionFields,
+            AlignSetClauseItem = AlignSetClauseItem,
+            AsKeywordOnOwnLine = AsKeywordOnOwnLine,
+            IncludeSemicolons = IncludeSemicolons,
+            IndentSetClause = IndentSetClause,
+            IndentViewBody = IndentViewBody,
+            IndentationSize = IndentationSize,
+            KeywordCasing = Enum.TryParse<Microsoft.SqlServer.TransactSql.ScriptDom.KeywordCasing>(KeywordCasing, true, out var kc) ? kc : Microsoft.SqlServer.TransactSql.ScriptDom.KeywordCasing.Uppercase,
+            MultilineInsertSourcesList = MultilineInsertSourcesList,
+            MultilineInsertTargetsList = MultilineInsertTargetsList,
+            MultilineSelectElementsList = MultilineSelectElementsList,
+            MultilineSetClauseItems = MultilineSetClauseItems,
+            MultilineViewColumnsList = MultilineViewColumnsList,
+            MultilineWherePredicatesList = MultilineWherePredicatesList,
+            NewLineBeforeCloseParenthesisInMultilineList = NewLineBeforeCloseParenthesisInMultilineList,
+            NewLineBeforeFromClause = NewLineBeforeFromClause,
+            NewLineBeforeGroupByClause = NewLineBeforeGroupByClause,
+            NewLineBeforeHavingClause = NewLineBeforeHavingClause,
+            NewLineBeforeJoinClause = NewLineBeforeJoinClause,
+            NewLineBeforeOffsetClause = NewLineBeforeOffsetClause,
+            NewLineBeforeOpenParenthesisInMultilineList = NewLineBeforeOpenParenthesisInMultilineList,
+            NewLineBeforeOrderByClause = NewLineBeforeOrderByClause,
+            NewLineBeforeOutputClause = NewLineBeforeOutputClause,
+            NewLineBeforeWhereClause = NewLineBeforeWhereClause,
+            NewLineBeforeWindowClause = NewLineBeforeWindowClause,
+        };
+
+        return opts;
+    }
+}
+
+/// <summary>
+/// Loads and saves <see cref="SqlFormatSettings"/> to a local JSON file.
+/// </summary>
+internal static class SqlFormatSettingsService
+{
+    private static readonly string SettingsDir = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "PerformanceStudio");
+
+    private static readonly string SettingsPath = Path.Combine(SettingsDir, "perfstudio_format_settings.json");
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public static SqlFormatSettings Load()
+    {
+        try
+        {
+            if (!File.Exists(SettingsPath))
+                return new SqlFormatSettings();
+
+            var json = File.ReadAllText(SettingsPath);
+            return JsonSerializer.Deserialize<SqlFormatSettings>(json, JsonOptions) ?? new SqlFormatSettings();
+        }
+        catch
+        {
+            return new SqlFormatSettings();
+        }
+    }
+
+    public static void Save(SqlFormatSettings settings)
+    {
+        try
+        {
+            Directory.CreateDirectory(SettingsDir);
+            var json = JsonSerializer.Serialize(settings, JsonOptions);
+            File.WriteAllText(SettingsPath, json);
+        }
+        catch
+        {
+            // Best-effort
+        }
+    }
+}

--- a/src/PlanViewer.App/Services/SqlFormatSettingsService.cs
+++ b/src/PlanViewer.App/Services/SqlFormatSettingsService.cs
@@ -1,8 +1,7 @@
 using System;
-using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Microsoft.SqlServer.TransactSql.ScriptDom;
 
 namespace PlanViewer.App.Services;
@@ -56,7 +55,9 @@ public sealed class SqlFormatSettings
             IndentSetClause = IndentSetClause,
             IndentViewBody = IndentViewBody,
             IndentationSize = IndentationSize,
-            KeywordCasing = Enum.TryParse<Microsoft.SqlServer.TransactSql.ScriptDom.KeywordCasing>(KeywordCasing, true, out var kc) ? kc : Microsoft.SqlServer.TransactSql.ScriptDom.KeywordCasing.Uppercase,
+            KeywordCasing = Enum.TryParse<Microsoft.SqlServer.TransactSql.ScriptDom.KeywordCasing>(KeywordCasing, true, out var kc)
+                            && Enum.IsDefined(kc)
+                            ? kc : Microsoft.SqlServer.TransactSql.ScriptDom.KeywordCasing.Uppercase,
             MultilineInsertSourcesList = MultilineInsertSourcesList,
             MultilineInsertTargetsList = MultilineInsertTargetsList,
             MultilineSelectElementsList = MultilineSelectElementsList,
@@ -93,8 +94,7 @@ internal static class SqlFormatSettingsService
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
-        WriteIndented = true,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        WriteIndented = true
     };
 
     public static SqlFormatSettings Load()
@@ -107,8 +107,9 @@ internal static class SqlFormatSettingsService
             var json = File.ReadAllText(SettingsPath);
             return JsonSerializer.Deserialize<SqlFormatSettings>(json, JsonOptions) ?? new SqlFormatSettings();
         }
-        catch
+        catch (Exception ex)
         {
+            Debug.WriteLine($"SqlFormatSettings: failed to load settings: {ex.Message}");
             return new SqlFormatSettings();
         }
     }
@@ -121,9 +122,9 @@ internal static class SqlFormatSettingsService
             var json = JsonSerializer.Serialize(settings, JsonOptions);
             File.WriteAllText(SettingsPath, json);
         }
-        catch
+        catch (Exception ex)
         {
-            // Best-effort
+            Debug.WriteLine($"SqlFormatSettings: failed to save settings: {ex.Message}");
         }
     }
 }

--- a/src/PlanViewer.App/Services/SqlFormattingService.cs
+++ b/src/PlanViewer.App/Services/SqlFormattingService.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+
+namespace PlanViewer.App.Services;
+
+/// <summary>
+/// Formats T-SQL text using Microsoft.SqlServer.TransactSql.ScriptDom.
+/// Inspired by https://github.com/madskristensen/SqlFormatter (MIT license).
+/// </summary>
+internal static class SqlFormattingService
+{
+    /// <summary>
+    /// Formats the given T-SQL text. Returns the formatted text, or the original text
+    /// with an error message if parsing fails.
+    /// </summary>
+    public static (string formattedText, IList<ParseError>? errors) Format(string sql, SqlFormatSettings? settings = null)
+    {
+        settings ??= new SqlFormatSettings();
+
+        var parser = GetParser(settings.SqlVersion);
+
+        using var reader = new StringReader(sql);
+        var fragment = parser.Parse(reader, out var errors);
+
+        if (errors != null && errors.Count > 0)
+            return (sql, errors);
+
+        var generator = GetGenerator(settings);
+        generator.GenerateScript(fragment, out var formatted);
+
+        return (formatted, null);
+    }
+
+    private static TSqlParser GetParser(int version)
+    {
+        return version switch
+        {
+            80 => new TSql80Parser(true),
+            90 => new TSql90Parser(true),
+            100 => new TSql100Parser(true),
+            110 => new TSql110Parser(true),
+            120 => new TSql120Parser(true),
+            130 => new TSql130Parser(true),
+            140 => new TSql140Parser(true),
+            150 => new TSql150Parser(true),
+            160 => new TSql160Parser(true),
+            _ => new TSql170Parser(true),
+        };
+    }
+
+    private static SqlScriptGenerator GetGenerator(SqlFormatSettings settings)
+    {
+        var options = settings.ToGeneratorOptions();
+
+        return settings.SqlVersion switch
+        {
+            80 => new Sql80ScriptGenerator(options),
+            90 => new Sql90ScriptGenerator(options),
+            100 => new Sql100ScriptGenerator(options),
+            110 => new Sql110ScriptGenerator(options),
+            120 => new Sql120ScriptGenerator(options),
+            130 => new Sql130ScriptGenerator(options),
+            140 => new Sql140ScriptGenerator(options),
+            150 => new Sql150ScriptGenerator(options),
+            160 => new Sql160ScriptGenerator(options),
+            _ => new Sql170ScriptGenerator(options),
+        };
+    }
+}

--- a/src/PlanViewer.App/Services/SqlFormattingService.cs
+++ b/src/PlanViewer.App/Services/SqlFormattingService.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using Microsoft.SqlServer.TransactSql.ScriptDom;
 
 namespace PlanViewer.App.Services;
@@ -24,13 +23,15 @@ internal static class SqlFormattingService
         using var reader = new StringReader(sql);
         var fragment = parser.Parse(reader, out var errors);
 
-        if (errors != null && errors.Count > 0)
+        if (fragment == null)
             return (sql, errors);
 
         var generator = GetGenerator(settings);
         generator.GenerateScript(fragment, out var formatted);
 
-        return (formatted, null);
+        // Return any non-fatal parse errors alongside the formatted output
+        var hasErrors = errors != null && errors.Count > 0;
+        return (formatted, hasErrors ? errors : null);
     }
 
     private static TSqlParser GetParser(int version)


### PR DESCRIPTION
## What does this PR do?

Add a SQL Formater to the Query Editor with format options

## Which component(s) does this affect?

- [x] Desktop App (PlanViewer.App)
- [ ] Core Library (PlanViewer.Core)
- [ ] CLI Tool (PlanViewer.Cli)
- [ ] SSMS Extension (PlanViewer.Ssms)
- [ ] Tests
- [ ] Documentation

## How was this tested?

<img width="1664" height="832" alt="2026-04-18_00h14_12" src="https://github.com/user-attachments/assets/3bea4b12-7df9-4f93-9e7a-a4263403c356" />

<img width="1664" height="832" alt="2026-04-18_00h14_52" src="https://github.com/user-attachments/assets/6f2c6f55-a32c-48e2-a665-3e39ed747527" />


Describe the testing you've done. Include:
- Plan files tested : query generated with nhibernate : a normal awfull one
- Platforms tested : Windows

## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceStudio/blob/main/CONTRIBUTING.md)
- [x] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] All tests pass (`dotnet test`)
- [x] I have not introduced any hardcoded credentials or server names
