### PR TITLE
Release v1.7.6 — C1 memory color + C4 compile time + C8 expensive-op + C9 columnstore

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -2800,9 +2800,12 @@ public partial class PlanViewerControl : UserControl
             rowIndex++;
         }
 
-        // Efficiency thresholds: white >= 80%, yellow >= 60%, orange >= 40%, red < 40%
-        static string EfficiencyColor(double pct) => pct >= 80 ? "#E4E6EB"
-            : pct >= 60 ? "#FFD700" : pct >= 40 ? "#FFB347" : "#E57373";
+        // Efficiency thresholds: white >= 40%, orange >= 20%, red < 20%.
+        // Loosened per Joe's feedback (#215 C1): for memory grants, moderate
+        // utilization (e.g. 60%) is fine — operators can spill near their max,
+        // so we shouldn't flag anything above a real over-grant threshold.
+        static string EfficiencyColor(double pct) => pct >= 40 ? "#E4E6EB"
+            : pct >= 20 ? "#FFB347" : "#E57373";
 
         // Runtime stats (actual plans)
         if (statement.QueryTimeStats != null)
@@ -2814,6 +2817,11 @@ public partial class PlanViewerControl : UserControl
             if (statement.QueryUdfElapsedTimeMs > 0)
                 AddRow("UDF elapsed", $"{statement.QueryUdfElapsedTimeMs:N0}ms");
         }
+
+        // Compile time — plan-level property (category B). Show regardless of
+        // threshold so it's always visible, not just when Rule 19 fires.
+        if (statement.CompileTimeMs > 0)
+            AddRow("Compile", $"{statement.CompileTimeMs:N0}ms");
 
         // Memory grant — color by utilization percentage
         if (statement.MemoryGrant != null)

--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -6,7 +6,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>EDD.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>1.7.5</Version>
+    <Version>1.7.6</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -6,7 +6,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>EDD.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>1.7.4</Version>
+    <Version>1.7.5</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Core/Output/HtmlExporter.cs
+++ b/src/PlanViewer.Core/Output/HtmlExporter.cs
@@ -308,6 +308,8 @@ pre.query-text, pre.text-output {
                 WriteRow(sb, "CPU:Elapsed", ratio.ToString("N2"));
             }
         }
+        if (stmt.CompileTimeMs > 0)
+            WriteRow(sb, "Compile", $"{stmt.CompileTimeMs:N0} ms");
         if (stmt.DegreeOfParallelism > 0)
             WriteRow(sb, "DOP", stmt.DegreeOfParallelism.ToString());
         if (stmt.NonParallelReason != null)
@@ -315,7 +317,7 @@ pre.query-text, pre.text-output {
         if (stmt.MemoryGrant != null && stmt.MemoryGrant.GrantedKB > 0)
         {
             var pctUsed = (double)stmt.MemoryGrant.MaxUsedKB / stmt.MemoryGrant.GrantedKB * 100;
-            var effClass = pctUsed >= 80 ? "eff-good" : pctUsed >= 40 ? "eff-warn" : "eff-bad";
+            var effClass = pctUsed >= 40 ? "eff-good" : pctUsed >= 20 ? "eff-warn" : "eff-bad";
             WriteRow(sb, "Memory", FormatKB(stmt.MemoryGrant.GrantedKB) + " granted");
             sb.AppendLine($"<div class=\"row\"><span class=\"label\">Used</span><span class=\"value {effClass}\">{FormatKB(stmt.MemoryGrant.MaxUsedKB)} ({pctUsed:N0}%)</span></div>");
         }

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.cs
@@ -921,21 +921,38 @@ public static class PlanAnalyzer
                 ? GetOperatorOwnElapsedMs(node) > 0
                 : node.CostPercent >= 20;
 
-            if (colCount <= 3 && isSignificant)
+            if (isSignificant)
             {
                 var scanKind = node.PhysicalOp == "Clustered Index Scan"
                     ? "Clustered index scan"
                     : "Heap table scan";
-                var indexAdvice = node.PhysicalOp == "Clustered Index Scan"
-                    ? "Consider a nonclustered index on the output columns (as key or INCLUDE) so SQL Server can read a narrower structure."
-                    : "Consider a clustered or nonclustered index on the output columns so SQL Server can read a narrower structure.";
 
-                node.Warnings.Add(new PlanWarning
+                if (colCount <= 3)
                 {
-                    WarningType = "Bare Scan",
-                    Message = $"{scanKind} reads the full table with no predicate, outputting {colCount} column(s): {Truncate(node.OutputColumns, 200)}. {indexAdvice} For analytical workloads, a columnstore index may be a better fit.",
-                    Severity = PlanWarningSeverity.Warning
-                });
+                    // Narrow output: a nonclustered rowstore index can cover this cheaply.
+                    var indexAdvice = node.PhysicalOp == "Clustered Index Scan"
+                        ? "Consider a nonclustered index on the output columns (as key or INCLUDE) so SQL Server can read a narrower structure."
+                        : "Consider a clustered or nonclustered index on the output columns so SQL Server can read a narrower structure.";
+
+                    node.Warnings.Add(new PlanWarning
+                    {
+                        WarningType = "Bare Scan",
+                        Message = $"{scanKind} reads the full table with no predicate, outputting {colCount} column(s): {Truncate(node.OutputColumns, 200)}. {indexAdvice} For analytical workloads, a columnstore index may be a better fit.",
+                        Severity = PlanWarningSeverity.Warning
+                    });
+                }
+                else
+                {
+                    // Wider output: rowstore NC index isn't a great fit (would have to
+                    // carry too many columns), but columnstore doesn't care about column
+                    // count. Suggest it for analytical / aggregate-style workloads.
+                    node.Warnings.Add(new PlanWarning
+                    {
+                        WarningType = "Bare Scan",
+                        Message = $"{scanKind} reads the full table with no predicate, outputting {colCount} columns. A nonclustered rowstore index isn't a great fit for wide outputs, but if this is an analytical or aggregate-style query, a columnstore index (CCI or NCCI) can scan the same data far more cheaply — column count doesn't penalize columnstore the way it does rowstore indexes.",
+                        Severity = PlanWarningSeverity.Warning
+                    });
+                }
             }
         }
 
@@ -1227,6 +1244,29 @@ public static class PlanAnalyzer
             {
                 w.Severity = PlanWarningSeverity.Critical;
                 w.Message = $"Implicit conversion prevented an index seek, forcing a scan instead. Fix the data type mismatch: ensure the parameter or variable type matches the column type exactly. {w.Message}";
+            }
+        }
+
+        // Rule 35: Expensive Operator — always show operators that take a significant
+        // share of statement time even when no other rule has something to say. Joe
+        // (#215 C8) wanted expensive scans that the tool had nothing to suggest on
+        // to still surface as top items. Threshold: self-time >= 20% of statement
+        // elapsed. Only emits if no other warning is already on the node to avoid
+        // doubling up. The benefit % is just the self-time share.
+        if (!cfg.IsRuleDisabled(35) && node.HasActualStats && node.Warnings.Count == 0
+            && stmt.QueryTimeStats != null && stmt.QueryTimeStats.ElapsedTimeMs > 0)
+        {
+            var selfMs = GetOperatorOwnElapsedMs(node);
+            var pct = (double)selfMs / stmt.QueryTimeStats.ElapsedTimeMs * 100;
+            if (pct >= 20.0)
+            {
+                node.Warnings.Add(new PlanWarning
+                {
+                    WarningType = "Expensive Operator",
+                    Message = $"{node.PhysicalOp} took {selfMs:N0}ms ({pct:N1}% of statement elapsed) but no specific rule identified a fix. Worth investigating: is the row volume necessary? Are upstream estimates driving this operator harder than it should be?",
+                    Severity = pct >= 50 ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning,
+                    MaxBenefitPercent = Math.Round(Math.Min(100.0, pct), 1)
+                });
             }
         }
     }

--- a/src/PlanViewer.Web/Pages/Index.razor
+++ b/src/PlanViewer.Web/Pages/Index.razor
@@ -171,6 +171,13 @@ else
                         </div>
                     }
                 }
+                @if (ActiveStmt!.CompileTimeMs > 0)
+                {
+                    <div class="insight-row">
+                        <span class="insight-label">Compile</span>
+                        <span class="insight-value">@ActiveStmt!.CompileTimeMs.ToString("N0") ms</span>
+                    </div>
+                }
                 @if (ActiveStmt!.DegreeOfParallelism > 0)
                 {
                     <div class="insight-row">
@@ -188,7 +195,7 @@ else
                 @if (ActiveStmt!.MemoryGrant != null && ActiveStmt!.MemoryGrant.GrantedKB > 0)
                 {
                     var pctUsed = (double)ActiveStmt!.MemoryGrant.MaxUsedKB / ActiveStmt!.MemoryGrant.GrantedKB * 100;
-                    var effClass = pctUsed >= 80 ? "eff-good" : pctUsed >= 60 ? "eff-ok" : pctUsed >= 40 ? "eff-warn" : "eff-bad";
+                    var effClass = pctUsed >= 40 ? "eff-good" : pctUsed >= 20 ? "eff-warn" : "eff-bad";
                     <div class="insight-row">
                         <span class="insight-label">Memory</span>
                         <span class="insight-value">@FormatKB(ActiveStmt!.MemoryGrant.GrantedKB) granted</span>


### PR DESCRIPTION
## Summary
Batched release covering four items from #215:

- **C1** (PR #261) — loosened memory grant color thresholds; ≥40% utilization is green
- **C4** (PR #261) — compile time always visible in Runtime panel as plan-level property
- **C8** (PR #263) — new Rule 35 "Expensive Operator" surfaces operators ≥20% self-time even when no other rule fires
- **C9** (PR #263) — Rule 34 now fires on wide-output bare scans with columnstore advice

## Test plan
- [x] All four items verified against private + public reference plans
- [ ] Visual checks post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)