### PR TITLE
Render benefit % and actionable fix in all warning surfaces (v1.7.1)

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -1754,6 +1754,18 @@ public partial class PlanViewerControl : UserControl
                         TextWrapping = TextWrapping.Wrap,
                         Margin = new Thickness(16, 0, 0, 0)
                     });
+                    if (!string.IsNullOrEmpty(w.ActionableFix))
+                    {
+                        warnPanel.Children.Add(new TextBlock
+                        {
+                            Text = w.ActionableFix,
+                            FontSize = 11,
+                            FontStyle = FontStyle.Italic,
+                            Foreground = TooltipFgBrush,
+                            TextWrapping = TextWrapping.Wrap,
+                            Margin = new Thickness(16, 2, 0, 0)
+                        });
+                    }
                     planWarningsPanel.Children.Add(warnPanel);
                 }
 

--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -6,7 +6,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>EDD.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>1.7.0</Version>
+    <Version>1.7.1</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Core/Output/HtmlExporter.cs
+++ b/src/PlanViewer.Core/Output/HtmlExporter.cs
@@ -187,6 +187,7 @@ pre.mi-create {
 .warn-type { font-size: 0.75rem; font-weight: 600; }
 .warn-benefit { font-size: 0.7rem; font-weight: 600; color: var(--text-muted); padding: 0.05rem 0.3rem; border-radius: 3px; background: rgba(0,0,0,0.04); }
 .warn-msg { font-size: 0.8rem; color: var(--text); flex-basis: 100%; }
+.warn-fix { font-size: 0.75rem; color: var(--text-secondary); font-style: italic; flex-basis: 100%; border-left: 2px solid var(--border); padding-left: 0.5rem; margin-top: 0.15rem; }
 
 /* Query text */
 details { margin-bottom: 0.75rem; }
@@ -459,6 +460,8 @@ pre.query-text, pre.text-output {
             if (w.MaxBenefitPercent.HasValue)
                 sb.AppendLine($"<span class=\"warn-benefit\">up to {w.MaxBenefitPercent:N0}% benefit</span>");
             sb.AppendLine($"<span class=\"warn-msg\">{Encode(w.Message)}</span>");
+            if (!string.IsNullOrEmpty(w.ActionableFix))
+                sb.AppendLine($"<span class=\"warn-fix\">{Encode(w.ActionableFix)}</span>");
             sb.AppendLine("</div>");
         }
         sb.AppendLine("</div>");

--- a/src/PlanViewer.Core/Output/TextFormatter.cs
+++ b/src/PlanViewer.Core/Output/TextFormatter.cs
@@ -172,6 +172,8 @@ public static class TextFormatter
                         ? $" (up to {w.MaxBenefitPercent:N0}% benefit)"
                         : "";
                     writer.WriteLine($"  [{w.Severity}] {w.Type}{benefitTag}: {EscapeNewlines(w.Message)}");
+                    if (!string.IsNullOrEmpty(w.ActionableFix))
+                        writer.WriteLine($"    Fix: {EscapeNewlines(w.ActionableFix)}");
                 }
             }
 

--- a/src/PlanViewer.Web/Pages/Index.razor
+++ b/src/PlanViewer.Web/Pages/Index.razor
@@ -332,7 +332,10 @@ else
                 @if (infoCount > 0) { <span class="warn-count-badge info">@infoCount</span> }
             </h4>
             <div class="warnings-list">
-                @foreach (var w in GetAllWarnings(ActiveStmt!))
+                @foreach (var w in GetAllWarnings(ActiveStmt!)
+                    .OrderByDescending(x => x.MaxBenefitPercent ?? -1)
+                    .ThenByDescending(x => x.Severity == "Critical" ? 3 : x.Severity == "Warning" ? 2 : 1)
+                    .ThenBy(x => x.Type))
                 {
                     <div class="warning @w.Severity.ToLower()">
                         <span class="severity">@w.Severity</span>
@@ -341,7 +344,15 @@ else
                             <span class="warning-op">@w.Operator</span>
                         }
                         <span class="warning-type">@w.Type</span>
+                        @if (w.MaxBenefitPercent.HasValue)
+                        {
+                            <span class="warn-benefit">up to @w.MaxBenefitPercent.Value.ToString("N0")% benefit</span>
+                        }
                         <span class="warning-msg">@w.Message</span>
+                        @if (!string.IsNullOrEmpty(w.ActionableFix))
+                        {
+                            <span class="warning-fix">@w.ActionableFix</span>
+                        }
                     </div>
                 }
             </div>

--- a/src/PlanViewer.Web/wwwroot/css/app.css
+++ b/src/PlanViewer.Web/wwwroot/css/app.css
@@ -807,6 +807,26 @@ textarea::placeholder {
     font-size: 0.75rem;
 }
 
+.warn-benefit {
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    padding: 0.05rem 0.35rem;
+    border-radius: 3px;
+    background: rgba(0, 0, 0, 0.05);
+    margin-right: 0.4rem;
+}
+
+.warning-fix {
+    color: var(--text-secondary);
+    display: block;
+    margin-top: 0.25rem;
+    font-size: 0.75rem;
+    font-style: italic;
+    border-left: 2px solid var(--border);
+    padding-left: 0.5rem;
+}
+
 /* === Query Text === */
 .stmt-text-section {
     margin-bottom: 0.75rem;


### PR DESCRIPTION
## Summary
Web viewer warnings strip was dropping \`MaxBenefitPercent\` and \`ActionableFix\` from every warning — the data flowed through \`ResultMapper\` into the JSON but the strip only rendered Severity/Type/Message. Joe caught the missing benefit % on v1.7.0 wait warnings.

Fixed the strip plus the same \`ActionableFix\` gap in the other surfaces that were already showing benefit (HTML export, Avalonia, plain text).

## Changes
- **Web viewer** (`Index.razor` + `app.css`): `.warn-benefit` badge + italic `.warning-fix` block. Strip now sorts by benefit desc, then severity, then type — matches HTML export and Avalonia.
- **HTML exporter**: appends `.warn-fix` block after `.warn-msg`.
- **Avalonia** (`PlanViewerControl`): italic TextBlock under the message when `ActionableFix` is present.
- **Text formatter**: indented \`Fix:\` line after each warning.
- **Version**: 1.7.0 → 1.7.1.

## Test plan
- [x] Text output verified — wait warnings now show \`(up to N% benefit)\` and \`Fix:\` line
- [ ] Web viewer visual check after deploy
- [ ] Avalonia Plan Warnings expander visual check after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)