### PR TITLE
fix: atomic config writes (no more truncated JSON on crash)

### DIFF
--- a/src/PlanViewer.App/AboutWindow.axaml.cs
+++ b/src/PlanViewer.App/AboutWindow.axaml.cs
@@ -56,7 +56,7 @@ public partial class AboutWindow : Window
         }, new JsonSerializerOptions { WriteIndented = true });
 
         Directory.CreateDirectory(settingsDir);
-        File.WriteAllText(settingsFile, json);
+        Services.AtomicFile.WriteAllText(settingsFile, json);
     }
 
     private void GitHubLink_Click(object? sender, PointerPressedEventArgs e) => OpenUrl(GitHubUrl);

--- a/src/PlanViewer.App/Services/AppSettingsService.cs
+++ b/src/PlanViewer.App/Services/AppSettingsService.cs
@@ -59,7 +59,7 @@ internal sealed class AppSettingsService
         {
             Directory.CreateDirectory(SettingsDir);
             var json = JsonSerializer.Serialize(settings, JsonOptions);
-            File.WriteAllText(SettingsPath, json);
+            AtomicFile.WriteAllText(SettingsPath, json);
         }
         catch
         {

--- a/src/PlanViewer.App/Services/AtomicFile.cs
+++ b/src/PlanViewer.App/Services/AtomicFile.cs
@@ -1,0 +1,27 @@
+using System.IO;
+
+namespace PlanViewer.App.Services;
+
+/// <summary>
+/// Helper for atomic text-file writes: write to a sibling .tmp and rename
+/// into place so a crash mid-write can't truncate the target file. Callers
+/// are responsible for creating the parent directory first.
+/// </summary>
+internal static class AtomicFile
+{
+    /// <summary>
+    /// Writes <paramref name="contents"/> to <paramref name="path"/> atomically
+    /// with respect to process crashes. If the process dies before the rename,
+    /// <paramref name="path"/> keeps its previous contents and a stray
+    /// <c>.tmp</c> sibling is left behind (cleaned up on the next call).
+    /// </summary>
+    public static void WriteAllText(string path, string contents)
+    {
+        var tmp = path + ".tmp";
+        File.WriteAllText(tmp, contents);
+        // File.Move with overwrite:true maps to MoveFileEx(MOVEFILE_REPLACE_EXISTING)
+        // on Windows and rename(2) on Unix — both atomic when source and destination
+        // live on the same filesystem, which is always the case here.
+        File.Move(tmp, path, overwrite: true);
+    }
+}

--- a/src/PlanViewer.App/Services/ConnectionStore.cs
+++ b/src/PlanViewer.App/Services/ConnectionStore.cs
@@ -39,7 +39,7 @@ public class ConnectionStore
     {
         Directory.CreateDirectory(ConfigDir);
         var json = JsonSerializer.Serialize(connections, JsonOptions);
-        File.WriteAllText(ConfigFile, json);
+        AtomicFile.WriteAllText(ConfigFile, json);
     }
 
     public void AddOrUpdate(ServerConnection connection)

--- a/src/PlanViewer.App/Services/SqlFormatSettingsService.cs
+++ b/src/PlanViewer.App/Services/SqlFormatSettingsService.cs
@@ -123,7 +123,7 @@ internal static class SqlFormatSettingsService
         {
             Directory.CreateDirectory(SettingsDir);
             var json = JsonSerializer.Serialize(settings, JsonOptions);
-            File.WriteAllText(SettingsPath, json);
+            AtomicFile.WriteAllText(SettingsPath, json);
             return true;
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary

All four per-user config save sites called `File.WriteAllText` directly — a process crash (power loss, kill, OOM) mid-write leaves a truncated JSON file, and on the next load the config-loaders catch the `JsonException` and silently replace the user's data with defaults. The `ConnectionStore.Save` case is the worst — entire saved-server list gone.

## Fix

New helper `Services/AtomicFile.WriteAllText`: write to a sibling `.tmp`, then rename into place with `File.Move(src, dst, overwrite: true)`, which maps to:
- **Windows**: `MoveFileEx(MOVEFILE_REPLACE_EXISTING)` — atomic on NTFS.
- **Unix**: `rename(2)` — atomic by spec.

Applied at all four save sites:
- `Services/ConnectionStore.cs` — saved server list
- `Services/AppSettingsService.cs` — recent/open plans, slicer days
- `Services/SqlFormatSettingsService.cs` — format options
- `AboutWindow.axaml.cs` — MCP enable + port

A crash between the tmp write and the rename leaves the original file intact and a stray `.tmp` behind; the next save overwrites that `.tmp` before renaming, so no manual cleanup is needed.

## Test plan

- [x] `dotnet build` on App: 0 errors.
- [x] Local harness (mirrors the helper exactly):
  - Happy path: write + overwrite round-trip ✅
  - Crash simulation: `.tmp` populated but never renamed → target preserves old contents ✅
  - Self-healing: next save cleans up the stray `.tmp` and writes target ✅
  - Control case: naive `File.WriteAllText` interrupted mid-write does truncate the file (this is the bug the fix avoids) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)