### PR TITLE
Await ShowDialog in Format_Click (fix CS4014)

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -2056,7 +2056,7 @@ public partial class QuerySessionControl : UserControl
                         }
                     }
                 };
-                dialog.ShowDialog(GetParentWindow());
+                await dialog.ShowDialog(GetParentWindow());
                 SetStatus($"Format failed: {errors.Count} error(s)");
                 return;
             }


### PR DESCRIPTION
## Summary
- Awaits `dialog.ShowDialog(GetParentWindow())` in `Format_Click` so the status update and method return wait for the user to dismiss the parse-error dialog
- Eliminates the new CS4014 warning introduced by #238

## Test plan
- [x] `dotnet build -c Debug` — 0 warnings, 0 errors
- [x] App launches and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)