### PR TITLE
Release v1.7.3 — visible web viewer version

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'src/PlanViewer.Core/**'
       - 'src/PlanViewer.Web/**'
+      - 'src/PlanViewer.App/PlanViewer.App.csproj'
       - '.github/workflows/deploy-web.yml'
   workflow_dispatch:
 
@@ -35,6 +36,17 @@ jobs:
 
       - name: Install WASM workload
         run: dotnet workload install wasm-tools
+
+      - name: Sync web version with app version
+        shell: pwsh
+        run: |
+          $appVersion = ([xml](Get-Content src/PlanViewer.App/PlanViewer.App.csproj)).Project.PropertyGroup.Version | Where-Object { $_ }
+          Write-Host "App version: $appVersion"
+          $webCsproj = 'src/PlanViewer.Web/PlanViewer.Web.csproj'
+          $content = Get-Content $webCsproj -Raw
+          $content = [regex]::Replace($content, '<Version>[^<]+</Version>', "<Version>$appVersion</Version>")
+          Set-Content -Path $webCsproj -Value $content -NoNewline
+          Write-Host "Synced web csproj to $appVersion"
 
       - name: Publish Blazor WASM
         run: dotnet publish src/PlanViewer.Web/PlanViewer.Web.csproj -c Release -o publish

--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -6,7 +6,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>EDD.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>1.7.2</Version>
+    <Version>1.7.3</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Web/Pages/Index.razor
+++ b/src/PlanViewer.Web/Pages/Index.razor
@@ -7,7 +7,7 @@
         <div class="landing-content">
             <h2>Free SQL Server Query Plan Analysis</h2>
             <p class="privacy">Paste or upload a .sqlplan file. Your plan XML never leaves your browser.</p>
-            <p class="powered-by">Powered by the same analysis engine in the <a href="https://github.com/erikdarlingdata/PerformanceStudio" target="_blank" rel="noopener">Performance Studio</a> app.</p>
+            <p class="powered-by">Powered by the same analysis engine in the <a href="https://github.com/erikdarlingdata/PerformanceStudio" target="_blank" rel="noopener">Performance Studio</a> app. <span class="app-version">@AppVersion</span></p>
 
             @if (errorMessage != null)
             {
@@ -57,6 +57,7 @@ else
         {
             <span class="toolbar-version">@result.SqlServerBuild</span>
         }
+        <span class="toolbar-app-version" title="Performance Studio web viewer version">@AppVersion</span>
         @if (shareUrl != null)
         {
             <span class="share-url"><a href="@shareUrl" target="_blank">@shareUrl</a></span>
@@ -1663,6 +1664,13 @@ else
 
 @code {
     private const string ShareApiBase = "https://stats.erikdarling.com";
+
+    private static readonly string AppVersion = GetAppVersion();
+    private static string GetAppVersion()
+    {
+        var v = typeof(Index).Assembly.GetName().Version;
+        return v == null ? "?" : $"v{v.Major}.{v.Minor}.{v.Build}";
+    }
 
     private string activeTab = "paste";
     private string planXml = "";

--- a/src/PlanViewer.Web/PlanViewer.Web.csproj
+++ b/src/PlanViewer.Web/PlanViewer.Web.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>PlanViewer.Web</RootNamespace>
-    <Version>1.4.0</Version>
+    <Version>1.7.3</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>SQL Performance Studio</Product>

--- a/src/PlanViewer.Web/wwwroot/css/app.css
+++ b/src/PlanViewer.Web/wwwroot/css/app.css
@@ -451,6 +451,23 @@ textarea::placeholder {
     color: var(--text-muted);
 }
 
+.toolbar-app-version {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    padding: 0.1rem 0.4rem;
+    border-radius: 3px;
+    background: rgba(0, 0, 0, 0.05);
+    margin-left: auto;
+}
+
+.app-version {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    margin-left: 0.25rem;
+}
+
 /* === Statement Tabs === */
 .statement-tabs {
     display: flex;


### PR DESCRIPTION
## Summary
- Web viewer now shows its deployed version on the landing page and toolbar so reviewers (Joe) can tell at a glance which code they're testing against.
- \`deploy-web.yml\` auto-syncs the web csproj version with the app csproj version and triggers on App.csproj changes so releases keep the web deploy in sync.

See PR #257.

## Test plan
- [x] PR #257 green
- [ ] Visual post-deploy: badge visible on landing + toolbar, version reads v1.7.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)