### PR TITLE
Release v1.7.1 — render benefit % and actionable fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,20 +46,17 @@ jobs:
           gh release create "v${{ steps.version.outputs.VERSION }}" --title "v${{ steps.version.outputs.VERSION }}" --generate-notes --target main
 
       - name: Setup .NET 8.0
-        if: steps.check.outputs.EXISTS == 'false'
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
 
       - name: Build and test
-        if: steps.check.outputs.EXISTS == 'false'
         run: |
           dotnet restore
           dotnet build -c Release
           dotnet test tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj -c Release --no-build --verbosity normal
 
       - name: Publish App (all platforms)
-        if: steps.check.outputs.EXISTS == 'false'
         run: |
           dotnet publish src/PlanViewer.App/PlanViewer.App.csproj -c Release -r win-x64 --self-contained -o publish/win-x64
           dotnet publish src/PlanViewer.App/PlanViewer.App.csproj -c Release -r linux-x64 --self-contained -o publish/linux-x64
@@ -68,7 +65,6 @@ jobs:
 
       # ── SignPath code signing (Windows only, skipped if secret not configured) ──
       - name: Check if signing is configured
-        if: steps.check.outputs.EXISTS == 'false'
         id: signing
         shell: bash
         run: |
@@ -80,7 +76,7 @@ jobs:
           fi
 
       - name: Upload Windows build for signing
-        if: steps.check.outputs.EXISTS == 'false' && steps.signing.outputs.ENABLED == 'true'
+        if: steps.signing.outputs.ENABLED == 'true'
         id: upload-unsigned
         uses: actions/upload-artifact@v4
         with:
@@ -88,7 +84,7 @@ jobs:
           path: publish/win-x64/
 
       - name: Sign Windows build
-        if: steps.check.outputs.EXISTS == 'false' && steps.signing.outputs.ENABLED == 'true'
+        if: steps.signing.outputs.ENABLED == 'true'
         uses: signpath/github-action-submit-signing-request@v1
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
@@ -101,7 +97,7 @@ jobs:
           output-artifact-directory: 'signed/win-x64'
 
       - name: Replace unsigned Windows build with signed
-        if: steps.check.outputs.EXISTS == 'false' && steps.signing.outputs.ENABLED == 'true'
+        if: steps.signing.outputs.ENABLED == 'true'
         shell: pwsh
         run: |
           Remove-Item -Recurse -Force publish/win-x64
@@ -109,7 +105,6 @@ jobs:
 
       # ── Velopack (uses signed Windows binaries) ───────────────────────
       - name: Create Velopack release (Windows)
-        if: steps.check.outputs.EXISTS == 'false'
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -126,7 +121,6 @@ jobs:
 
       # ── Package and upload ────────────────────────────────────────────
       - name: Package and upload
-        if: steps.check.outputs.EXISTS == 'false'
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -1754,6 +1754,18 @@ public partial class PlanViewerControl : UserControl
                         TextWrapping = TextWrapping.Wrap,
                         Margin = new Thickness(16, 0, 0, 0)
                     });
+                    if (!string.IsNullOrEmpty(w.ActionableFix))
+                    {
+                        warnPanel.Children.Add(new TextBlock
+                        {
+                            Text = w.ActionableFix,
+                            FontSize = 11,
+                            FontStyle = FontStyle.Italic,
+                            Foreground = TooltipFgBrush,
+                            TextWrapping = TextWrapping.Wrap,
+                            Margin = new Thickness(16, 2, 0, 0)
+                        });
+                    }
                     planWarningsPanel.Children.Add(warnPanel);
                 }
 

--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -6,7 +6,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>EDD.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>1.7.0</Version>
+    <Version>1.7.1</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Core/Output/HtmlExporter.cs
+++ b/src/PlanViewer.Core/Output/HtmlExporter.cs
@@ -187,6 +187,7 @@ pre.mi-create {
 .warn-type { font-size: 0.75rem; font-weight: 600; }
 .warn-benefit { font-size: 0.7rem; font-weight: 600; color: var(--text-muted); padding: 0.05rem 0.3rem; border-radius: 3px; background: rgba(0,0,0,0.04); }
 .warn-msg { font-size: 0.8rem; color: var(--text); flex-basis: 100%; }
+.warn-fix { font-size: 0.75rem; color: var(--text-secondary); font-style: italic; flex-basis: 100%; border-left: 2px solid var(--border); padding-left: 0.5rem; margin-top: 0.15rem; }
 
 /* Query text */
 details { margin-bottom: 0.75rem; }
@@ -459,6 +460,8 @@ pre.query-text, pre.text-output {
             if (w.MaxBenefitPercent.HasValue)
                 sb.AppendLine($"<span class=\"warn-benefit\">up to {w.MaxBenefitPercent:N0}% benefit</span>");
             sb.AppendLine($"<span class=\"warn-msg\">{Encode(w.Message)}</span>");
+            if (!string.IsNullOrEmpty(w.ActionableFix))
+                sb.AppendLine($"<span class=\"warn-fix\">{Encode(w.ActionableFix)}</span>");
             sb.AppendLine("</div>");
         }
         sb.AppendLine("</div>");

--- a/src/PlanViewer.Core/Output/TextFormatter.cs
+++ b/src/PlanViewer.Core/Output/TextFormatter.cs
@@ -172,6 +172,8 @@ public static class TextFormatter
                         ? $" (up to {w.MaxBenefitPercent:N0}% benefit)"
                         : "";
                     writer.WriteLine($"  [{w.Severity}] {w.Type}{benefitTag}: {EscapeNewlines(w.Message)}");
+                    if (!string.IsNullOrEmpty(w.ActionableFix))
+                        writer.WriteLine($"    Fix: {EscapeNewlines(w.ActionableFix)}");
                 }
             }
 

--- a/src/PlanViewer.Web/Pages/Index.razor
+++ b/src/PlanViewer.Web/Pages/Index.razor
@@ -332,7 +332,10 @@ else
                 @if (infoCount > 0) { <span class="warn-count-badge info">@infoCount</span> }
             </h4>
             <div class="warnings-list">
-                @foreach (var w in GetAllWarnings(ActiveStmt!))
+                @foreach (var w in GetAllWarnings(ActiveStmt!)
+                    .OrderByDescending(x => x.MaxBenefitPercent ?? -1)
+                    .ThenByDescending(x => x.Severity == "Critical" ? 3 : x.Severity == "Warning" ? 2 : 1)
+                    .ThenBy(x => x.Type))
                 {
                     <div class="warning @w.Severity.ToLower()">
                         <span class="severity">@w.Severity</span>
@@ -341,7 +344,15 @@ else
                             <span class="warning-op">@w.Operator</span>
                         }
                         <span class="warning-type">@w.Type</span>
+                        @if (w.MaxBenefitPercent.HasValue)
+                        {
+                            <span class="warn-benefit">up to @w.MaxBenefitPercent.Value.ToString("N0")% benefit</span>
+                        }
                         <span class="warning-msg">@w.Message</span>
+                        @if (!string.IsNullOrEmpty(w.ActionableFix))
+                        {
+                            <span class="warning-fix">@w.ActionableFix</span>
+                        }
                     </div>
                 }
             </div>

--- a/src/PlanViewer.Web/wwwroot/css/app.css
+++ b/src/PlanViewer.Web/wwwroot/css/app.css
@@ -807,6 +807,26 @@ textarea::placeholder {
     font-size: 0.75rem;
 }
 
+.warn-benefit {
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    padding: 0.05rem 0.35rem;
+    border-radius: 3px;
+    background: rgba(0, 0, 0, 0.05);
+    margin-right: 0.4rem;
+}
+
+.warning-fix {
+    color: var(--text-secondary);
+    display: block;
+    margin-top: 0.25rem;
+    font-size: 0.75rem;
+    font-style: italic;
+    border-left: 2px solid var(--border);
+    padding-left: 0.5rem;
+}
+
 /* === Query Text === */
 .stmt-text-section {
     margin-bottom: 0.75rem;


### PR DESCRIPTION
## Summary
Hotfix for the rendering gap Joe spotted on v1.7.0: the web warnings strip was dropping \`MaxBenefitPercent\` and \`ActionableFix\`. Fixed that, closed the same \`ActionableFix\` gap on HTML export / Avalonia / plain text, plus the idempotent-rerun workflow fix from PR #246.

See PR #247 and PR #246 for details.

## Test plan
- [x] Text output verified locally — benefit + Fix both present
- [ ] Web viewer visual check post-deploy
- [ ] Avalonia Plan Warnings expander visual check post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)