### PR TITLE
Release v1.6.0

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,35 @@
+# Third-Party Notices
+
+This project incorporates material from the projects listed below.
+
+---
+
+## SqlFormatter
+
+- **Source:** https://github.com/madskristensen/SqlFormatter
+- **License:** MIT (Apache-2.0 per repository; individual files carry MIT terms)
+- **Copyright:** Copyright (c) Mads Kristensen
+
+The `SqlFormattingService` in this project was inspired by and partially derived
+from the SqlFormatter extension for Visual Studio by Mads Kristensen. It uses
+`Microsoft.SqlServer.TransactSql.ScriptDom` for T-SQL parsing and formatting.
+
+### MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml
@@ -13,39 +13,39 @@
         <Border Grid.Row="0" Background="{DynamicResource BackgroundDarkBrush}" Padding="8,6"
                 BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,0,1">
             <DockPanel>
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" Spacing="4">
                     <Button x:Name="PlanConnectButton" Content="Connect" Click="PlanConnect_Click"
-                            Height="28" Padding="10,0" FontSize="12"
+                            Height="28" Padding="8,0" FontSize="12"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Connect to a SQL Server for schema lookups"/>
                     <TextBlock x:Name="PlanServerLabel" Text=""
                                VerticalAlignment="Center" FontSize="12"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="6,0,0,0"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="2,0,0,0"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="6,0"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="2,0"/>
                     <ComboBox x:Name="PlanDatabaseBox" Width="180" Height="28" FontSize="12"
                               IsEnabled="False" PlaceholderText="Database"
                               SelectionChanged="PlanDatabase_SelectionChanged"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="6,0"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="2,0"/>
                     <Button Content="+" Click="ZoomIn_Click" Width="28" Height="28" Padding="0" FontSize="16"
                             FontWeight="Bold" ToolTip.Tip="Zoom In"
                             Theme="{StaticResource AppButton}"/>
                     <Button Content="&#x2212;" Click="ZoomOut_Click" Width="28" Height="28" Padding="0" FontSize="16"
-                            FontWeight="Bold" Margin="4,0,0,0" ToolTip.Tip="Zoom Out"
+                            FontWeight="Bold" ToolTip.Tip="Zoom Out"
                             Theme="{StaticResource AppButton}"/>
-                    <Button Content="Fit" Click="ZoomFit_Click" Height="28" Padding="8,0" Margin="4,0,0,0"
+                    <Button Content="Fit" Click="ZoomFit_Click" Height="28" Padding="8,0"
                             ToolTip.Tip="Zoom to Fit"
                             Theme="{StaticResource AppButton}"/>
                     <TextBlock x:Name="ZoomLevelText" Text="100%" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="8,0,0,0" FontSize="11"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="4,0,0,0" FontSize="11"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="12,0"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="6,0"/>
                     <Button Content="Save .sqlplan" Click="SavePlan_Click" Height="28" Padding="8,0"
                             ToolTip.Tip="Save plan as .sqlplan file"
                             Theme="{StaticResource AppButton}"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="12,0"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="6,0"
                                x:Name="StatementsButtonSeparator" IsVisible="False"/>
                     <Button x:Name="StatementsButton" Content="Statements" Click="ToggleStatements_Click"
                             Height="28" Padding="8,0" IsVisible="False"

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml
@@ -69,6 +69,16 @@
                             Height="28" Padding="8,0" FontSize="12" IsEnabled="False"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Execute the repro script and capture actual plan with runtime stats"/>
+                    <TextBlock Text="|" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="4,0"/>
+                    <Button x:Name="FormatButton" Content="&#x1F4DD; Format" Click="Format_Click"
+                            Height="28" Padding="10,0" FontSize="12"
+                            Theme="{StaticResource AppButton}"
+                            ToolTip.Tip="Format the SQL query"/>
+                    <Button x:Name="FormatOptionsButton" Content="&#x2699; Format Options" Click="FormatOptions_Click"
+                            Height="28" Padding="10,0" FontSize="12"
+                            Theme="{StaticResource AppButton}"
+                            ToolTip.Tip="Configure SQL formatting options"/>
                 </StackPanel>
                 <TextBlock x:Name="StatusText" DockPanel.Dock="Right"
                            HorizontalAlignment="Right" VerticalAlignment="Center"

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml
@@ -8,65 +8,65 @@
         <Border Grid.Row="0" Background="{DynamicResource BackgroundDarkBrush}" Padding="8,6"
                 BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,0,1">
             <DockPanel>
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" Spacing="6">
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" Spacing="4">
                     <Button x:Name="ConnectButton" Content="Connect" Click="Connect_Click"
-                            Height="28" Padding="10,0" FontSize="12"
+                            Height="28" Padding="8,0" FontSize="12"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Connect to a SQL Server"/>
                     <TextBlock x:Name="ServerLabel" Text="Not connected"
                                VerticalAlignment="Center" FontSize="12"
-                               Foreground="{DynamicResource ForegroundBrush}"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="2,0,0,0"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="4,0"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="2,0"/>
                     <ComboBox x:Name="DatabaseBox" Width="200" Height="28" FontSize="12"
                               IsEnabled="False" PlaceholderText="Database"
                               SelectionChanged="Database_SelectionChanged"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="4,0"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="2,0"/>
                     <Button x:Name="ExecuteButton" Content="&#x25B6; Actual Plan" Click="Execute_Click"
-                            Height="28" Padding="10,0" FontSize="12" IsEnabled="False"
+                            Height="28" Padding="8,0" FontSize="12" IsEnabled="False"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Run query and capture execution plan with runtime stats (F5 / Ctrl+E)"/>
                     <Button x:Name="ExecuteEstButton" Content="&#x25C7; Estimated Plan" Click="ExecuteEstimated_Click"
-                            Height="28" Padding="10,0" FontSize="12" IsEnabled="False"
+                            Height="28" Padding="8,0" FontSize="12" IsEnabled="False"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Capture estimated plan without executing (Ctrl+L)"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="4,0"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="2,0"/>
                     <Button x:Name="HumanAdviceButton" Content="&#x1F9D1; Human Advice"
                             Click="HumanAdvice_Click"
-                            Height="28" Padding="10,0" FontSize="12" IsEnabled="False"
+                            Height="28" Padding="8,0" FontSize="12" IsEnabled="False"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Human-readable plan analysis"/>
                     <Button x:Name="RobotAdviceButton" Content="&#x1F916; Robot Advice"
                             Click="RobotAdvice_Click"
-                            Height="28" Padding="10,0" FontSize="12" IsEnabled="False"
+                            Height="28" Padding="8,0" FontSize="12" IsEnabled="False"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="JSON analysis for LLMs and automation"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="4,0"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="2,0"/>
                     <Button x:Name="ComparePlansButton" Content="&#x2194; Compare Plans"
                             Click="ComparePlans_Click"
-                            Height="28" Padding="10,0" FontSize="12" IsEnabled="False"
+                            Height="28" Padding="8,0" FontSize="12" IsEnabled="False"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Compare two plan tabs"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="4,0"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="2,0"/>
                     <Button x:Name="QueryStoreButton" Content="&#x1F4CA; Query Store"
                             Click="QueryStore_Click"
-                            Height="28" Padding="10,0" FontSize="12"
+                            Height="28" Padding="8,0" FontSize="12"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Analyze top queries from Query Store"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
-                               Foreground="{DynamicResource ForegroundBrush}" Margin="4,0"/>
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="2,0"/>
                     <Button x:Name="CopyReproButton" Content="&#x1F4CB; Copy Repro"
                             Click="CopyRepro_Click"
-                            Height="28" Padding="10,0" FontSize="12" IsEnabled="False"
+                            Height="28" Padding="8,0" FontSize="12" IsEnabled="False"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Copy reproduction script to clipboard"/>
                     <Button x:Name="GetActualPlanButton" Content="&#x25B6; Run Repro"
                             Click="GetActualPlan_Click"
-                            Height="28" Padding="10,0" FontSize="12" IsEnabled="False"
+                            Height="28" Padding="8,0" FontSize="12" IsEnabled="False"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Execute the repro script and capture actual plan with runtime stats"/>
                 </StackPanel>

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -2056,7 +2056,7 @@ public partial class QuerySessionControl : UserControl
                         }
                     }
                 };
-                dialog.ShowDialog(GetParentWindow());
+                await dialog.ShowDialog(GetParentWindow());
                 SetStatus($"Format failed: {errors.Count} error(s)");
                 return;
             }

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -2005,4 +2005,86 @@ public partial class QuerySessionControl : UserControl
         var parent = this.VisualRoot;
         return parent as Window ?? throw new InvalidOperationException("No parent window");
     }
+
+    private async void Format_Click(object? sender, RoutedEventArgs e)
+    {
+        var sql = QueryEditor.Text;
+        if (string.IsNullOrWhiteSpace(sql))
+            return;
+
+        FormatButton.IsEnabled = false;
+        SetStatus("Formatting...");
+
+        try
+        {
+            var settings = SqlFormatSettingsService.Load(out var loadError);
+            if (loadError != null)
+                SetStatus("Warning: using default format settings (load failed)");
+
+            var (formatted, errors) = await Task.Run(() => SqlFormattingService.Format(sql, settings));
+
+            if (errors != null && errors.Count > 0)
+            {
+                var errorMessages = string.Join("\n", errors.Select(err => $"Line {err.Line}: {err.Message}"));
+                var dialog = new Window
+                {
+                    Title = "SQL Format Error",
+                    Width = 500,
+                    Height = 250,
+                    WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                    Icon = GetParentWindow().Icon,
+                    Background = (IBrush)this.FindResource("BackgroundBrush")!,
+                    Foreground = (IBrush)this.FindResource("ForegroundBrush")!,
+                    Content = new StackPanel
+                    {
+                        Margin = new Avalonia.Thickness(20),
+                        Children =
+                        {
+                            new TextBlock
+                            {
+                                Text = $"Could not format: {errors.Count} parse error(s)",
+                                FontWeight = Avalonia.Media.FontWeight.Bold,
+                                FontSize = 14,
+                                Margin = new Avalonia.Thickness(0, 0, 0, 10)
+                            },
+                            new TextBlock
+                            {
+                                Text = errorMessages,
+                                TextWrapping = TextWrapping.Wrap,
+                                FontSize = 12
+                            }
+                        }
+                    }
+                };
+                dialog.ShowDialog(GetParentWindow());
+                SetStatus($"Format failed: {errors.Count} error(s)");
+                return;
+            }
+
+            var caretOffset = QueryEditor.CaretOffset;
+
+            QueryEditor.Document.BeginUpdate();
+            try
+            {
+                QueryEditor.Document.Replace(0, QueryEditor.Document.TextLength, formatted);
+            }
+            finally
+            {
+                QueryEditor.Document.EndUpdate();
+            }
+
+            QueryEditor.CaretOffset = Math.Min(caretOffset, QueryEditor.Document.TextLength);
+            SetStatus("Formatted");
+        }
+        finally
+        {
+            FormatButton.IsEnabled = true;
+        }
+    }
+
+    private void FormatOptions_Click(object? sender, RoutedEventArgs e)
+    {
+        var dialog = new Dialogs.FormatOptionsWindow();
+        dialog.ShowDialog(GetParentWindow());
+    }
 }

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -68,13 +68,22 @@ public partial class QuerySessionControl : UserControl
         QueryEditor.TextArea.TextEntered += OnTextEntered;
 
         // Focus the editor when the control is attached to the visual tree
+        // Re-install TextMate if it was disposed on detach (tab switching disposes it)
         AttachedToVisualTree += (_, _) =>
         {
+            if (_textMateInstallation == null)
+                SetupSyntaxHighlighting();
+
             QueryEditor.Focus();
             QueryEditor.TextArea.Focus();
         };
 
-        DetachedFromVisualTree += (_, _) => _textMateInstallation?.Dispose();
+        // Dispose TextMate when detached (e.g. tab switch) to release renderers/transformers
+        DetachedFromVisualTree += (_, _) =>
+        {
+            _textMateInstallation?.Dispose();
+            _textMateInstallation = null;
+        };
 
         // Focus the editor when the Editor tab is selected; toggle plan-dependent buttons
         SubTabControl.SelectionChanged += (_, _) =>

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
@@ -209,8 +209,8 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTextColumn Header="Last Executed (Local)" Binding="{ReflectionBinding LastExecutedLocal}" SortMemberPath="LastExecutedLocal" Width="160"/>
-                <DataGridTemplateColumn Header="Executions" SortMemberPath="ExecsSort" Width="100">
+                <DataGridTextColumn Header="Last Executed" Binding="{ReflectionBinding LastExecutedLocal}" SortMemberPath="LastExecutedLocal" Width="160"/>
+                <DataGridTemplateColumn Header="Executions" SortMemberPath="ExecsSort" Width="105">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate x:DataType="local:QueryStoreRow">
                             <local:BarChartCell DisplayText="{Binding ExecsDisplay}"
@@ -220,7 +220,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Total CPU (ms)" SortMemberPath="TotalCpuSort" Width="120">
+                <DataGridTemplateColumn Header="Total CPU (ms)" SortMemberPath="TotalCpuSort" Width="135">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate x:DataType="local:QueryStoreRow">
                             <local:BarChartCell DisplayText="{Binding TotalCpuDisplay}"
@@ -230,7 +230,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Avg CPU (ms)" SortMemberPath="AvgCpuSort" Width="110">
+                <DataGridTemplateColumn Header="Avg CPU (ms)" SortMemberPath="AvgCpuSort" Width="120">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate x:DataType="local:QueryStoreRow">
                             <local:BarChartCell DisplayText="{Binding AvgCpuDisplay}"
@@ -240,7 +240,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Total Duration (ms)" SortMemberPath="TotalDurSort" Width="150">
+                <DataGridTemplateColumn Header="Total Duration (ms)" SortMemberPath="TotalDurSort" Width="165">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate x:DataType="local:QueryStoreRow">
                             <local:BarChartCell DisplayText="{Binding TotalDurDisplay}"
@@ -250,7 +250,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Avg Duration (ms)" SortMemberPath="AvgDurSort" Width="140">
+                <DataGridTemplateColumn Header="Avg Duration (ms)" SortMemberPath="AvgDurSort" Width="155">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate x:DataType="local:QueryStoreRow">
                             <local:BarChartCell DisplayText="{Binding AvgDurDisplay}"
@@ -300,7 +300,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Total Physical Reads" SortMemberPath="TotalPhysReadsSort" Width="155">
+                <DataGridTemplateColumn Header="Total Phys Reads" SortMemberPath="TotalPhysReadsSort" Width="140">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate x:DataType="local:QueryStoreRow">
                             <local:BarChartCell DisplayText="{Binding TotalPhysReadsDisplay}"
@@ -310,7 +310,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Avg Physical Reads" SortMemberPath="AvgPhysReadsSort" Width="140">
+                <DataGridTemplateColumn Header="Avg Phys Reads" SortMemberPath="AvgPhysReadsSort" Width="130">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate x:DataType="local:QueryStoreRow">
                             <local:BarChartCell DisplayText="{Binding AvgPhysReadsDisplay}"
@@ -320,7 +320,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Total Memory (MB)" SortMemberPath="TotalMemSort" Width="140">
+                <DataGridTemplateColumn Header="Total Memory (MB)" SortMemberPath="TotalMemSort" Width="155">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate x:DataType="local:QueryStoreRow">
                             <local:BarChartCell DisplayText="{Binding TotalMemDisplay}"
@@ -330,7 +330,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Avg Memory (MB)" SortMemberPath="AvgMemSort" Width="130">
+                <DataGridTemplateColumn Header="Avg Memory (MB)" SortMemberPath="AvgMemSort" Width="145">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate x:DataType="local:QueryStoreRow">
                             <local:BarChartCell DisplayText="{Binding AvgMemDisplay}"

--- a/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml
+++ b/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml
@@ -1,0 +1,121 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dialogs="using:PlanViewer.App.Dialogs"
+        x:Class="PlanViewer.App.Dialogs.FormatOptionsWindow"
+        Title="SQL Format Options"
+        Width="650" Height="580"
+        MinWidth="520" MinHeight="400"
+        Background="{DynamicResource BackgroundBrush}"
+        Foreground="{DynamicResource ForegroundBrush}"
+        WindowStartupLocation="CenterOwner">
+
+    <Window.Styles>
+        <Style Selector="ToggleSwitch">
+            <Setter Property="OnContent" Value=""/>
+            <Setter Property="OffContent" Value=""/>
+            <Setter Property="MinWidth" Value="0"/>
+            <Setter Property="MinHeight" Value="0"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="Margin" Value="0"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="RenderTransformOrigin" Value="0%,50%"/>
+            <Setter Property="RenderTransform" Value="scale(0.75)"/>
+        </Style>
+        <Style Selector="ToggleSwitch:checked /template/ Border#SwitchKnobBounds">
+            <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+        </Style>
+        <Style Selector="ToggleSwitch:checked /template/ Border#OuterBorder">
+            <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+        </Style>
+    </Window.Styles>
+
+    <Grid RowDefinitions="*,Auto" Margin="12">
+        <DataGrid x:Name="OptionsGrid" Grid.Row="0"
+                  x:DataType="dialogs:FormatOptionRow"
+                  AutoGenerateColumns="False"
+                  CanUserReorderColumns="False"
+                  CanUserSortColumns="False"
+                  HeadersVisibility="Column"
+                  GridLinesVisibility="Horizontal"
+                  IsReadOnly="False"
+                  Background="{DynamicResource BackgroundBrush}"
+                  Foreground="{DynamicResource ForegroundBrush}"
+                  Margin="0,0,0,12">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Parameter" Binding="{Binding Name}" IsReadOnly="True" Width="2*"/>
+                <DataGridTemplateColumn Header="Current Value" Width="*">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate x:DataType="dialogs:FormatOptionRow">
+                            <Panel>
+                                <ToggleSwitch IsChecked="{Binding BoolValue}"
+                                              IsVisible="{Binding IsBool}"
+                                              VerticalAlignment="Center"
+                                              Margin="4,0"/>
+                                <ComboBox ItemsSource="{Binding ChoiceOptions}"
+                                          SelectedItem="{Binding CurrentValue}"
+                                          IsVisible="{Binding IsChoice}"
+                                          VerticalAlignment="Center"
+                                          MinHeight="0" Height="26" FontSize="12"
+                                          Margin="4,0"/>
+                                <TextBlock Text="{Binding CurrentValue}"
+                                           IsVisible="{Binding IsText}"
+                                           VerticalAlignment="Center"
+                                           Margin="8,0"/>
+                            </Panel>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                    <DataGridTemplateColumn.CellEditingTemplate>
+                        <DataTemplate x:DataType="dialogs:FormatOptionRow">
+                            <Panel>
+                                <ToggleSwitch IsChecked="{Binding BoolValue}"
+                                              IsVisible="{Binding IsBool}"
+                                              VerticalAlignment="Center"
+                                              Margin="4,0"/>
+                                <ComboBox ItemsSource="{Binding ChoiceOptions}"
+                                          SelectedItem="{Binding CurrentValue}"
+                                          IsVisible="{Binding IsChoice}"
+                                          VerticalAlignment="Center"
+                                          MinHeight="0" Height="26" FontSize="12"
+                                          Margin="4,0"/>
+                                <TextBox Text="{Binding CurrentValue}"
+                                         IsVisible="{Binding IsText}"
+                                         VerticalAlignment="Center"
+                                         Margin="4,0"/>
+                            </Panel>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellEditingTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTemplateColumn Header="Default Value" IsReadOnly="True" Width="*">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate x:DataType="dialogs:FormatOptionRow">
+                            <Panel>
+                                <ToggleSwitch IsChecked="{Binding DefaultBoolValue}"
+                                              IsVisible="{Binding IsBool}"
+                                              IsEnabled="False"
+                                              VerticalAlignment="Center"
+                                              Margin="4,0"/>
+                                <TextBlock Text="{Binding DefaultValue}"
+                                           IsVisible="{Binding !IsBool}"
+                                           VerticalAlignment="Center"
+                                           Margin="8,0"/>
+                                <!-- Choice defaults shown as text -->
+                            </Panel>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+            </DataGrid.Columns>
+        </DataGrid>
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+            <Button x:Name="RevertButton" Content="Revert to Default" Click="Revert_Click"
+                    Height="32" Padding="16,0" FontSize="12"
+                    Theme="{StaticResource AppButton}"/>
+            <Button x:Name="SaveButton" Content="Save" Click="Save_Click"
+                    Height="32" Padding="16,0" FontSize="12"
+                    Theme="{StaticResource AppButton}"/>
+            <Button x:Name="CloseButton" Content="Close" Click="Close_Click"
+                    Height="32" Padding="16,0" FontSize="12"
+                    Theme="{StaticResource AppButton}"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml.cs
+++ b/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml.cs
@@ -1,0 +1,326 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using PlanViewer.App.Services;
+
+namespace PlanViewer.App.Dialogs;
+
+public partial class FormatOptionsWindow : Window
+{
+    private readonly ObservableCollection<FormatOptionRow> _rows = new();
+    private readonly SqlFormatSettings _defaults = new();
+
+    private bool _isDirty;
+
+    public FormatOptionsWindow()
+    {
+        InitializeComponent();
+        LoadSettings();
+    }
+
+    // Explicit ordering — reflection doesn't guarantee declaration order
+    private static readonly string[] PropertyOrder =
+    [
+        "KeywordCasing", "SqlVersion", "IndentationSize",
+        "AlignClauseBodies", "AlignColumnDefinitionFields", "AlignSetClauseItem",
+        "AsKeywordOnOwnLine", "IncludeSemicolons",
+        "IndentSetClause", "IndentViewBody",
+        "MultilineInsertSourcesList", "MultilineInsertTargetsList",
+        "MultilineSelectElementsList", "MultilineSetClauseItems",
+        "MultilineViewColumnsList", "MultilineWherePredicatesList",
+        "NewLineBeforeCloseParenthesisInMultilineList",
+        "NewLineBeforeFromClause", "NewLineBeforeGroupByClause",
+        "NewLineBeforeHavingClause", "NewLineBeforeJoinClause",
+        "NewLineBeforeOffsetClause", "NewLineBeforeOpenParenthesisInMultilineList",
+        "NewLineBeforeOrderByClause", "NewLineBeforeOutputClause",
+        "NewLineBeforeWhereClause", "NewLineBeforeWindowClause",
+    ];
+
+    private static readonly Dictionary<string, string[]> ChoiceOptionsMap = new()
+    {
+        ["KeywordCasing"] = ["Uppercase", "Lowercase", "PascalCase"],
+        ["SqlVersion"] = ["80", "90", "100", "110", "120", "130", "140", "150", "160", "170"],
+    };
+
+    private void LoadSettings()
+    {
+        var current = SqlFormatSettingsService.Load(out var loadError);
+        if (loadError != null)
+            ShowErrorPopup("Load Error", loadError);
+        _rows.Clear();
+
+        var props = typeof(SqlFormatSettings).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .ToDictionary(p => p.Name);
+
+        foreach (var name in PropertyOrder)
+        {
+            if (!props.TryGetValue(name, out var prop))
+                continue;
+
+            var currentVal = prop.GetValue(current);
+            var defaultVal = prop.GetValue(_defaults);
+            var isBool = prop.PropertyType == typeof(bool);
+
+            ChoiceOptionsMap.TryGetValue(prop.Name, out var choiceOptions);
+
+            _rows.Add(new FormatOptionRow
+            {
+                Name = prop.Name,
+                CurrentValue = currentVal?.ToString() ?? "",
+                DefaultValue = defaultVal?.ToString() ?? "",
+                IsBool = isBool,
+                BoolValue = isBool && currentVal is true,
+                DefaultBoolValue = isBool && defaultVal is true,
+                ChoiceOptions = choiceOptions,
+                PropertyInfo = prop
+            });
+        }
+
+        OptionsGrid.ItemsSource = _rows;
+
+        // Track changes for dirty-state prompt
+        foreach (var row in _rows)
+            row.PropertyChanged += (_, _) => _isDirty = true;
+    }
+
+    private void Save_Click(object? sender, RoutedEventArgs e)
+    {
+        var settings = new SqlFormatSettings();
+
+        foreach (var row in _rows)
+        {
+            try
+            {
+                var prop = row.PropertyInfo;
+                object? value;
+
+                if (prop.PropertyType == typeof(bool))
+                    value = row.BoolValue;
+                else if (prop.PropertyType == typeof(int))
+                {
+                    if (!int.TryParse(row.CurrentValue, out var intVal))
+                    {
+                        Debug.WriteLine($"FormatOptions: invalid int value '{row.CurrentValue}' for {row.Name}, using default");
+                        continue;
+                    }
+                    value = intVal;
+                }
+                else
+                    value = row.CurrentValue;
+
+                prop.SetValue(settings, value);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"FormatOptions: failed to set {row.Name}: {ex.Message}");
+            }
+        }
+
+        if (!SqlFormatSettingsService.Save(settings, out var saveError))
+        {
+            ShowErrorPopup("Save Error", saveError!);
+            return;
+        }
+        _isDirty = false;
+        Close();
+    }
+
+    private void Revert_Click(object? sender, RoutedEventArgs e)
+    {
+        foreach (var row in _rows)
+        {
+            row.CurrentValue = row.DefaultValue;
+            if (row.IsBool)
+                row.BoolValue = row.DefaultBoolValue;
+        }
+    }
+
+    private void ShowErrorPopup(string title, string message)
+    {
+        var dialog = new Window
+        {
+            Title = title,
+            Width = 480,
+            Height = 220,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            Background = (IBrush)this.FindResource("BackgroundBrush")!,
+            Foreground = (IBrush)this.FindResource("ForegroundBrush")!,
+            Content = new StackPanel
+            {
+                Margin = new Avalonia.Thickness(20),
+                Children =
+                {
+                    new TextBlock
+                    {
+                        Text = message,
+                        TextWrapping = TextWrapping.Wrap,
+                        FontSize = 13
+                    }
+                }
+            }
+        };
+        dialog.ShowDialog(this);
+    }
+
+    private void Close_Click(object? sender, RoutedEventArgs e)
+    {
+        TryClose();
+    }
+
+    protected override void OnClosing(WindowClosingEventArgs e)
+    {
+        if (_isDirty)
+        {
+            e.Cancel = true;
+            TryClose();
+            return;
+        }
+        base.OnClosing(e);
+    }
+
+    private async void TryClose()
+    {
+        if (!_isDirty)
+        {
+            _isDirty = false; // prevent re-entry
+            Close();
+            return;
+        }
+
+        var result = await ShowDiscardDialog();
+        if (result)
+        {
+            _isDirty = false;
+            Close();
+        }
+    }
+
+    private async Task<bool> ShowDiscardDialog()
+    {
+        var tcs = new TaskCompletionSource<bool>();
+
+        var dialog = new Window
+        {
+            Title = "Unsaved Changes",
+            Width = 360,
+            Height = 160,
+            MinWidth = 360,
+            MinHeight = 160,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            Background = (IBrush)this.FindResource("BackgroundBrush")!,
+            Foreground = (IBrush)this.FindResource("ForegroundBrush")!,
+            Content = new StackPanel
+            {
+                Margin = new Avalonia.Thickness(20),
+                Children =
+                {
+                    new TextBlock
+                    {
+                        Text = "You have unsaved changes. Discard them?",
+                        FontSize = 13,
+                        TextWrapping = TextWrapping.Wrap,
+                        Margin = new Avalonia.Thickness(0, 0, 0, 16)
+                    }
+                }
+            }
+        };
+
+        var discardBtn = new Button
+        {
+            Content = "Discard",
+            Height = 32, Width = 90,
+            Padding = new Avalonia.Thickness(16, 0),
+            FontSize = 12,
+            HorizontalContentAlignment = Avalonia.Layout.HorizontalAlignment.Center,
+            VerticalContentAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            Theme = (Avalonia.Styling.ControlTheme)this.FindResource("AppButton")!
+        };
+
+        var cancelBtn = new Button
+        {
+            Content = "Cancel",
+            Height = 32, Width = 90,
+            Padding = new Avalonia.Thickness(16, 0),
+            FontSize = 12,
+            Margin = new Avalonia.Thickness(8, 0, 0, 0),
+            HorizontalContentAlignment = Avalonia.Layout.HorizontalAlignment.Center,
+            VerticalContentAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            Theme = (Avalonia.Styling.ControlTheme)this.FindResource("AppButton")!
+        };
+
+        var buttonPanel = new StackPanel
+        {
+            Orientation = Avalonia.Layout.Orientation.Horizontal,
+            HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Right
+        };
+        buttonPanel.Children.Add(discardBtn);
+        buttonPanel.Children.Add(cancelBtn);
+
+        ((StackPanel)dialog.Content!).Children.Add(buttonPanel);
+
+        discardBtn.Click += (_, _) => { tcs.TrySetResult(true); dialog.Close(); };
+        cancelBtn.Click += (_, _) => { tcs.TrySetResult(false); dialog.Close(); };
+        dialog.Closing += (_, _) => tcs.TrySetResult(false);
+
+        await dialog.ShowDialog(this);
+        return await tcs.Task;
+    }
+}
+
+public class FormatOptionRow : INotifyPropertyChanged
+{
+    private string _currentValue = "";
+    private bool _boolValue;
+
+    public string Name { get; set; } = "";
+
+    public bool IsBool { get; set; }
+
+    public bool BoolValue
+    {
+        get => _boolValue;
+        set
+        {
+            _boolValue = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(BoolValue)));
+            // Keep CurrentValue in sync for serialization
+            if (IsBool)
+            {
+                _currentValue = value.ToString();
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CurrentValue)));
+            }
+        }
+    }
+
+    public bool DefaultBoolValue { get; set; }
+
+    public string[]? ChoiceOptions { get; set; }
+
+    public bool IsChoice => ChoiceOptions != null;
+
+    public bool IsText => !IsBool && !IsChoice;
+
+    public string CurrentValue
+    {
+        get => _currentValue;
+        set
+        {
+            _currentValue = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CurrentValue)));
+        }
+    }
+
+    public string DefaultValue { get; set; } = "";
+
+    internal PropertyInfo PropertyInfo { get; set; } = null!;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+}

--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -6,7 +6,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>EDD.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="ModelContextProtocol" Version="0.7.0-preview.1" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.7.0-preview.1" />
     <PackageReference Include="TextMateSharp.Grammars" Version="2.0.3" />
+    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="170.191.0" />
     <PackageReference Include="Velopack" Version="0.0.1298" />
 
     <!-- Pin SkiaSharp native assets to match SkiaSharp 3.119.0.

--- a/src/PlanViewer.App/Services/SqlFormatSettingsService.cs
+++ b/src/PlanViewer.App/Services/SqlFormatSettingsService.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+
+namespace PlanViewer.App.Services;
+
+/// <summary>
+/// Formatting options that map to <see cref="SqlScriptGeneratorOptions"/> properties.
+/// Persisted as a JSON file in the app's local data directory.
+/// </summary>
+public sealed class SqlFormatSettings
+{
+    public bool AlignClauseBodies { get; set; } = true;
+    public bool AlignColumnDefinitionFields { get; set; } = true;
+    public bool AlignSetClauseItem { get; set; } = true;
+    public bool AsKeywordOnOwnLine { get; set; } = true;
+    public bool IncludeSemicolons { get; set; } = false;
+    public bool IndentSetClause { get; set; } = false;
+    public bool IndentViewBody { get; set; } = false;
+    public int IndentationSize { get; set; } = 4;
+    public string KeywordCasing { get; set; } = "Uppercase";
+    public bool MultilineInsertSourcesList { get; set; } = true;
+    public bool MultilineInsertTargetsList { get; set; } = true;
+    public bool MultilineSelectElementsList { get; set; } = true;
+    public bool MultilineSetClauseItems { get; set; } = true;
+    public bool MultilineViewColumnsList { get; set; } = true;
+    public bool MultilineWherePredicatesList { get; set; } = true;
+    public bool NewLineBeforeCloseParenthesisInMultilineList { get; set; } = true;
+    public bool NewLineBeforeFromClause { get; set; } = true;
+    public bool NewLineBeforeGroupByClause { get; set; } = true;
+    public bool NewLineBeforeHavingClause { get; set; } = true;
+    public bool NewLineBeforeJoinClause { get; set; } = true;
+    public bool NewLineBeforeOffsetClause { get; set; } = true;
+    public bool NewLineBeforeOpenParenthesisInMultilineList { get; set; } = false;
+    public bool NewLineBeforeOrderByClause { get; set; } = true;
+    public bool NewLineBeforeOutputClause { get; set; } = true;
+    public bool NewLineBeforeWhereClause { get; set; } = true;
+    public bool NewLineBeforeWindowClause { get; set; } = true;
+    public int SqlVersion { get; set; } = 170;
+
+    /// <summary>
+    /// Applies these settings to a <see cref="SqlScriptGeneratorOptions"/> instance.
+    /// </summary>
+    public SqlScriptGeneratorOptions ToGeneratorOptions()
+    {
+        var opts = new SqlScriptGeneratorOptions
+        {
+            AlignClauseBodies = AlignClauseBodies,
+            AlignColumnDefinitionFields = AlignColumnDefinitionFields,
+            AlignSetClauseItem = AlignSetClauseItem,
+            AsKeywordOnOwnLine = AsKeywordOnOwnLine,
+            IncludeSemicolons = IncludeSemicolons,
+            IndentSetClause = IndentSetClause,
+            IndentViewBody = IndentViewBody,
+            IndentationSize = IndentationSize,
+            KeywordCasing = Enum.TryParse<Microsoft.SqlServer.TransactSql.ScriptDom.KeywordCasing>(KeywordCasing, true, out var kc)
+                            && Enum.IsDefined(kc)
+                            ? kc : Microsoft.SqlServer.TransactSql.ScriptDom.KeywordCasing.Uppercase,
+            MultilineInsertSourcesList = MultilineInsertSourcesList,
+            MultilineInsertTargetsList = MultilineInsertTargetsList,
+            MultilineSelectElementsList = MultilineSelectElementsList,
+            MultilineSetClauseItems = MultilineSetClauseItems,
+            MultilineViewColumnsList = MultilineViewColumnsList,
+            MultilineWherePredicatesList = MultilineWherePredicatesList,
+            NewLineBeforeCloseParenthesisInMultilineList = NewLineBeforeCloseParenthesisInMultilineList,
+            NewLineBeforeFromClause = NewLineBeforeFromClause,
+            NewLineBeforeGroupByClause = NewLineBeforeGroupByClause,
+            NewLineBeforeHavingClause = NewLineBeforeHavingClause,
+            NewLineBeforeJoinClause = NewLineBeforeJoinClause,
+            NewLineBeforeOffsetClause = NewLineBeforeOffsetClause,
+            NewLineBeforeOpenParenthesisInMultilineList = NewLineBeforeOpenParenthesisInMultilineList,
+            NewLineBeforeOrderByClause = NewLineBeforeOrderByClause,
+            NewLineBeforeOutputClause = NewLineBeforeOutputClause,
+            NewLineBeforeWhereClause = NewLineBeforeWhereClause,
+            NewLineBeforeWindowClause = NewLineBeforeWindowClause,
+        };
+
+        return opts;
+    }
+}
+
+/// <summary>
+/// Loads and saves <see cref="SqlFormatSettings"/> to a local JSON file.
+/// </summary>
+internal static class SqlFormatSettingsService
+{
+    private static readonly string SettingsDir = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "PerformanceStudio");
+
+    private static readonly string SettingsPath = Path.Combine(SettingsDir, "perfstudio_format_settings.json");
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    public static SqlFormatSettings Load(out string? error)
+    {
+        error = null;
+        try
+        {
+            if (!File.Exists(SettingsPath))
+                return new SqlFormatSettings();
+
+            var json = File.ReadAllText(SettingsPath);
+            return JsonSerializer.Deserialize<SqlFormatSettings>(json, JsonOptions) ?? new SqlFormatSettings();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"SqlFormatSettings: failed to load settings: {ex.Message}");
+            error = $"Could not load format settings from:\n{SettingsPath}\n\n{ex.Message}\n\nUsing defaults. Delete or fix the file to clear this error.";
+            return new SqlFormatSettings();
+        }
+    }
+
+    public static bool Save(SqlFormatSettings settings, out string? error)
+    {
+        error = null;
+        try
+        {
+            Directory.CreateDirectory(SettingsDir);
+            var json = JsonSerializer.Serialize(settings, JsonOptions);
+            File.WriteAllText(SettingsPath, json);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"SqlFormatSettings: failed to save settings: {ex.Message}");
+            error = $"Could not save format settings to:\n{SettingsPath}\n\n{ex.Message}\n\nCheck that the folder is writable and not locked by another process.";
+            return false;
+        }
+    }
+}

--- a/src/PlanViewer.App/Services/SqlFormattingService.cs
+++ b/src/PlanViewer.App/Services/SqlFormattingService.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+
+namespace PlanViewer.App.Services;
+
+/// <summary>
+/// Formats T-SQL text using Microsoft.SqlServer.TransactSql.ScriptDom.
+/// Inspired by https://github.com/madskristensen/SqlFormatter (MIT license).
+/// </summary>
+internal static class SqlFormattingService
+{
+    /// <summary>
+    /// Formats the given T-SQL text. Returns the formatted text, or the original text
+    /// with an error message if parsing fails.
+    /// </summary>
+    public static (string formattedText, IList<ParseError>? errors) Format(string sql, SqlFormatSettings? settings = null)
+    {
+        settings ??= new SqlFormatSettings();
+
+        var parser = GetParser(settings.SqlVersion);
+
+        using var reader = new StringReader(sql);
+        var fragment = parser.Parse(reader, out var errors);
+
+        if (fragment == null)
+            return (sql, errors);
+
+        var generator = GetGenerator(settings);
+        generator.GenerateScript(fragment, out var formatted);
+
+        // Return any non-fatal parse errors alongside the formatted output
+        var hasErrors = errors != null && errors.Count > 0;
+        return (formatted, hasErrors ? errors : null);
+    }
+
+    private static TSqlParser GetParser(int version)
+    {
+        return version switch
+        {
+            80 => new TSql80Parser(true),
+            90 => new TSql90Parser(true),
+            100 => new TSql100Parser(true),
+            110 => new TSql110Parser(true),
+            120 => new TSql120Parser(true),
+            130 => new TSql130Parser(true),
+            140 => new TSql140Parser(true),
+            150 => new TSql150Parser(true),
+            160 => new TSql160Parser(true),
+            _ => new TSql170Parser(true),
+        };
+    }
+
+    private static SqlScriptGenerator GetGenerator(SqlFormatSettings settings)
+    {
+        var options = settings.ToGeneratorOptions();
+
+        return settings.SqlVersion switch
+        {
+            80 => new Sql80ScriptGenerator(options),
+            90 => new Sql90ScriptGenerator(options),
+            100 => new Sql100ScriptGenerator(options),
+            110 => new Sql110ScriptGenerator(options),
+            120 => new Sql120ScriptGenerator(options),
+            130 => new Sql130ScriptGenerator(options),
+            140 => new Sql140ScriptGenerator(options),
+            150 => new Sql150ScriptGenerator(options),
+            160 => new Sql160ScriptGenerator(options),
+            _ => new Sql170ScriptGenerator(options),
+        };
+    }
+}

--- a/src/PlanViewer.App/Themes/DarkTheme.axaml
+++ b/src/PlanViewer.App/Themes/DarkTheme.axaml
@@ -8,6 +8,13 @@
     <SolidColorBrush x:Key="BorderBrush" Color="#3A3D45"/>
     <SolidColorBrush x:Key="AccentBrush" Color="#2eaef1"/>
 
+    <!-- Fluent theme accent override: TabItem selected underline, focus rings, etc. -->
+    <Color x:Key="SystemAccentColor">#2eaef1</Color>
+    <Color x:Key="SystemAccentColorDark1">#2596d4</Color>
+    <Color x:Key="SystemAccentColorDark2">#1f80b6</Color>
+    <Color x:Key="SystemAccentColorLight1">#5bc0f4</Color>
+    <Color x:Key="SystemAccentColorLight2">#88d1f7</Color>
+
     <!-- Button style: brand blue on hover -->
     <ControlTheme x:Key="AppButton" TargetType="Button">
         <Setter Property="Background" Value="{DynamicResource BackgroundLightBrush}"/>
@@ -67,7 +74,7 @@
     <!-- Wait Stats category colors (fixed per category) -->
     <SolidColorBrush x:Key="WaitCategory.Unknown"            Color="#8E8E93"/>
     <SolidColorBrush x:Key="WaitCategory.CPU"                Color="#00bd23"/>
-    <SolidColorBrush x:Key="WaitCategory.Worker Thread"      Color="#19ff25"/>
+    <SolidColorBrush x:Key="WaitCategory.Worker Thread"      Color="#52E3B5"/>
     <SolidColorBrush x:Key="WaitCategory.Lock"               Color="#EE5A24"/>
     <SolidColorBrush x:Key="WaitCategory.Latch"              Color="#F368E0"/>
     <SolidColorBrush x:Key="WaitCategory.Buffer Latch"       Color="#f5069e"/>
@@ -80,7 +87,7 @@
     <SolidColorBrush x:Key="WaitCategory.Service Broker"     Color="#E17055"/>
     <SolidColorBrush x:Key="WaitCategory.Tran Log IO"        Color="#0984E3"/>
     <SolidColorBrush x:Key="WaitCategory.Network IO"         Color="#75bbf8"/>
-    <SolidColorBrush x:Key="WaitCategory.Parallelism"        Color="#fd01d3"/>
+    <SolidColorBrush x:Key="WaitCategory.Parallelism"        Color="#7B4FFF"/>
     <SolidColorBrush x:Key="WaitCategory.Memory"             Color="#FDCB6E"/>
     <SolidColorBrush x:Key="WaitCategory.Tracing"            Color="#B2BEC3"/>
     <SolidColorBrush x:Key="WaitCategory.Full Text Search"   Color="#DFE6E9"/>

--- a/src/PlanViewer.Core/Models/ServerConnection.cs
+++ b/src/PlanViewer.Core/Models/ServerConnection.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Text.Json.Serialization;
 using Microsoft.Data.SqlClient;
 using PlanViewer.Core.Interfaces;


### PR DESCRIPTION
## v1.6.0 Release

### Highlights
- **Wait stats benefit scoring (Stage 2 of #215)** — wait stats now contribute to the max-benefit calculation in PlanAnalyzer findings
- **CPU:Elapsed ratio** replaces the old parallelism-efficiency warnings for clearer parallel-plan diagnosis
- **SQL Formatter** in the Query Editor (#238) with persistent format options (parameters dialog, async formatting, parse-error popup)
- **Query Store group-by changer** (#218) — group plans by QueryHash or Module, with auto-expand, golden headers, and reordered columns
- **Built-in analytics** for PlanShare and stats dashboard
- **Joe's plan-review feedback** — false-positive fixes, improved messaging, Rule 34 narrowing, Serial Plan / adaptive join math, MAXDOP 1 wording, Scalar UDF redundancy, parallel-skew + key-lookup NL join scoring

### Other
- PlanViewer toolbars / Query Store headers / tab accent polish
- Query Editor no longer loses syntax highlighting on tab switch (#234)
- Auto-scrolling improvements (#225, thanks @ClaudioESSilva)
- Wait-stats benefit wired into the web plan viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)