### PR TITLE
fix: CLI --password-stdin + honor handler exit codes

### DIFF
--- a/src/PlanViewer.Cli/Commands/AnalyzeCommand.cs
+++ b/src/PlanViewer.Cli/Commands/AnalyzeCommand.cs
@@ -95,7 +95,11 @@ public static class AnalyzeCommand
 
         var passwordOption = new Option<string?>(
             "--password",
-            "SQL Server password (bypasses credential store)");
+            "SQL Server password (bypasses credential store). Visible in process listings — prefer --password-stdin.");
+
+        var passwordStdinOption = new Option<bool>(
+            "--password-stdin",
+            "Read the SQL Server password from stdin (avoids process-listing exposure). Mutually exclusive with --password.");
 
         var configOption = new Option<string?>(
             "--config",
@@ -118,6 +122,7 @@ public static class AnalyzeCommand
             timeoutOption,
             loginOption,
             passwordOption,
+            passwordStdinOption,
             configOption
         };
 
@@ -137,7 +142,8 @@ public static class AnalyzeCommand
             var trustCert = ctx.ParseResult.GetValueForOption(trustCertOption);
             var timeout = ctx.ParseResult.GetValueForOption(timeoutOption);
             var login = ctx.ParseResult.GetValueForOption(loginOption);
-            var password = ctx.ParseResult.GetValueForOption(passwordOption);
+            var passwordInline = ctx.ParseResult.GetValueForOption(passwordOption);
+            var passwordStdin = ctx.ParseResult.GetValueForOption(passwordStdinOption);
             var configPath = ctx.ParseResult.GetValueForOption(configOption);
 
             // Load analyzer config
@@ -148,9 +154,19 @@ public static class AnalyzeCommand
             server ??= env.GetValueOrDefault("PLANVIEW_SERVER");
             database ??= env.GetValueOrDefault("PLANVIEW_DATABASE");
             login ??= env.GetValueOrDefault("PLANVIEW_LOGIN");
-            password ??= env.GetValueOrDefault("PLANVIEW_PASSWORD");
             if (!trustCert && env.GetValueOrDefault("PLANVIEW_TRUST_CERT")?.Equals("true", StringComparison.OrdinalIgnoreCase) == true)
                 trustCert = true;
+
+            // Resolve password from --password-stdin, --password, or PLANVIEW_PASSWORD
+            // (in that order). --stdin for plan XML conflicts with --password-stdin.
+            if (!PasswordResolver.TryResolve(
+                    passwordInline, passwordStdin, stdin,
+                    env.GetValueOrDefault("PLANVIEW_PASSWORD"),
+                    out var password))
+            {
+                Environment.ExitCode = 1;
+                return;
+            }
 
             if (server != null)
             {

--- a/src/PlanViewer.Cli/Commands/CredentialCommand.cs
+++ b/src/PlanViewer.Cli/Commands/CredentialCommand.cs
@@ -36,6 +36,9 @@ public static class CredentialCommand
             string password;
             if (!string.IsNullOrEmpty(passwordArg))
             {
+                Console.Error.WriteLine(
+                    "Warning: --password is visible in process listings and shell history. " +
+                    "Prefer piping the password into stdin (e.g. `echo hunter2 | planview credential add ...`).");
                 password = passwordArg;
             }
             else if (Console.IsInputRedirected)

--- a/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
+++ b/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
@@ -72,7 +72,11 @@ public static class QueryStoreCommand
             "--login", "SQL Server login (bypasses credential store)");
 
         var passwordOption = new Option<string?>(
-            "--password", "SQL Server password");
+            "--password", "SQL Server password. Visible in process listings — prefer --password-stdin.");
+
+        var passwordStdinOption = new Option<bool>(
+            "--password-stdin",
+            "Read the SQL Server password from stdin (avoids process-listing exposure). Mutually exclusive with --password.");
 
         var queryIdOption = new Option<long?>(
             "--query-id", "Filter by Query Store query ID");
@@ -93,7 +97,7 @@ public static class QueryStoreCommand
         {
             serverOption, databaseOption, topOption, orderByOption, hoursBackOption,
             outputDirOption, outputOption, compactOption, warningsOnlyOption, configOption,
-            authOption, trustCertOption, loginOption, passwordOption,
+            authOption, trustCertOption, loginOption, passwordOption, passwordStdinOption,
             queryIdOption, planIdOption, queryHashOption, planHashOption, moduleOption
         };
 
@@ -112,7 +116,8 @@ public static class QueryStoreCommand
             var auth = ctx.ParseResult.GetValueForOption(authOption);
             var trustCert = ctx.ParseResult.GetValueForOption(trustCertOption);
             var login = ctx.ParseResult.GetValueForOption(loginOption);
-            var password = ctx.ParseResult.GetValueForOption(passwordOption);
+            var passwordInline = ctx.ParseResult.GetValueForOption(passwordOption);
+            var passwordStdin = ctx.ParseResult.GetValueForOption(passwordStdinOption);
             var filterQueryId = ctx.ParseResult.GetValueForOption(queryIdOption);
             var filterPlanId = ctx.ParseResult.GetValueForOption(planIdOption);
             var filterQueryHash = ctx.ParseResult.GetValueForOption(queryHashOption);
@@ -122,9 +127,18 @@ public static class QueryStoreCommand
             // Load .env file if present (CLI args take precedence)
             var env = ConnectionHelper.LoadEnvFile();
             login ??= env.GetValueOrDefault("PLANVIEW_LOGIN");
-            password ??= env.GetValueOrDefault("PLANVIEW_PASSWORD");
             if (!trustCert && env.GetValueOrDefault("PLANVIEW_TRUST_CERT")?.Equals("true", StringComparison.OrdinalIgnoreCase) == true)
                 trustCert = true;
+
+            // Resolve password from --password-stdin, --password, or PLANVIEW_PASSWORD
+            if (!PasswordResolver.TryResolve(
+                    passwordInline, passwordStdin, stdinAlreadyClaimed: false,
+                    env.GetValueOrDefault("PLANVIEW_PASSWORD"),
+                    out var password))
+            {
+                Environment.ExitCode = 1;
+                return;
+            }
 
             if (top < 1)
             {

--- a/src/PlanViewer.Cli/PasswordResolver.cs
+++ b/src/PlanViewer.Cli/PasswordResolver.cs
@@ -1,0 +1,63 @@
+namespace PlanViewer.Cli;
+
+/// <summary>
+/// Resolves a SQL Server password from the available CLI inputs:
+///   1. --password-stdin (reads one line from redirected stdin)
+///   2. --password      (inline CLI arg; emits a stderr warning because it's
+///                       visible in process listings, shell history, and audit logs)
+///   3. PLANVIEW_PASSWORD environment variable (from the process environment or
+///                       a .env file, already looked up by the caller)
+/// </summary>
+internal static class PasswordResolver
+{
+    /// <summary>
+    /// Returns true with a resolved password (which may be null if no source provided
+    /// one). Returns false on user error (mutual-exclusion violation or stdin not
+    /// redirected when --password-stdin was requested). The caller is responsible
+    /// for setting Environment.ExitCode on failure.
+    /// </summary>
+    public static bool TryResolve(
+        string? inlinePassword,
+        bool passwordFromStdin,
+        bool stdinAlreadyClaimed,
+        string? envPassword,
+        out string? password)
+    {
+        password = null;
+
+        if (passwordFromStdin && !string.IsNullOrEmpty(inlinePassword))
+        {
+            Console.Error.WriteLine("--password and --password-stdin are mutually exclusive.");
+            return false;
+        }
+
+        if (passwordFromStdin && stdinAlreadyClaimed)
+        {
+            Console.Error.WriteLine("--password-stdin can't be combined with --stdin (both read from stdin).");
+            return false;
+        }
+
+        if (passwordFromStdin)
+        {
+            if (!Console.IsInputRedirected)
+            {
+                Console.Error.WriteLine("--password-stdin requires stdin to be redirected (pipe the password into the command).");
+                return false;
+            }
+            password = Console.In.ReadLine()?.TrimEnd('\r', '\n') ?? "";
+            return true;
+        }
+
+        if (!string.IsNullOrEmpty(inlinePassword))
+        {
+            Console.Error.WriteLine(
+                "Warning: --password is visible in process listings and shell history. " +
+                "Prefer --password-stdin, the PLANVIEW_PASSWORD env var, or the credential store.");
+            password = inlinePassword;
+            return true;
+        }
+
+        password = envPassword;
+        return true;
+    }
+}

--- a/src/PlanViewer.Cli/Program.cs
+++ b/src/PlanViewer.Cli/Program.cs
@@ -23,4 +23,8 @@ var root = new RootCommand("SQL Server execution plan analyzer")
 if (credentialService != null)
     root.Add(CredentialCommand.Create(credentialService));
 
-return await root.InvokeAsync(args);
+// System.CommandLine's InvokeAsync returns 0 for successful dispatch even when a
+// handler set Environment.ExitCode = 1 to signal a validation error. Honor either
+// signal so scripts can tell success from failure.
+var code = await root.InvokeAsync(args);
+return code != 0 ? code : Environment.ExitCode;


### PR DESCRIPTION
## Summary

CLI passwords passed on the command line (`--password hunter2`) are visible in process listings (`tasklist /v`, `ps`), shell history, and OS audit logs. This PR adds `--password-stdin` so the password can be piped in instead, and warns when the inline flag is used.

While investigating, noticed a pre-existing bug: handlers that set `Environment.ExitCode = 1` on validation failure were exiting 0 because `return await root.InvokeAsync(args)` clobbered the exit code in the top-level program. Fixed that in the same PR since `--password-stdin` depends on it (the mutual-exclusion and stdin-not-redirected checks would otherwise be advisory).

## Changes

- **New:** `src/PlanViewer.Cli/PasswordResolver.cs` — shared resolver for the CLI password input chain.
- `AnalyzeCommand`, `QueryStoreCommand`: add `--password-stdin` option, route through the resolver.
- `CredentialCommand`: add the same inline-password warning for symmetry (existing stdin-when-redirected behavior is already correct).
- `Program.cs`: propagate `Environment.ExitCode` through the top-level `return`, so handlers that signal failure actually exit non-zero.

## Resolver rules

1. `--password` and `--password-stdin` are mutually exclusive → exit 1.
2. `--password-stdin` + `--stdin` (plan XML) → exit 1 (both claim stdin).
3. `--password-stdin` without stdin redirected → exit 1.
4. `--password` inline → emit stderr warning pointing at safer alternatives.
5. Otherwise fall back to `PLANVIEW_PASSWORD` env var (unchanged).

## Test plan

Exercised against the built `planview.exe`:

| Scenario | Expected | Got |
|---|---|---|
| `--password X --password-stdin` | exit 1, "mutually exclusive" | ✅ exit 1 |
| `--stdin --password-stdin` (piped) | exit 1, "can't be combined with --stdin" | ✅ exit 1 |
| `--password X file.sqlplan` (inline) | stderr warning + usual processing | ✅ warning printed |
| `echo X \| planview analyze --password-stdin ...` | password read, no warning | ✅ |
| `planview analyze /nonexistent.sqlplan` (pre-existing path) | exit 1 (regression: was 0) | ✅ exit 1 |
| `planview --help` | exit 0 | ✅ |

Also verified the `--password-stdin` option appears in `--help` for both `analyze` and `query-store`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)