### PR TITLE
fix: SSMS extension uses a random temp filename

### DIFF
--- a/src/PlanViewer.Ssms/AppLauncher.cs
+++ b/src/PlanViewer.Ssms/AppLauncher.cs
@@ -20,12 +20,21 @@ namespace PlanViewer.Ssms
 
         /// <summary>
         /// Saves plan XML to a temp .sqlplan file and returns the path.
+        /// Uses a cryptographically-random suffix so the filename can't be predicted
+        /// or preempted by another local process (e.g. planting a symlink at the
+        /// expected path before the write lands). FileMode.CreateNew refuses to
+        /// overwrite a pre-existing file, closing the race further.
         /// </summary>
         public static string SavePlanToTemp(string planXml)
         {
-            var fileName = $"ssms_plan_{DateTime.Now:yyyyMMdd_HHmmss}.sqlplan";
+            var suffix = Path.GetFileNameWithoutExtension(Path.GetRandomFileName());
+            var fileName = "ssms_plan_" + suffix + ".sqlplan";
             var tempPath = Path.Combine(Path.GetTempPath(), fileName);
-            File.WriteAllText(tempPath, planXml);
+            using (var fs = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+            using (var writer = new StreamWriter(fs))
+            {
+                writer.Write(planXml);
+            }
             return tempPath;
         }
 


### PR DESCRIPTION
## Summary

`PlanViewer.Ssms/AppLauncher.cs:SavePlanToTemp` was naming its temp file `ssms_plan_{yyyyMMdd_HHmmss}.sqlplan`, which is trivially predictable by any other process on the machine. Combined with `File.WriteAllText` (which follows symlinks), a same-privilege attacker could plant a symlink at the expected path and have the extension's write redirect into an arbitrary file.

## Fix

- Name becomes `ssms_plan_<random>.sqlplan` using `Path.GetRandomFileName` for the suffix.
- Open with `FileMode.CreateNew + FileShare.None` so the write refuses to land if a file already exists at that path.
- Extension stays `.sqlplan` so the app still recognizes the file type.

## Test plan

- [x] Local net8 harness (mirrors the same `System.IO` calls, which behave identically on net472/net8.0) confirms:
  - File created, content round-trips.
  - Two consecutive saves produce different filenames.
  - Filename no longer matches the old `yyyyMMdd_HHmmss` pattern.
  - `FileMode.CreateNew` throws `IOException` on a pre-existing file and the pre-existing content is preserved (the symlink-plant defense).
- [ ] CI builds the actual VSIX (local `dotnet build` can't — net472 targeting pack isn't installed on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)