### PR TITLE
Loosen memory grant colors + compile time as plan-level property (#215 C1, C4)

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -2800,9 +2800,12 @@ public partial class PlanViewerControl : UserControl
             rowIndex++;
         }
 
-        // Efficiency thresholds: white >= 80%, yellow >= 60%, orange >= 40%, red < 40%
-        static string EfficiencyColor(double pct) => pct >= 80 ? "#E4E6EB"
-            : pct >= 60 ? "#FFD700" : pct >= 40 ? "#FFB347" : "#E57373";
+        // Efficiency thresholds: white >= 40%, orange >= 20%, red < 20%.
+        // Loosened per Joe's feedback (#215 C1): for memory grants, moderate
+        // utilization (e.g. 60%) is fine — operators can spill near their max,
+        // so we shouldn't flag anything above a real over-grant threshold.
+        static string EfficiencyColor(double pct) => pct >= 40 ? "#E4E6EB"
+            : pct >= 20 ? "#FFB347" : "#E57373";
 
         // Runtime stats (actual plans)
         if (statement.QueryTimeStats != null)
@@ -2814,6 +2817,11 @@ public partial class PlanViewerControl : UserControl
             if (statement.QueryUdfElapsedTimeMs > 0)
                 AddRow("UDF elapsed", $"{statement.QueryUdfElapsedTimeMs:N0}ms");
         }
+
+        // Compile time — plan-level property (category B). Show regardless of
+        // threshold so it's always visible, not just when Rule 19 fires.
+        if (statement.CompileTimeMs > 0)
+            AddRow("Compile", $"{statement.CompileTimeMs:N0}ms");
 
         // Memory grant — color by utilization percentage
         if (statement.MemoryGrant != null)

--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -6,7 +6,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>EDD.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>1.7.4</Version>
+    <Version>1.7.5</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Core/Output/HtmlExporter.cs
+++ b/src/PlanViewer.Core/Output/HtmlExporter.cs
@@ -308,6 +308,8 @@ pre.query-text, pre.text-output {
                 WriteRow(sb, "CPU:Elapsed", ratio.ToString("N2"));
             }
         }
+        if (stmt.CompileTimeMs > 0)
+            WriteRow(sb, "Compile", $"{stmt.CompileTimeMs:N0} ms");
         if (stmt.DegreeOfParallelism > 0)
             WriteRow(sb, "DOP", stmt.DegreeOfParallelism.ToString());
         if (stmt.NonParallelReason != null)
@@ -315,7 +317,7 @@ pre.query-text, pre.text-output {
         if (stmt.MemoryGrant != null && stmt.MemoryGrant.GrantedKB > 0)
         {
             var pctUsed = (double)stmt.MemoryGrant.MaxUsedKB / stmt.MemoryGrant.GrantedKB * 100;
-            var effClass = pctUsed >= 80 ? "eff-good" : pctUsed >= 40 ? "eff-warn" : "eff-bad";
+            var effClass = pctUsed >= 40 ? "eff-good" : pctUsed >= 20 ? "eff-warn" : "eff-bad";
             WriteRow(sb, "Memory", FormatKB(stmt.MemoryGrant.GrantedKB) + " granted");
             sb.AppendLine($"<div class=\"row\"><span class=\"label\">Used</span><span class=\"value {effClass}\">{FormatKB(stmt.MemoryGrant.MaxUsedKB)} ({pctUsed:N0}%)</span></div>");
         }

--- a/src/PlanViewer.Web/Pages/Index.razor
+++ b/src/PlanViewer.Web/Pages/Index.razor
@@ -171,6 +171,13 @@ else
                         </div>
                     }
                 }
+                @if (ActiveStmt!.CompileTimeMs > 0)
+                {
+                    <div class="insight-row">
+                        <span class="insight-label">Compile</span>
+                        <span class="insight-value">@ActiveStmt!.CompileTimeMs.ToString("N0") ms</span>
+                    </div>
+                }
                 @if (ActiveStmt!.DegreeOfParallelism > 0)
                 {
                     <div class="insight-row">
@@ -188,7 +195,7 @@ else
                 @if (ActiveStmt!.MemoryGrant != null && ActiveStmt!.MemoryGrant.GrantedKB > 0)
                 {
                     var pctUsed = (double)ActiveStmt!.MemoryGrant.MaxUsedKB / ActiveStmt!.MemoryGrant.GrantedKB * 100;
-                    var effClass = pctUsed >= 80 ? "eff-good" : pctUsed >= 60 ? "eff-ok" : pctUsed >= 40 ? "eff-warn" : "eff-bad";
+                    var effClass = pctUsed >= 40 ? "eff-good" : pctUsed >= 20 ? "eff-warn" : "eff-bad";
                     <div class="insight-row">
                         <span class="insight-label">Memory</span>
                         <span class="insight-value">@FormatKB(ActiveStmt!.MemoryGrant.GrantedKB) granted</span>


### PR DESCRIPTION
## Summary
- **C1**: memory grant color scale was too harsh (61% utilized showed orange). New tiers: ≥40% good, 20–39% warn, <20% bad. Operators spill near their max, so moderate utilization is fine; what we flag now is real over-granting.
- **C4**: compile time always visible in the Runtime panel (category B plan-level property), not just when Rule 19 fires above 1000ms.

## Details
- \`PlanViewerControl.EfficiencyColor\` loosened — affects memory grant, DOP efficiency, thread utilization consistently.
- \`HtmlExporter\` memory card eff class + \`Index.razor\` eff class updated.
- \`Compile: Nms\` row added to Runtime card on all three surfaces.
- Version 1.7.4 → 1.7.5.

## Test plan
- [x] Build green
- [ ] Visual: 61% grant now reads green; compile row visible on plans with >0 compile time