### PR TITLE
Release v1.7.2 — operator self-time fix + decimal benefit %

### DIFF
--- a/server/PlanShare/Program.cs
+++ b/server/PlanShare/Program.cs
@@ -44,8 +44,14 @@ using (var conn = new SqliteConnection(connectionString))
     cmd.ExecuteNonQuery();
 }
 
+// --- Rate limiters (in-memory) ---
+// Created before Build() so they can be DI-registered and swept by CleanupService.
+var rateLimiter = new RateLimiter(maxRequests: 10, windowSeconds: 60);
+var analyticsRateLimiter = new RateLimiter(maxRequests: 30, windowSeconds: 60);
+
 // Register the cleanup background service
 builder.Services.AddSingleton(new PlanDbConfig(connectionString));
+builder.Services.AddSingleton(new RateLimiters(rateLimiter, analyticsRateLimiter));
 builder.Services.AddHostedService<CleanupService>();
 
 // Request size limit (10 MB)
@@ -53,10 +59,6 @@ builder.WebHost.ConfigureKestrel(o => o.Limits.MaxRequestBodySize = 10 * 1024 * 
 
 var app = builder.Build();
 app.UseCors();
-
-// --- Rate limiters (in-memory) ---
-var rateLimiter = new RateLimiter(maxRequests: 10, windowSeconds: 60);
-var analyticsRateLimiter = new RateLimiter(maxRequests: 30, windowSeconds: 60);
 
 const int MaxTtlDays = 365;
 
@@ -161,9 +163,15 @@ app.MapPost("/api/event", async (HttpContext ctx) =>
         return Results.BadRequest("Invalid JSON");
     }
 
-    // Strip referrer to domain only (no full URLs with query params)
-    if (!string.IsNullOrEmpty(referrer) && Uri.TryCreate(referrer, UriKind.Absolute, out var refUri))
-        referrer = refUri.Host;
+    // Strip referrer to domain only (no full URLs with query params).
+    // If it doesn't parse as an absolute URL, drop it — never persist raw
+    // client-supplied strings, since the dashboard renders referrers in HTML.
+    if (!string.IsNullOrEmpty(referrer))
+    {
+        referrer = Uri.TryCreate(referrer, UriKind.Absolute, out var refUri)
+            ? refUri.Host
+            : null;
+    }
 
     // Visitor hash: SHA256(IP + User-Agent + date) — unique per day, no PII stored
     var ua = ctx.Request.Headers.UserAgent.FirstOrDefault() ?? "";
@@ -352,14 +360,18 @@ static string GenerateDeleteToken()
 
 record PlanDbConfig(string ConnectionString);
 
+record RateLimiters(RateLimiter Share, RateLimiter Analytics);
+
 sealed class CleanupService : BackgroundService
 {
     private readonly PlanDbConfig _config;
+    private readonly RateLimiters _rateLimiters;
     private readonly ILogger<CleanupService> _logger;
 
-    public CleanupService(PlanDbConfig config, ILogger<CleanupService> logger)
+    public CleanupService(PlanDbConfig config, RateLimiters rateLimiters, ILogger<CleanupService> logger)
     {
         _config = config;
+        _rateLimiters = rateLimiters;
         _logger = logger;
     }
 
@@ -401,6 +413,14 @@ sealed class CleanupService : BackgroundService
                 if (deleted > 0)
                     _logger.LogInformation("Cleaned up {Count} old page views", deleted);
             }
+
+            // Evict stale rate-limiter keys so the dictionary doesn't grow forever.
+            var shareEvicted = _rateLimiters.Share.Sweep();
+            var analyticsEvicted = _rateLimiters.Analytics.Sweep();
+            if (shareEvicted + analyticsEvicted > 0)
+                _logger.LogInformation(
+                    "Evicted {Share} share + {Analytics} analytics rate-limit keys",
+                    shareEvicted, analyticsEvicted);
         }
         catch (Exception ex)
         {
@@ -440,5 +460,26 @@ sealed class RateLimiter
             timestamps.Add(now);
             return true;
         }
+    }
+
+    /// <summary>
+    /// Evicts keys whose timestamp lists have gone empty. Call periodically
+    /// so the dictionary doesn't grow forever across unique IPs.
+    /// Returns the number of keys evicted.
+    /// </summary>
+    public int Sweep()
+    {
+        var cutoff = DateTime.UtcNow.AddSeconds(-_windowSeconds);
+        var evicted = 0;
+        foreach (var kvp in _requests)
+        {
+            lock (kvp.Value)
+            {
+                kvp.Value.RemoveAll(t => t < cutoff);
+                if (kvp.Value.Count == 0 && _requests.TryRemove(kvp))
+                    evicted++;
+            }
+        }
+        return evicted;
     }
 }

--- a/server/PlanShare/dashboard.html
+++ b/server/PlanShare/dashboard.html
@@ -275,13 +275,28 @@
     }
     function updateReferrers() {
         var tbody = document.querySelector("#referrersTable tbody");
+        tbody.replaceChildren();
         if (!planStats || !planStats.traffic.top_referrers.length) {
-            tbody.innerHTML = "<tr><td colspan='2' style='color:#484f58'>No referrer data yet</td></tr>";
+            var tr = document.createElement("tr");
+            var td = document.createElement("td");
+            td.setAttribute("colspan", "2");
+            td.style.color = "#484f58";
+            td.textContent = "No referrer data yet";
+            tr.appendChild(td);
+            tbody.appendChild(tr);
             return;
         }
-        tbody.innerHTML = planStats.traffic.top_referrers.map(function(r) {
-            return "<tr><td>" + r.referrer + "</td><td class='num'>" + fmt(r.count) + "</td></tr>";
-        }).join("");
+        planStats.traffic.top_referrers.forEach(function(r) {
+            var tr = document.createElement("tr");
+            var tdRef = document.createElement("td");
+            tdRef.textContent = r.referrer;
+            var tdCount = document.createElement("td");
+            tdCount.className = "num";
+            tdCount.textContent = fmt(r.count);
+            tr.appendChild(tdRef);
+            tr.appendChild(tdCount);
+            tbody.appendChild(tr);
+        });
     }
     function updateCharts() {
         updateChart("starsChart", "line", {

--- a/src/PlanViewer.App/AboutWindow.axaml.cs
+++ b/src/PlanViewer.App/AboutWindow.axaml.cs
@@ -56,7 +56,7 @@ public partial class AboutWindow : Window
         }, new JsonSerializerOptions { WriteIndented = true });
 
         Directory.CreateDirectory(settingsDir);
-        File.WriteAllText(settingsFile, json);
+        Services.AtomicFile.WriteAllText(settingsFile, json);
     }
 
     private void GitHubLink_Click(object? sender, PointerPressedEventArgs e) => OpenUrl(GitHubUrl);

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -801,6 +801,9 @@ public partial class PlanViewerControl : UserControl
         return $"{bytes / (1024L * 1024 * 1024):N1} GB";
     }
 
+    private static string FormatBenefitPercent(double pct) =>
+        pct >= 100 ? $"{pct:N0}" : $"{pct:N1}";
+
     #endregion
 
     #region Node Selection & Properties Panel
@@ -1737,7 +1740,7 @@ public partial class PlanViewerControl : UserControl
                         : w.Severity == PlanWarningSeverity.Warning ? "#FFB347" : "#6BB5FF";
                     var warnPanel = new StackPanel { Margin = new Thickness(10, 2, 10, 2) };
                     var planWarnHeader = w.MaxBenefitPercent.HasValue
-                        ? $"\u26A0 {w.WarningType} \u2014 up to {w.MaxBenefitPercent:N0}% benefit"
+                        ? $"\u26A0 {w.WarningType} \u2014 up to {FormatBenefitPercent(w.MaxBenefitPercent.Value)}% benefit"
                         : $"\u26A0 {w.WarningType}";
                     warnPanel.Children.Add(new TextBlock
                     {
@@ -1819,7 +1822,7 @@ public partial class PlanViewerControl : UserControl
                     : w.Severity == PlanWarningSeverity.Warning ? "#FFB347" : "#6BB5FF";
                 var warnPanel = new StackPanel { Margin = new Thickness(10, 2, 10, 2) };
                 var nodeWarnHeader = w.MaxBenefitPercent.HasValue
-                    ? $"\u26A0 {w.WarningType} \u2014 up to {w.MaxBenefitPercent:N0}% benefit"
+                    ? $"\u26A0 {w.WarningType} \u2014 up to {FormatBenefitPercent(w.MaxBenefitPercent.Value)}% benefit"
                     : $"\u26A0 {w.WarningType}";
                 warnPanel.Children.Add(new TextBlock
                 {

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -78,11 +78,15 @@ public partial class QuerySessionControl : UserControl
             QueryEditor.TextArea.Focus();
         };
 
-        // Dispose TextMate when detached (e.g. tab switch) to release renderers/transformers
+        // Dispose TextMate when detached (e.g. tab switch) to release renderers/transformers.
+        // Also cancel any in-flight status-clear dispatch so it doesn't fire on a dead control.
         DetachedFromVisualTree += (_, _) =>
         {
             _textMateInstallation?.Dispose();
             _textMateInstallation = null;
+            _statusClearCts?.Cancel();
+            _statusClearCts?.Dispose();
+            _statusClearCts = null;
         };
 
         // Focus the editor when the Editor tab is selected; toggle plan-dependent buttons

--- a/src/PlanViewer.App/Dialogs/QueryStoreHistoryWindow.axaml.cs
+++ b/src/PlanViewer.App/Dialogs/QueryStoreHistoryWindow.axaml.cs
@@ -169,6 +169,16 @@ public partial class QueryStoreHistoryWindow : Window
             : "AvgCpuMs";
     }
 
+    protected override void OnClosed(EventArgs e)
+    {
+        // Cancel any in-flight history fetch so the SqlConnection doesn't sit open on the
+        // server after the dialog is dismissed.
+        _fetchCts?.Cancel();
+        _fetchCts?.Dispose();
+        _fetchCts = null;
+        base.OnClosed(e);
+    }
+
     private async System.Threading.Tasks.Task LoadHistoryAsync()
     {
         _fetchCts?.Cancel();

--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -6,7 +6,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>EDD.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>1.7.1</Version>
+    <Version>1.7.2</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.App/Services/AppSettingsService.cs
+++ b/src/PlanViewer.App/Services/AppSettingsService.cs
@@ -59,7 +59,7 @@ internal sealed class AppSettingsService
         {
             Directory.CreateDirectory(SettingsDir);
             var json = JsonSerializer.Serialize(settings, JsonOptions);
-            File.WriteAllText(SettingsPath, json);
+            AtomicFile.WriteAllText(SettingsPath, json);
         }
         catch
         {

--- a/src/PlanViewer.App/Services/AtomicFile.cs
+++ b/src/PlanViewer.App/Services/AtomicFile.cs
@@ -1,0 +1,27 @@
+using System.IO;
+
+namespace PlanViewer.App.Services;
+
+/// <summary>
+/// Helper for atomic text-file writes: write to a sibling .tmp and rename
+/// into place so a crash mid-write can't truncate the target file. Callers
+/// are responsible for creating the parent directory first.
+/// </summary>
+internal static class AtomicFile
+{
+    /// <summary>
+    /// Writes <paramref name="contents"/> to <paramref name="path"/> atomically
+    /// with respect to process crashes. If the process dies before the rename,
+    /// <paramref name="path"/> keeps its previous contents and a stray
+    /// <c>.tmp</c> sibling is left behind (cleaned up on the next call).
+    /// </summary>
+    public static void WriteAllText(string path, string contents)
+    {
+        var tmp = path + ".tmp";
+        File.WriteAllText(tmp, contents);
+        // File.Move with overwrite:true maps to MoveFileEx(MOVEFILE_REPLACE_EXISTING)
+        // on Windows and rename(2) on Unix — both atomic when source and destination
+        // live on the same filesystem, which is always the case here.
+        File.Move(tmp, path, overwrite: true);
+    }
+}

--- a/src/PlanViewer.App/Services/ConnectionStore.cs
+++ b/src/PlanViewer.App/Services/ConnectionStore.cs
@@ -39,7 +39,7 @@ public class ConnectionStore
     {
         Directory.CreateDirectory(ConfigDir);
         var json = JsonSerializer.Serialize(connections, JsonOptions);
-        File.WriteAllText(ConfigFile, json);
+        AtomicFile.WriteAllText(ConfigFile, json);
     }
 
     public void AddOrUpdate(ServerConnection connection)

--- a/src/PlanViewer.App/Services/SqlFormatSettingsService.cs
+++ b/src/PlanViewer.App/Services/SqlFormatSettingsService.cs
@@ -123,7 +123,7 @@ internal static class SqlFormatSettingsService
         {
             Directory.CreateDirectory(SettingsDir);
             var json = JsonSerializer.Serialize(settings, JsonOptions);
-            File.WriteAllText(SettingsPath, json);
+            AtomicFile.WriteAllText(SettingsPath, json);
             return true;
         }
         catch (Exception ex)

--- a/src/PlanViewer.Cli/Commands/AnalyzeCommand.cs
+++ b/src/PlanViewer.Cli/Commands/AnalyzeCommand.cs
@@ -95,7 +95,11 @@ public static class AnalyzeCommand
 
         var passwordOption = new Option<string?>(
             "--password",
-            "SQL Server password (bypasses credential store)");
+            "SQL Server password (bypasses credential store). Visible in process listings — prefer --password-stdin.");
+
+        var passwordStdinOption = new Option<bool>(
+            "--password-stdin",
+            "Read the SQL Server password from stdin (avoids process-listing exposure). Mutually exclusive with --password.");
 
         var configOption = new Option<string?>(
             "--config",
@@ -118,6 +122,7 @@ public static class AnalyzeCommand
             timeoutOption,
             loginOption,
             passwordOption,
+            passwordStdinOption,
             configOption
         };
 
@@ -137,7 +142,8 @@ public static class AnalyzeCommand
             var trustCert = ctx.ParseResult.GetValueForOption(trustCertOption);
             var timeout = ctx.ParseResult.GetValueForOption(timeoutOption);
             var login = ctx.ParseResult.GetValueForOption(loginOption);
-            var password = ctx.ParseResult.GetValueForOption(passwordOption);
+            var passwordInline = ctx.ParseResult.GetValueForOption(passwordOption);
+            var passwordStdin = ctx.ParseResult.GetValueForOption(passwordStdinOption);
             var configPath = ctx.ParseResult.GetValueForOption(configOption);
 
             // Load analyzer config
@@ -148,9 +154,19 @@ public static class AnalyzeCommand
             server ??= env.GetValueOrDefault("PLANVIEW_SERVER");
             database ??= env.GetValueOrDefault("PLANVIEW_DATABASE");
             login ??= env.GetValueOrDefault("PLANVIEW_LOGIN");
-            password ??= env.GetValueOrDefault("PLANVIEW_PASSWORD");
             if (!trustCert && env.GetValueOrDefault("PLANVIEW_TRUST_CERT")?.Equals("true", StringComparison.OrdinalIgnoreCase) == true)
                 trustCert = true;
+
+            // Resolve password from --password-stdin, --password, or PLANVIEW_PASSWORD
+            // (in that order). --stdin for plan XML conflicts with --password-stdin.
+            if (!PasswordResolver.TryResolve(
+                    passwordInline, passwordStdin, stdin,
+                    env.GetValueOrDefault("PLANVIEW_PASSWORD"),
+                    out var password))
+            {
+                Environment.ExitCode = 1;
+                return;
+            }
 
             if (server != null)
             {

--- a/src/PlanViewer.Cli/Commands/CredentialCommand.cs
+++ b/src/PlanViewer.Cli/Commands/CredentialCommand.cs
@@ -36,6 +36,9 @@ public static class CredentialCommand
             string password;
             if (!string.IsNullOrEmpty(passwordArg))
             {
+                Console.Error.WriteLine(
+                    "Warning: --password is visible in process listings and shell history. " +
+                    "Prefer piping the password into stdin (e.g. `echo hunter2 | planview credential add ...`).");
                 password = passwordArg;
             }
             else if (Console.IsInputRedirected)

--- a/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
+++ b/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
@@ -72,7 +72,11 @@ public static class QueryStoreCommand
             "--login", "SQL Server login (bypasses credential store)");
 
         var passwordOption = new Option<string?>(
-            "--password", "SQL Server password");
+            "--password", "SQL Server password. Visible in process listings — prefer --password-stdin.");
+
+        var passwordStdinOption = new Option<bool>(
+            "--password-stdin",
+            "Read the SQL Server password from stdin (avoids process-listing exposure). Mutually exclusive with --password.");
 
         var queryIdOption = new Option<long?>(
             "--query-id", "Filter by Query Store query ID");
@@ -93,7 +97,7 @@ public static class QueryStoreCommand
         {
             serverOption, databaseOption, topOption, orderByOption, hoursBackOption,
             outputDirOption, outputOption, compactOption, warningsOnlyOption, configOption,
-            authOption, trustCertOption, loginOption, passwordOption,
+            authOption, trustCertOption, loginOption, passwordOption, passwordStdinOption,
             queryIdOption, planIdOption, queryHashOption, planHashOption, moduleOption
         };
 
@@ -112,7 +116,8 @@ public static class QueryStoreCommand
             var auth = ctx.ParseResult.GetValueForOption(authOption);
             var trustCert = ctx.ParseResult.GetValueForOption(trustCertOption);
             var login = ctx.ParseResult.GetValueForOption(loginOption);
-            var password = ctx.ParseResult.GetValueForOption(passwordOption);
+            var passwordInline = ctx.ParseResult.GetValueForOption(passwordOption);
+            var passwordStdin = ctx.ParseResult.GetValueForOption(passwordStdinOption);
             var filterQueryId = ctx.ParseResult.GetValueForOption(queryIdOption);
             var filterPlanId = ctx.ParseResult.GetValueForOption(planIdOption);
             var filterQueryHash = ctx.ParseResult.GetValueForOption(queryHashOption);
@@ -122,9 +127,18 @@ public static class QueryStoreCommand
             // Load .env file if present (CLI args take precedence)
             var env = ConnectionHelper.LoadEnvFile();
             login ??= env.GetValueOrDefault("PLANVIEW_LOGIN");
-            password ??= env.GetValueOrDefault("PLANVIEW_PASSWORD");
             if (!trustCert && env.GetValueOrDefault("PLANVIEW_TRUST_CERT")?.Equals("true", StringComparison.OrdinalIgnoreCase) == true)
                 trustCert = true;
+
+            // Resolve password from --password-stdin, --password, or PLANVIEW_PASSWORD
+            if (!PasswordResolver.TryResolve(
+                    passwordInline, passwordStdin, stdinAlreadyClaimed: false,
+                    env.GetValueOrDefault("PLANVIEW_PASSWORD"),
+                    out var password))
+            {
+                Environment.ExitCode = 1;
+                return;
+            }
 
             if (top < 1)
             {

--- a/src/PlanViewer.Cli/PasswordResolver.cs
+++ b/src/PlanViewer.Cli/PasswordResolver.cs
@@ -1,0 +1,63 @@
+namespace PlanViewer.Cli;
+
+/// <summary>
+/// Resolves a SQL Server password from the available CLI inputs:
+///   1. --password-stdin (reads one line from redirected stdin)
+///   2. --password      (inline CLI arg; emits a stderr warning because it's
+///                       visible in process listings, shell history, and audit logs)
+///   3. PLANVIEW_PASSWORD environment variable (from the process environment or
+///                       a .env file, already looked up by the caller)
+/// </summary>
+internal static class PasswordResolver
+{
+    /// <summary>
+    /// Returns true with a resolved password (which may be null if no source provided
+    /// one). Returns false on user error (mutual-exclusion violation or stdin not
+    /// redirected when --password-stdin was requested). The caller is responsible
+    /// for setting Environment.ExitCode on failure.
+    /// </summary>
+    public static bool TryResolve(
+        string? inlinePassword,
+        bool passwordFromStdin,
+        bool stdinAlreadyClaimed,
+        string? envPassword,
+        out string? password)
+    {
+        password = null;
+
+        if (passwordFromStdin && !string.IsNullOrEmpty(inlinePassword))
+        {
+            Console.Error.WriteLine("--password and --password-stdin are mutually exclusive.");
+            return false;
+        }
+
+        if (passwordFromStdin && stdinAlreadyClaimed)
+        {
+            Console.Error.WriteLine("--password-stdin can't be combined with --stdin (both read from stdin).");
+            return false;
+        }
+
+        if (passwordFromStdin)
+        {
+            if (!Console.IsInputRedirected)
+            {
+                Console.Error.WriteLine("--password-stdin requires stdin to be redirected (pipe the password into the command).");
+                return false;
+            }
+            password = Console.In.ReadLine()?.TrimEnd('\r', '\n') ?? "";
+            return true;
+        }
+
+        if (!string.IsNullOrEmpty(inlinePassword))
+        {
+            Console.Error.WriteLine(
+                "Warning: --password is visible in process listings and shell history. " +
+                "Prefer --password-stdin, the PLANVIEW_PASSWORD env var, or the credential store.");
+            password = inlinePassword;
+            return true;
+        }
+
+        password = envPassword;
+        return true;
+    }
+}

--- a/src/PlanViewer.Cli/Program.cs
+++ b/src/PlanViewer.Cli/Program.cs
@@ -23,4 +23,8 @@ var root = new RootCommand("SQL Server execution plan analyzer")
 if (credentialService != null)
     root.Add(CredentialCommand.Create(credentialService));
 
-return await root.InvokeAsync(args);
+// System.CommandLine's InvokeAsync returns 0 for successful dispatch even when a
+// handler set Environment.ExitCode = 1 to signal a validation error. Honor either
+// signal so scripts can tell success from failure.
+var code = await root.InvokeAsync(args);
+return code != 0 ? code : Environment.ExitCode;

--- a/src/PlanViewer.Core/Output/HtmlExporter.cs
+++ b/src/PlanViewer.Core/Output/HtmlExporter.cs
@@ -407,7 +407,7 @@ pre.query-text, pre.text-output {
             {
                 var barPct = maxWait > 0 ? (double)w.WaitTimeMs / maxWait * 100 : 0;
                 var benefitTag = benefitLookup.TryGetValue(w.WaitType, out var pct)
-                    ? $" <span class=\"warn-benefit\">up to {pct:N0}%</span>"
+                    ? $" <span class=\"warn-benefit\">up to {(pct >= 100 ? pct.ToString("N0") : pct.ToString("N1"))}%</span>"
                     : "";
                 sb.AppendLine("<div class=\"wait-row\">");
                 sb.AppendLine($"<span class=\"wait-type\">{Encode(w.WaitType)}</span>");
@@ -458,7 +458,7 @@ pre.query-text, pre.text-output {
                 sb.AppendLine($"<span class=\"warn-op\">{Encode(w.Operator)}</span>");
             sb.AppendLine($"<span class=\"warn-type\">{Encode(w.Type)}</span>");
             if (w.MaxBenefitPercent.HasValue)
-                sb.AppendLine($"<span class=\"warn-benefit\">up to {w.MaxBenefitPercent:N0}% benefit</span>");
+                sb.AppendLine($"<span class=\"warn-benefit\">up to {(w.MaxBenefitPercent.Value >= 100 ? w.MaxBenefitPercent.Value.ToString("N0") : w.MaxBenefitPercent.Value.ToString("N1"))}% benefit</span>");
             sb.AppendLine($"<span class=\"warn-msg\">{Encode(w.Message)}</span>");
             if (!string.IsNullOrEmpty(w.ActionableFix))
                 sb.AppendLine($"<span class=\"warn-fix\">{Encode(w.ActionableFix)}</span>");

--- a/src/PlanViewer.Core/Output/TextFormatter.cs
+++ b/src/PlanViewer.Core/Output/TextFormatter.cs
@@ -139,7 +139,7 @@ public static class TextFormatter
                 foreach (var w in stmt.WaitStats.OrderByDescending(w => w.WaitTimeMs))
                 {
                     var benefitTag = benefitLookup.TryGetValue(w.WaitType, out var pct)
-                        ? $" (up to {pct:N0}% benefit)"
+                        ? $" (up to {(pct >= 100 ? pct.ToString("N0") : pct.ToString("N1"))}% benefit)"
                         : "";
                     writer.WriteLine($"  {w.WaitType}: {w.WaitTimeMs:N0}ms{benefitTag}");
                 }
@@ -169,7 +169,7 @@ public static class TextFormatter
                 foreach (var w in sortedWarnings)
                 {
                     var benefitTag = w.MaxBenefitPercent.HasValue
-                        ? $" (up to {w.MaxBenefitPercent:N0}% benefit)"
+                        ? $" (up to {(w.MaxBenefitPercent.Value >= 100 ? w.MaxBenefitPercent.Value.ToString("N0") : w.MaxBenefitPercent.Value.ToString("N1"))}% benefit)"
                         : "";
                     writer.WriteLine($"  [{w.Severity}] {w.Type}{benefitTag}: {EscapeNewlines(w.Message)}");
                     if (!string.IsNullOrEmpty(w.ActionableFix))

--- a/src/PlanViewer.Core/Services/KeychainCredentialService.cs
+++ b/src/PlanViewer.Core/Services/KeychainCredentialService.cs
@@ -103,11 +103,14 @@ public class KeychainCredentialService : ICredentialService
         using var process = Process.Start(psi);
         if (process == null) return (-1, string.Empty);
 
+        // Read both streams concurrently. Doing stderr synchronously while stdout is
+        // async can deadlock if stderr fills its pipe buffer before the process exits
+        // (reproduces on `security dump-keychain` with large keychains).
         var stdoutTask = process.StandardOutput.ReadToEndAsync();
-        var stderr = process.StandardError.ReadToEnd();
+        var stderrTask = process.StandardError.ReadToEndAsync();
         process.WaitForExit();
-        var stdout = stdoutTask.Result;
+        Task.WaitAll(stdoutTask, stderrTask);
 
-        return (process.ExitCode, stdout + stderr);
+        return (process.ExitCode, stdoutTask.Result + stderrTask.Result);
     }
 }

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.cs
@@ -1593,24 +1593,43 @@ public static class PlanAnalyzer
     }
 
     /// <summary>
-    /// Serial row mode self-time: subtract all direct children's elapsed.
-    /// Exchange children are skipped through to their real child.
+    /// Serial row mode self-time: subtract all direct children's effective elapsed.
+    /// Pass-through operators (Compute Scalar, etc.) don't carry runtime stats —
+    /// look through them to the first descendant that does. Exchange children
+    /// use max-child elapsed because exchange times are unreliable.
     /// </summary>
     private static long GetSerialOwnElapsed(PlanNode node)
     {
         var totalChildElapsed = 0L;
         foreach (var child in node.Children)
-        {
-            var childElapsed = child.ActualElapsedMs;
-
-            // Exchange operators have unreliable times — skip to their child
-            if (child.PhysicalOp == "Parallelism" && child.Children.Count > 0)
-                childElapsed = child.Children.Max(c => c.ActualElapsedMs);
-
-            totalChildElapsed += childElapsed;
-        }
+            totalChildElapsed += GetEffectiveChildElapsedMs(child);
 
         return Math.Max(0, node.ActualElapsedMs - totalChildElapsed);
+    }
+
+    /// <summary>
+    /// Returns the elapsed time a child contributes to its parent's subtree.
+    /// Looks through pass-through operators (Compute Scalar, Parallelism exchange)
+    /// that don't carry reliable runtime stats.
+    /// </summary>
+    private static long GetEffectiveChildElapsedMs(PlanNode child)
+    {
+        // Exchange operators: unreliable times, use max child
+        if (child.PhysicalOp == "Parallelism" && child.Children.Count > 0)
+            return child.Children.Max(GetEffectiveChildElapsedMs);
+
+        // Child has its own stats: use them
+        if (child.ActualElapsedMs > 0)
+            return child.ActualElapsedMs;
+
+        // No stats (Compute Scalar and similar): look through to descendants
+        if (child.Children.Count == 0)
+            return 0;
+
+        var sum = 0L;
+        foreach (var grandchild in child.Children)
+            sum += GetEffectiveChildElapsedMs(grandchild);
+        return sum;
     }
 
     /// <summary>

--- a/src/PlanViewer.Core/Services/ReproScriptBuilder.cs
+++ b/src/PlanViewer.Core/Services/ReproScriptBuilder.cs
@@ -21,6 +21,20 @@ namespace PlanViewer.Core.Services;
 public static class ReproScriptBuilder
 {
     /// <summary>
+    /// Valid T-SQL isolation level names (uppercase) that may appear in a SET TRANSACTION
+    /// ISOLATION LEVEL statement. Used to gate interpolation so arbitrary upstream strings
+    /// can't land in the generated script.
+    /// </summary>
+    private static readonly HashSet<string> IsolationLevels = new(StringComparer.Ordinal)
+    {
+        "READ UNCOMMITTED",
+        "READ COMMITTED",
+        "REPEATABLE READ",
+        "SNAPSHOT",
+        "SERIALIZABLE",
+    };
+
+    /// <summary>
     /// Builds a complete reproduction script from available query data.
     /// </summary>
     public static string BuildReproScript(
@@ -94,10 +108,11 @@ public static class ReproScriptBuilder
         sb.AppendLine("*/");
         sb.AppendLine();
 
-        /* USE database (skip for Azure SQL DB — USE is invalid there) */
+        /* USE database (skip for Azure SQL DB — USE is invalid there).
+           Double any ']' in the identifier so names like 'cool]stuff' still parse. */
         if (!string.IsNullOrEmpty(databaseName) && !isAzureSqlDb)
         {
-            sb.AppendLine($"USE [{databaseName}];");
+            sb.AppendLine($"USE [{databaseName.Replace("]", "]]")}];");
             sb.AppendLine();
         }
 
@@ -116,7 +131,9 @@ public static class ReproScriptBuilder
 
         if (!string.IsNullOrEmpty(isolationLevel))
         {
-            sb.AppendLine($"SET TRANSACTION ISOLATION LEVEL {isolationLevel.ToUpperInvariant()};");
+            var upper = isolationLevel.ToUpperInvariant();
+            if (IsolationLevels.Contains(upper))
+                sb.AppendLine($"SET TRANSACTION ISOLATION LEVEL {upper};");
         }
         sb.AppendLine("SET NOCOUNT ON;");
         sb.AppendLine();

--- a/src/PlanViewer.Core/Services/ShowPlanParser.cs
+++ b/src/PlanViewer.Core/Services/ShowPlanParser.cs
@@ -1832,6 +1832,7 @@ public static class ShowPlanParser
     private static long ParseLong(string? value)
     {
         if (string.IsNullOrEmpty(value)) return 0;
-        return long.TryParse(value, out var result) ? result : 0;
+        return long.TryParse(value, System.Globalization.NumberStyles.Integer,
+            System.Globalization.CultureInfo.InvariantCulture, out var result) ? result : 0;
     }
 }

--- a/src/PlanViewer.Core/Services/WindowsCredentialService.cs
+++ b/src/PlanViewer.Core/Services/WindowsCredentialService.cs
@@ -16,7 +16,7 @@ public class WindowsCredentialService : ICredentialService
                 userName: username,
                 secret: password,
                 comment: "planview credential",
-                persistence: CredentialPersistence.LocalMachine);
+                persistence: CredentialPersistence.Enterprise);
             return true;
         }
         catch { return false; }

--- a/src/PlanViewer.Ssms/AppLauncher.cs
+++ b/src/PlanViewer.Ssms/AppLauncher.cs
@@ -20,12 +20,21 @@ namespace PlanViewer.Ssms
 
         /// <summary>
         /// Saves plan XML to a temp .sqlplan file and returns the path.
+        /// Uses a cryptographically-random suffix so the filename can't be predicted
+        /// or preempted by another local process (e.g. planting a symlink at the
+        /// expected path before the write lands). FileMode.CreateNew refuses to
+        /// overwrite a pre-existing file, closing the race further.
         /// </summary>
         public static string SavePlanToTemp(string planXml)
         {
-            var fileName = $"ssms_plan_{DateTime.Now:yyyyMMdd_HHmmss}.sqlplan";
+            var suffix = Path.GetFileNameWithoutExtension(Path.GetRandomFileName());
+            var fileName = "ssms_plan_" + suffix + ".sqlplan";
             var tempPath = Path.Combine(Path.GetTempPath(), fileName);
-            File.WriteAllText(tempPath, planXml);
+            using (var fs = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+            using (var writer = new StreamWriter(fs))
+            {
+                writer.Write(planXml);
+            }
             return tempPath;
         }
 

--- a/src/PlanViewer.Web/Pages/Index.razor
+++ b/src/PlanViewer.Web/Pages/Index.razor
@@ -302,7 +302,7 @@ else
                                 @w.WaitTimeMs.ToString("N0") ms
                                 @if (benefitPct > 0)
                                 {
-                                    <span class="wait-benefit">up to @benefitPct.ToString("N0")%</span>
+                                    <span class="wait-benefit">up to @(benefitPct >= 100 ? benefitPct.ToString("N0") : benefitPct.ToString("N1"))%</span>
                                 }
                             </span>
                         </div>
@@ -346,7 +346,7 @@ else
                         <span class="warning-type">@w.Type</span>
                         @if (w.MaxBenefitPercent.HasValue)
                         {
-                            <span class="warn-benefit">up to @w.MaxBenefitPercent.Value.ToString("N0")% benefit</span>
+                            <span class="warn-benefit">up to @(w.MaxBenefitPercent.Value >= 100 ? w.MaxBenefitPercent.Value.ToString("N0") : w.MaxBenefitPercent.Value.ToString("N1"))% benefit</span>
                         }
                         <span class="warning-msg">@w.Message</span>
                         @if (!string.IsNullOrEmpty(w.ActionableFix))


### PR DESCRIPTION
## Summary
Hotfix for #215 Joe feedback:

- **C5**: operator self-time was wrong for parents of Compute Scalar children (bug since v1.5.0). Fixed via look-through helper. Node-6 Hash Spill on Joe's plan went from a bogus 95% to the correct 17.4%.
- **C2**: benefit % now shows one decimal instead of rounding tiny waits to "up to 0%".

See PR #255 for details.

## Test plan
- [x] Joe's private plan math matches
- [x] Regression check on \`20260415_1.sqlplan\`
- [ ] Web viewer visual post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)