### PR TITLE
Remove redundant System using in ServerConnection

### DIFF
--- a/src/PlanViewer.Core/Models/ServerConnection.cs
+++ b/src/PlanViewer.Core/Models/ServerConnection.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Text.Json.Serialization;
 using Microsoft.Data.SqlClient;
 using PlanViewer.Core.Interfaces;


### PR DESCRIPTION
## Summary
- Drop `using System;` from `ServerConnection.cs` — already covered by .NET 8 implicit global usings.
- Clears LSP warnings CS8933 (duplicate of global using) and CS8019 (unnecessary using).

## Test plan
- [ ] `dotnet build` is clean
- [ ] No new diagnostics on the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)