### PR TITLE
Fix operator self-time through Compute Scalar children + one-decimal benefit % (#215 C5, C2)

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -801,6 +801,9 @@ public partial class PlanViewerControl : UserControl
         return $"{bytes / (1024L * 1024 * 1024):N1} GB";
     }
 
+    private static string FormatBenefitPercent(double pct) =>
+        pct >= 100 ? $"{pct:N0}" : $"{pct:N1}";
+
     #endregion
 
     #region Node Selection & Properties Panel
@@ -1737,7 +1740,7 @@ public partial class PlanViewerControl : UserControl
                         : w.Severity == PlanWarningSeverity.Warning ? "#FFB347" : "#6BB5FF";
                     var warnPanel = new StackPanel { Margin = new Thickness(10, 2, 10, 2) };
                     var planWarnHeader = w.MaxBenefitPercent.HasValue
-                        ? $"\u26A0 {w.WarningType} \u2014 up to {w.MaxBenefitPercent:N0}% benefit"
+                        ? $"\u26A0 {w.WarningType} \u2014 up to {FormatBenefitPercent(w.MaxBenefitPercent.Value)}% benefit"
                         : $"\u26A0 {w.WarningType}";
                     warnPanel.Children.Add(new TextBlock
                     {
@@ -1819,7 +1822,7 @@ public partial class PlanViewerControl : UserControl
                     : w.Severity == PlanWarningSeverity.Warning ? "#FFB347" : "#6BB5FF";
                 var warnPanel = new StackPanel { Margin = new Thickness(10, 2, 10, 2) };
                 var nodeWarnHeader = w.MaxBenefitPercent.HasValue
-                    ? $"\u26A0 {w.WarningType} \u2014 up to {w.MaxBenefitPercent:N0}% benefit"
+                    ? $"\u26A0 {w.WarningType} \u2014 up to {FormatBenefitPercent(w.MaxBenefitPercent.Value)}% benefit"
                     : $"\u26A0 {w.WarningType}";
                 warnPanel.Children.Add(new TextBlock
                 {

--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -6,7 +6,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>EDD.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>1.7.1</Version>
+    <Version>1.7.2</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Core/Output/HtmlExporter.cs
+++ b/src/PlanViewer.Core/Output/HtmlExporter.cs
@@ -407,7 +407,7 @@ pre.query-text, pre.text-output {
             {
                 var barPct = maxWait > 0 ? (double)w.WaitTimeMs / maxWait * 100 : 0;
                 var benefitTag = benefitLookup.TryGetValue(w.WaitType, out var pct)
-                    ? $" <span class=\"warn-benefit\">up to {pct:N0}%</span>"
+                    ? $" <span class=\"warn-benefit\">up to {(pct >= 100 ? pct.ToString("N0") : pct.ToString("N1"))}%</span>"
                     : "";
                 sb.AppendLine("<div class=\"wait-row\">");
                 sb.AppendLine($"<span class=\"wait-type\">{Encode(w.WaitType)}</span>");
@@ -458,7 +458,7 @@ pre.query-text, pre.text-output {
                 sb.AppendLine($"<span class=\"warn-op\">{Encode(w.Operator)}</span>");
             sb.AppendLine($"<span class=\"warn-type\">{Encode(w.Type)}</span>");
             if (w.MaxBenefitPercent.HasValue)
-                sb.AppendLine($"<span class=\"warn-benefit\">up to {w.MaxBenefitPercent:N0}% benefit</span>");
+                sb.AppendLine($"<span class=\"warn-benefit\">up to {(w.MaxBenefitPercent.Value >= 100 ? w.MaxBenefitPercent.Value.ToString("N0") : w.MaxBenefitPercent.Value.ToString("N1"))}% benefit</span>");
             sb.AppendLine($"<span class=\"warn-msg\">{Encode(w.Message)}</span>");
             if (!string.IsNullOrEmpty(w.ActionableFix))
                 sb.AppendLine($"<span class=\"warn-fix\">{Encode(w.ActionableFix)}</span>");

--- a/src/PlanViewer.Core/Output/TextFormatter.cs
+++ b/src/PlanViewer.Core/Output/TextFormatter.cs
@@ -139,7 +139,7 @@ public static class TextFormatter
                 foreach (var w in stmt.WaitStats.OrderByDescending(w => w.WaitTimeMs))
                 {
                     var benefitTag = benefitLookup.TryGetValue(w.WaitType, out var pct)
-                        ? $" (up to {pct:N0}% benefit)"
+                        ? $" (up to {(pct >= 100 ? pct.ToString("N0") : pct.ToString("N1"))}% benefit)"
                         : "";
                     writer.WriteLine($"  {w.WaitType}: {w.WaitTimeMs:N0}ms{benefitTag}");
                 }
@@ -169,7 +169,7 @@ public static class TextFormatter
                 foreach (var w in sortedWarnings)
                 {
                     var benefitTag = w.MaxBenefitPercent.HasValue
-                        ? $" (up to {w.MaxBenefitPercent:N0}% benefit)"
+                        ? $" (up to {(w.MaxBenefitPercent.Value >= 100 ? w.MaxBenefitPercent.Value.ToString("N0") : w.MaxBenefitPercent.Value.ToString("N1"))}% benefit)"
                         : "";
                     writer.WriteLine($"  [{w.Severity}] {w.Type}{benefitTag}: {EscapeNewlines(w.Message)}");
                     if (!string.IsNullOrEmpty(w.ActionableFix))

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.cs
@@ -1593,24 +1593,43 @@ public static class PlanAnalyzer
     }
 
     /// <summary>
-    /// Serial row mode self-time: subtract all direct children's elapsed.
-    /// Exchange children are skipped through to their real child.
+    /// Serial row mode self-time: subtract all direct children's effective elapsed.
+    /// Pass-through operators (Compute Scalar, etc.) don't carry runtime stats —
+    /// look through them to the first descendant that does. Exchange children
+    /// use max-child elapsed because exchange times are unreliable.
     /// </summary>
     private static long GetSerialOwnElapsed(PlanNode node)
     {
         var totalChildElapsed = 0L;
         foreach (var child in node.Children)
-        {
-            var childElapsed = child.ActualElapsedMs;
-
-            // Exchange operators have unreliable times — skip to their child
-            if (child.PhysicalOp == "Parallelism" && child.Children.Count > 0)
-                childElapsed = child.Children.Max(c => c.ActualElapsedMs);
-
-            totalChildElapsed += childElapsed;
-        }
+            totalChildElapsed += GetEffectiveChildElapsedMs(child);
 
         return Math.Max(0, node.ActualElapsedMs - totalChildElapsed);
+    }
+
+    /// <summary>
+    /// Returns the elapsed time a child contributes to its parent's subtree.
+    /// Looks through pass-through operators (Compute Scalar, Parallelism exchange)
+    /// that don't carry reliable runtime stats.
+    /// </summary>
+    private static long GetEffectiveChildElapsedMs(PlanNode child)
+    {
+        // Exchange operators: unreliable times, use max child
+        if (child.PhysicalOp == "Parallelism" && child.Children.Count > 0)
+            return child.Children.Max(GetEffectiveChildElapsedMs);
+
+        // Child has its own stats: use them
+        if (child.ActualElapsedMs > 0)
+            return child.ActualElapsedMs;
+
+        // No stats (Compute Scalar and similar): look through to descendants
+        if (child.Children.Count == 0)
+            return 0;
+
+        var sum = 0L;
+        foreach (var grandchild in child.Children)
+            sum += GetEffectiveChildElapsedMs(grandchild);
+        return sum;
     }
 
     /// <summary>

--- a/src/PlanViewer.Web/Pages/Index.razor
+++ b/src/PlanViewer.Web/Pages/Index.razor
@@ -302,7 +302,7 @@ else
                                 @w.WaitTimeMs.ToString("N0") ms
                                 @if (benefitPct > 0)
                                 {
-                                    <span class="wait-benefit">up to @benefitPct.ToString("N0")%</span>
+                                    <span class="wait-benefit">up to @(benefitPct >= 100 ? benefitPct.ToString("N0") : benefitPct.ToString("N1"))%</span>
                                 }
                             </span>
                         </div>
@@ -346,7 +346,7 @@ else
                         <span class="warning-type">@w.Type</span>
                         @if (w.MaxBenefitPercent.HasValue)
                         {
-                            <span class="warn-benefit">up to @w.MaxBenefitPercent.Value.ToString("N0")% benefit</span>
+                            <span class="warn-benefit">up to @(w.MaxBenefitPercent.Value >= 100 ? w.MaxBenefitPercent.Value.ToString("N0") : w.MaxBenefitPercent.Value.ToString("N1"))% benefit</span>
                         }
                         <span class="warning-msg">@w.Message</span>
                         @if (!string.IsNullOrEmpty(w.ActionableFix))


### PR DESCRIPTION
## Summary
Two Joe-feedback items from #215:

- **C5 (bug):** operator self-time was wrong for any operator whose direct children were Compute Scalars. \`GetSerialOwnElapsed\` subtracted each child's \`ActualElapsedMs\`, but Compute Scalars don't carry runtime stats, so it subtracted 0 and the parent kept its full elapsed. Joe's node-6 Hash Spill reported 95% / 8,829ms; correct is 17.4% / 1,609ms (\`8.829 − 7.121 − 0.099\`). New \`GetEffectiveChildElapsedMs\` helper walks through pass-through operators to the first descendant with real stats.

- **C2:** benefit % was \`N0\` everywhere, so tiny waits showed as "up to 0%". Now one decimal except at 100 (shown as "100"). Applied to web strip + wait-stats card, HTML export, text formatter, Avalonia plan + node warning headers.

## Details
\`GetSerialOwnElapsed\` → iterates children calling \`GetEffectiveChildElapsedMs(child)\` instead of reading \`child.ActualElapsedMs\` directly. The helper:
- Parallelism exchange child → max-child elapsed (unchanged, exchange times unreliable)
- Child has \`ActualElapsedMs > 0\` → use it
- Otherwise → recurse into grandchildren and sum

Applies to every operator-time benefit scorer: spills (Rule 7), key lookups (Rule 10), scan with predicate (Rule 11), non-SARGable (Rule 12), bare scan (Rule 34), scan cardinality misestimate (Rule 32), eager index spool, filter operator, nested loops high executions, row estimate mismatch.

## Test plan
- [x] Joe's private plan — node-6 Hash Spill now shows 17.4% benefit, 1,609ms self-time (matches his math)
- [x] Wait items show 0.0–0.5% benefit instead of 0%
- [x] Regression check on \`20260415_1.sqlplan\` — all existing benefits unchanged
- [ ] Web viewer visual post-deploy
- [ ] Desktop Plan Warnings expander visual post-deploy

Version 1.7.1 → 1.7.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)