### PR TITLE
Polish PlanViewer toolbars, Query Store headers, and tab accent

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml
@@ -13,39 +13,39 @@
         <Border Grid.Row="0" Background="{DynamicResource BackgroundDarkBrush}" Padding="8,6"
                 BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,0,1">
             <DockPanel>
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" Spacing="4">
                     <Button x:Name="PlanConnectButton" Content="Connect" Click="PlanConnect_Click"
-                            Height="28" Padding="10,0" FontSize="12"
+                            Height="28" Padding="8,0" FontSize="12"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Connect to a SQL Server for schema lookups"/>
                     <TextBlock x:Name="PlanServerLabel" Text=""
                                VerticalAlignment="Center" FontSize="12"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="6,0,0,0"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="2,0,0,0"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="6,0"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="2,0"/>
                     <ComboBox x:Name="PlanDatabaseBox" Width="180" Height="28" FontSize="12"
                               IsEnabled="False" PlaceholderText="Database"
                               SelectionChanged="PlanDatabase_SelectionChanged"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="6,0"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="2,0"/>
                     <Button Content="+" Click="ZoomIn_Click" Width="28" Height="28" Padding="0" FontSize="16"
                             FontWeight="Bold" ToolTip.Tip="Zoom In"
                             Theme="{StaticResource AppButton}"/>
                     <Button Content="&#x2212;" Click="ZoomOut_Click" Width="28" Height="28" Padding="0" FontSize="16"
-                            FontWeight="Bold" Margin="4,0,0,0" ToolTip.Tip="Zoom Out"
+                            FontWeight="Bold" ToolTip.Tip="Zoom Out"
                             Theme="{StaticResource AppButton}"/>
-                    <Button Content="Fit" Click="ZoomFit_Click" Height="28" Padding="8,0" Margin="4,0,0,0"
+                    <Button Content="Fit" Click="ZoomFit_Click" Height="28" Padding="8,0"
                             ToolTip.Tip="Zoom to Fit"
                             Theme="{StaticResource AppButton}"/>
                     <TextBlock x:Name="ZoomLevelText" Text="100%" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="8,0,0,0" FontSize="11"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="4,0,0,0" FontSize="11"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="12,0"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="6,0"/>
                     <Button Content="Save .sqlplan" Click="SavePlan_Click" Height="28" Padding="8,0"
                             ToolTip.Tip="Save plan as .sqlplan file"
                             Theme="{StaticResource AppButton}"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="12,0"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="6,0"
                                x:Name="StatementsButtonSeparator" IsVisible="False"/>
                     <Button x:Name="StatementsButton" Content="Statements" Click="ToggleStatements_Click"
                             Height="28" Padding="8,0" IsVisible="False"

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml
@@ -8,65 +8,65 @@
         <Border Grid.Row="0" Background="{DynamicResource BackgroundDarkBrush}" Padding="8,6"
                 BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,0,1">
             <DockPanel>
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" Spacing="6">
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" Spacing="4">
                     <Button x:Name="ConnectButton" Content="Connect" Click="Connect_Click"
-                            Height="28" Padding="10,0" FontSize="12"
+                            Height="28" Padding="8,0" FontSize="12"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Connect to a SQL Server"/>
                     <TextBlock x:Name="ServerLabel" Text="Not connected"
                                VerticalAlignment="Center" FontSize="12"
-                               Foreground="{DynamicResource ForegroundBrush}"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="2,0,0,0"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="4,0"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="2,0"/>
                     <ComboBox x:Name="DatabaseBox" Width="200" Height="28" FontSize="12"
                               IsEnabled="False" PlaceholderText="Database"
                               SelectionChanged="Database_SelectionChanged"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="4,0"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="2,0"/>
                     <Button x:Name="ExecuteButton" Content="&#x25B6; Actual Plan" Click="Execute_Click"
-                            Height="28" Padding="10,0" FontSize="12" IsEnabled="False"
+                            Height="28" Padding="8,0" FontSize="12" IsEnabled="False"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Run query and capture execution plan with runtime stats (F5 / Ctrl+E)"/>
                     <Button x:Name="ExecuteEstButton" Content="&#x25C7; Estimated Plan" Click="ExecuteEstimated_Click"
-                            Height="28" Padding="10,0" FontSize="12" IsEnabled="False"
+                            Height="28" Padding="8,0" FontSize="12" IsEnabled="False"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Capture estimated plan without executing (Ctrl+L)"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="4,0"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="2,0"/>
                     <Button x:Name="HumanAdviceButton" Content="&#x1F9D1; Human Advice"
                             Click="HumanAdvice_Click"
-                            Height="28" Padding="10,0" FontSize="12" IsEnabled="False"
+                            Height="28" Padding="8,0" FontSize="12" IsEnabled="False"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Human-readable plan analysis"/>
                     <Button x:Name="RobotAdviceButton" Content="&#x1F916; Robot Advice"
                             Click="RobotAdvice_Click"
-                            Height="28" Padding="10,0" FontSize="12" IsEnabled="False"
+                            Height="28" Padding="8,0" FontSize="12" IsEnabled="False"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="JSON analysis for LLMs and automation"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="4,0"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="2,0"/>
                     <Button x:Name="ComparePlansButton" Content="&#x2194; Compare Plans"
                             Click="ComparePlans_Click"
-                            Height="28" Padding="10,0" FontSize="12" IsEnabled="False"
+                            Height="28" Padding="8,0" FontSize="12" IsEnabled="False"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Compare two plan tabs"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="4,0"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="2,0"/>
                     <Button x:Name="QueryStoreButton" Content="&#x1F4CA; Query Store"
                             Click="QueryStore_Click"
-                            Height="28" Padding="10,0" FontSize="12"
+                            Height="28" Padding="8,0" FontSize="12"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Analyze top queries from Query Store"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="4,0"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="2,0"/>
                     <Button x:Name="CopyReproButton" Content="&#x1F4CB; Copy Repro"
                             Click="CopyRepro_Click"
-                            Height="28" Padding="10,0" FontSize="12" IsEnabled="False"
+                            Height="28" Padding="8,0" FontSize="12" IsEnabled="False"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Copy reproduction script to clipboard"/>
                     <Button x:Name="GetActualPlanButton" Content="&#x25B6; Run Repro"
                             Click="GetActualPlan_Click"
-                            Height="28" Padding="10,0" FontSize="12" IsEnabled="False"
+                            Height="28" Padding="8,0" FontSize="12" IsEnabled="False"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Execute the repro script and capture actual plan with runtime stats"/>
                 </StackPanel>

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
@@ -209,8 +209,8 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTextColumn Header="Last Executed (Local)" Binding="{ReflectionBinding LastExecutedLocal}" SortMemberPath="LastExecutedLocal" Width="160"/>
-                <DataGridTemplateColumn Header="Executions" SortMemberPath="ExecsSort" Width="100">
+                <DataGridTextColumn Header="Last Executed" Binding="{ReflectionBinding LastExecutedLocal}" SortMemberPath="LastExecutedLocal" Width="160"/>
+                <DataGridTemplateColumn Header="Executions" SortMemberPath="ExecsSort" Width="105">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate x:DataType="local:QueryStoreRow">
                             <local:BarChartCell DisplayText="{Binding ExecsDisplay}"
@@ -220,7 +220,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Total CPU (ms)" SortMemberPath="TotalCpuSort" Width="120">
+                <DataGridTemplateColumn Header="Total CPU (ms)" SortMemberPath="TotalCpuSort" Width="135">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate x:DataType="local:QueryStoreRow">
                             <local:BarChartCell DisplayText="{Binding TotalCpuDisplay}"
@@ -230,7 +230,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Avg CPU (ms)" SortMemberPath="AvgCpuSort" Width="110">
+                <DataGridTemplateColumn Header="Avg CPU (ms)" SortMemberPath="AvgCpuSort" Width="120">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate x:DataType="local:QueryStoreRow">
                             <local:BarChartCell DisplayText="{Binding AvgCpuDisplay}"
@@ -240,7 +240,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Total Duration (ms)" SortMemberPath="TotalDurSort" Width="150">
+                <DataGridTemplateColumn Header="Total Duration (ms)" SortMemberPath="TotalDurSort" Width="165">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate x:DataType="local:QueryStoreRow">
                             <local:BarChartCell DisplayText="{Binding TotalDurDisplay}"
@@ -250,7 +250,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Avg Duration (ms)" SortMemberPath="AvgDurSort" Width="140">
+                <DataGridTemplateColumn Header="Avg Duration (ms)" SortMemberPath="AvgDurSort" Width="155">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate x:DataType="local:QueryStoreRow">
                             <local:BarChartCell DisplayText="{Binding AvgDurDisplay}"
@@ -300,7 +300,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Total Physical Reads" SortMemberPath="TotalPhysReadsSort" Width="155">
+                <DataGridTemplateColumn Header="Total Phys Reads" SortMemberPath="TotalPhysReadsSort" Width="140">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate x:DataType="local:QueryStoreRow">
                             <local:BarChartCell DisplayText="{Binding TotalPhysReadsDisplay}"
@@ -310,7 +310,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Avg Physical Reads" SortMemberPath="AvgPhysReadsSort" Width="140">
+                <DataGridTemplateColumn Header="Avg Phys Reads" SortMemberPath="AvgPhysReadsSort" Width="130">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate x:DataType="local:QueryStoreRow">
                             <local:BarChartCell DisplayText="{Binding AvgPhysReadsDisplay}"
@@ -320,7 +320,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Total Memory (MB)" SortMemberPath="TotalMemSort" Width="140">
+                <DataGridTemplateColumn Header="Total Memory (MB)" SortMemberPath="TotalMemSort" Width="155">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate x:DataType="local:QueryStoreRow">
                             <local:BarChartCell DisplayText="{Binding TotalMemDisplay}"
@@ -330,7 +330,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Avg Memory (MB)" SortMemberPath="AvgMemSort" Width="130">
+                <DataGridTemplateColumn Header="Avg Memory (MB)" SortMemberPath="AvgMemSort" Width="145">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate x:DataType="local:QueryStoreRow">
                             <local:BarChartCell DisplayText="{Binding AvgMemDisplay}"

--- a/src/PlanViewer.App/Themes/DarkTheme.axaml
+++ b/src/PlanViewer.App/Themes/DarkTheme.axaml
@@ -8,6 +8,13 @@
     <SolidColorBrush x:Key="BorderBrush" Color="#3A3D45"/>
     <SolidColorBrush x:Key="AccentBrush" Color="#2eaef1"/>
 
+    <!-- Fluent theme accent override: TabItem selected underline, focus rings, etc. -->
+    <Color x:Key="SystemAccentColor">#2eaef1</Color>
+    <Color x:Key="SystemAccentColorDark1">#2596d4</Color>
+    <Color x:Key="SystemAccentColorDark2">#1f80b6</Color>
+    <Color x:Key="SystemAccentColorLight1">#5bc0f4</Color>
+    <Color x:Key="SystemAccentColorLight2">#88d1f7</Color>
+
     <!-- Button style: brand blue on hover -->
     <ControlTheme x:Key="AppButton" TargetType="Button">
         <Setter Property="Background" Value="{DynamicResource BackgroundLightBrush}"/>
@@ -67,7 +74,7 @@
     <!-- Wait Stats category colors (fixed per category) -->
     <SolidColorBrush x:Key="WaitCategory.Unknown"            Color="#8E8E93"/>
     <SolidColorBrush x:Key="WaitCategory.CPU"                Color="#00bd23"/>
-    <SolidColorBrush x:Key="WaitCategory.Worker Thread"      Color="#19ff25"/>
+    <SolidColorBrush x:Key="WaitCategory.Worker Thread"      Color="#52E3B5"/>
     <SolidColorBrush x:Key="WaitCategory.Lock"               Color="#EE5A24"/>
     <SolidColorBrush x:Key="WaitCategory.Latch"              Color="#F368E0"/>
     <SolidColorBrush x:Key="WaitCategory.Buffer Latch"       Color="#f5069e"/>
@@ -80,7 +87,7 @@
     <SolidColorBrush x:Key="WaitCategory.Service Broker"     Color="#E17055"/>
     <SolidColorBrush x:Key="WaitCategory.Tran Log IO"        Color="#0984E3"/>
     <SolidColorBrush x:Key="WaitCategory.Network IO"         Color="#75bbf8"/>
-    <SolidColorBrush x:Key="WaitCategory.Parallelism"        Color="#fd01d3"/>
+    <SolidColorBrush x:Key="WaitCategory.Parallelism"        Color="#7B4FFF"/>
     <SolidColorBrush x:Key="WaitCategory.Memory"             Color="#FDCB6E"/>
     <SolidColorBrush x:Key="WaitCategory.Tracing"            Color="#B2BEC3"/>
     <SolidColorBrush x:Key="WaitCategory.Full Text Search"   Color="#DFE6E9"/>


### PR DESCRIPTION
## Summary

Small set of in-session polish items for Performance Studio:

- **Query Store grid column headers** — dropped `(Local)` from Last Executed (Time display dropdown already controls timezone), shortened `Physical Reads` → `Phys Reads`, and widened CPU / Duration / Memory / Phys Reads / Executions columns by 5–15px so `(ms)` and `(MB)` suffixes no longer truncate in the default layout.
- **Toolbar density** — reduced button padding `10,0 → 8,0`, StackPanel `Spacing 6 → 4`, and pipe-separator margins `4,0 → 2,0` (and `12,0 → 6,0`) across both `QuerySessionControl` and `PlanViewerControl` toolbars. Dropped redundant per-button margins now that Spacing handles them.
- **Wait palette collisions** — Worker Thread `#19ff25` → `#52E3B5` (teal, distinct from CPU green) and Parallelism `#fd01d3` → `#7B4FFF` (vivid purple, out of the pink/magenta cluster) so neighboring wait categories on the stacked wait profile bar read as different colors.
- **Tab active-state accent** — added `SystemAccentColor` (and its Dark1/Dark2/Light1/Light2 variants) to `DarkTheme.axaml`. Fluent's `TabItem` selected pipe reads from `SystemAccentColor`, so Plan 1 / Plan 2 tabs now get the brand-blue underline consistently instead of the Fluent default teal.

## Test plan
- [ ] Launch app, open Query Store, verify column headers fully readable without horizontal scroll
- [ ] Open an .sqlplan with multiple statements, hover toolbars, verify tighter spacing still readable and usable
- [ ] Load a plan with parallel + worker-thread waits and verify the stacked wait bar shows distinct colors for each category
- [ ] Open two plan tabs, switch between them, confirm the active tab shows a brand-blue underline

🤖 Generated with [Claude Code](https://claude.com/claude-code)