### PR TITLE
fix: XSS, DPAPI scope, rate-limiter eviction (bug-bash batch 1)

### DIFF
--- a/server/PlanShare/Program.cs
+++ b/server/PlanShare/Program.cs
@@ -44,8 +44,14 @@ using (var conn = new SqliteConnection(connectionString))
     cmd.ExecuteNonQuery();
 }
 
+// --- Rate limiters (in-memory) ---
+// Created before Build() so they can be DI-registered and swept by CleanupService.
+var rateLimiter = new RateLimiter(maxRequests: 10, windowSeconds: 60);
+var analyticsRateLimiter = new RateLimiter(maxRequests: 30, windowSeconds: 60);
+
 // Register the cleanup background service
 builder.Services.AddSingleton(new PlanDbConfig(connectionString));
+builder.Services.AddSingleton(new RateLimiters(rateLimiter, analyticsRateLimiter));
 builder.Services.AddHostedService<CleanupService>();
 
 // Request size limit (10 MB)
@@ -53,10 +59,6 @@ builder.WebHost.ConfigureKestrel(o => o.Limits.MaxRequestBodySize = 10 * 1024 * 
 
 var app = builder.Build();
 app.UseCors();
-
-// --- Rate limiters (in-memory) ---
-var rateLimiter = new RateLimiter(maxRequests: 10, windowSeconds: 60);
-var analyticsRateLimiter = new RateLimiter(maxRequests: 30, windowSeconds: 60);
 
 const int MaxTtlDays = 365;
 
@@ -161,9 +163,15 @@ app.MapPost("/api/event", async (HttpContext ctx) =>
         return Results.BadRequest("Invalid JSON");
     }
 
-    // Strip referrer to domain only (no full URLs with query params)
-    if (!string.IsNullOrEmpty(referrer) && Uri.TryCreate(referrer, UriKind.Absolute, out var refUri))
-        referrer = refUri.Host;
+    // Strip referrer to domain only (no full URLs with query params).
+    // If it doesn't parse as an absolute URL, drop it — never persist raw
+    // client-supplied strings, since the dashboard renders referrers in HTML.
+    if (!string.IsNullOrEmpty(referrer))
+    {
+        referrer = Uri.TryCreate(referrer, UriKind.Absolute, out var refUri)
+            ? refUri.Host
+            : null;
+    }
 
     // Visitor hash: SHA256(IP + User-Agent + date) — unique per day, no PII stored
     var ua = ctx.Request.Headers.UserAgent.FirstOrDefault() ?? "";
@@ -352,14 +360,18 @@ static string GenerateDeleteToken()
 
 record PlanDbConfig(string ConnectionString);
 
+record RateLimiters(RateLimiter Share, RateLimiter Analytics);
+
 sealed class CleanupService : BackgroundService
 {
     private readonly PlanDbConfig _config;
+    private readonly RateLimiters _rateLimiters;
     private readonly ILogger<CleanupService> _logger;
 
-    public CleanupService(PlanDbConfig config, ILogger<CleanupService> logger)
+    public CleanupService(PlanDbConfig config, RateLimiters rateLimiters, ILogger<CleanupService> logger)
     {
         _config = config;
+        _rateLimiters = rateLimiters;
         _logger = logger;
     }
 
@@ -401,6 +413,14 @@ sealed class CleanupService : BackgroundService
                 if (deleted > 0)
                     _logger.LogInformation("Cleaned up {Count} old page views", deleted);
             }
+
+            // Evict stale rate-limiter keys so the dictionary doesn't grow forever.
+            var shareEvicted = _rateLimiters.Share.Sweep();
+            var analyticsEvicted = _rateLimiters.Analytics.Sweep();
+            if (shareEvicted + analyticsEvicted > 0)
+                _logger.LogInformation(
+                    "Evicted {Share} share + {Analytics} analytics rate-limit keys",
+                    shareEvicted, analyticsEvicted);
         }
         catch (Exception ex)
         {
@@ -440,5 +460,26 @@ sealed class RateLimiter
             timestamps.Add(now);
             return true;
         }
+    }
+
+    /// <summary>
+    /// Evicts keys whose timestamp lists have gone empty. Call periodically
+    /// so the dictionary doesn't grow forever across unique IPs.
+    /// Returns the number of keys evicted.
+    /// </summary>
+    public int Sweep()
+    {
+        var cutoff = DateTime.UtcNow.AddSeconds(-_windowSeconds);
+        var evicted = 0;
+        foreach (var kvp in _requests)
+        {
+            lock (kvp.Value)
+            {
+                kvp.Value.RemoveAll(t => t < cutoff);
+                if (kvp.Value.Count == 0 && _requests.TryRemove(kvp))
+                    evicted++;
+            }
+        }
+        return evicted;
     }
 }

--- a/server/PlanShare/dashboard.html
+++ b/server/PlanShare/dashboard.html
@@ -275,13 +275,28 @@
     }
     function updateReferrers() {
         var tbody = document.querySelector("#referrersTable tbody");
+        tbody.replaceChildren();
         if (!planStats || !planStats.traffic.top_referrers.length) {
-            tbody.innerHTML = "<tr><td colspan='2' style='color:#484f58'>No referrer data yet</td></tr>";
+            var tr = document.createElement("tr");
+            var td = document.createElement("td");
+            td.setAttribute("colspan", "2");
+            td.style.color = "#484f58";
+            td.textContent = "No referrer data yet";
+            tr.appendChild(td);
+            tbody.appendChild(tr);
             return;
         }
-        tbody.innerHTML = planStats.traffic.top_referrers.map(function(r) {
-            return "<tr><td>" + r.referrer + "</td><td class='num'>" + fmt(r.count) + "</td></tr>";
-        }).join("");
+        planStats.traffic.top_referrers.forEach(function(r) {
+            var tr = document.createElement("tr");
+            var tdRef = document.createElement("td");
+            tdRef.textContent = r.referrer;
+            var tdCount = document.createElement("td");
+            tdCount.className = "num";
+            tdCount.textContent = fmt(r.count);
+            tr.appendChild(tdRef);
+            tr.appendChild(tdCount);
+            tbody.appendChild(tr);
+        });
     }
     function updateCharts() {
         updateChart("starsChart", "line", {

--- a/src/PlanViewer.Core/Services/WindowsCredentialService.cs
+++ b/src/PlanViewer.Core/Services/WindowsCredentialService.cs
@@ -16,7 +16,7 @@ public class WindowsCredentialService : ICredentialService
                 userName: username,
                 secret: password,
                 comment: "planview credential",
-                persistence: CredentialPersistence.LocalMachine);
+                persistence: CredentialPersistence.Enterprise);
             return true;
         }
         catch { return false; }


### PR DESCRIPTION
## Summary

Three security / reliability fixes surfaced by a max-effort bug-bash review. Each is small, localized, verified end-to-end, and independent.

### 1. Stored XSS on the PlanShare dashboard
`server/PlanShare/dashboard.html:282` rendered `r.referrer` via `innerHTML` string-concat. `server/PlanShare/Program.cs:165` only sanitized referrers when `Uri.TryCreate` succeeded — non-URL strings flowed through raw.

**Fix (defense in depth):**
- Server now sets `referrer = null` when `TryCreate` rejects the input, so raw attacker strings never reach storage.
- Dashboard rebuilds the referrer table with `document.createElement` + `textContent`, so even any legacy row containing a hostile string can't execute.

### 2. DPAPI scope leaks SQL creds across Windows users
`WindowsCredentialService.cs:19` was saving with `CredentialPersistence.LocalMachine`, which makes the credential decryptable by any account on the same box (shared dev VMs, jump hosts, Citrix).

**Fix:** one-word change to `CredentialPersistence.Enterprise` (per-user, DPAPI-scoped, roams with the domain profile). Pre-existing `LocalMachine`-scoped credentials remain readable; next re-save migrates them.

### 3. PlanShare rate limiter grows unbounded
`server/PlanShare/Program.cs` — the `ConcurrentDictionary<string, List<DateTime>>` keyed by IP pruned per-IP timestamp lists but never evicted the *keys*. Any unique-IP traffic over time grew memory forever.

**Fix:** added `RateLimiter.Sweep()` which prunes each list and `TryRemove`s keys whose list is empty. Both limiters are DI-registered via a `RateLimiters` container; `CleanupService` invokes `Sweep()` on its existing hourly tick and logs evictions.

## Test plan

- [x] `dotnet build` on `PlanViewer.Core` and `PlanShare`: 0 errors, no new warnings.
- [x] **XSS end-to-end:** ran PlanShare locally, POSTed `<img src=x onerror=...>` and `"><script>...</script>` plus a legit URL to `/api/event`, then `GET /api/stats`. Only `good.example.com` landed in `top_referrers`; both XSS payloads dropped as expected.
- [x] **DPAPI round-trip:** `SaveCredential` → `GetCredential` → `DeleteCredential` with `Enterprise` scope and a password containing `!`, `$`, `"` — byte-for-byte match.
- [x] **Rate limiter:** 10 000 unique keys, window=1s. Fresh `Sweep()` evicted 0 (expected). Waited 1.5s, stale `Sweep()` evicted 10 000, 0 remaining. Post-sweep insert still works.

## Dropped (false positives)

Bug-bash agents flagged several that didn't survive verification; not addressing these:
- `BenefitScorer.cs:584` "ms² unit bug" — dimensionally `ms·ms/ms = ms`, math is correct.
- `BenefitScorer.cs:367-378` Key-Lookup "double counts parent NL" — `CostPercent` is own-cost, not subtree (see `ShowPlanParser.cs:1787`).
- `PlanAnalyzer.cs:863` Rule 32 "fires on ActualRows=0" — that IS the scan-caused-by-bad-CE case the rule targets.
- `QueryStoreGridControl:1231` "duplicate Click handlers accumulate" — lines 1213-1219 explicitly `-=` before `+=`.
- A handful of others (PlanShare DELETE "token leak", HKCU registry "injection", installer symlink, etc.) — detailed in the review thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)