### PR TITLE
Batch-mode subtree elapsed sums when computing parent self-time (#215 D1)

### DIFF
--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -6,7 +6,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>EDD.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>1.7.7</Version>
+    <Version>1.7.8</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.cs
@@ -1731,6 +1731,14 @@ public static class PlanAnalyzer
         if (child.PhysicalOp == "Parallelism" && child.Children.Count > 0)
             return child.Children.Max(GetEffectiveChildElapsedMs);
 
+        // Batch mode pipelines — each operator's elapsed stands alone rather than
+        // rolling up its descendants the way row-mode does. For a parent computing
+        // self-time above a batch-mode subtree, subtract the whole pipeline's time
+        // (Joe #215 D1: Parallelism gather-streams above three batch operators).
+        var mode = child.ActualExecutionMode ?? child.ExecutionMode;
+        if (mode == "Batch" && child.HasActualStats)
+            return SumBatchSubtreeElapsedMs(child);
+
         // Child has its own stats: use them
         if (child.ActualElapsedMs > 0)
             return child.ActualElapsedMs;
@@ -1742,6 +1750,30 @@ public static class PlanAnalyzer
         var sum = 0L;
         foreach (var grandchild in child.Children)
             sum += GetEffectiveChildElapsedMs(grandchild);
+        return sum;
+    }
+
+    /// <summary>
+    /// Sums ActualElapsedMs across a contiguous batch-mode subtree (stops at
+    /// Parallelism exchange zone boundaries). Batch operators pipeline — elapsed
+    /// times are standalone, not cumulative — so summing gives the total work the
+    /// zone did, which is what a row-mode parent above the zone should subtract
+    /// to get its own self-time.
+    /// </summary>
+    private static long SumBatchSubtreeElapsedMs(PlanNode node)
+    {
+        long sum = node.ActualElapsedMs;
+        foreach (var child in node.Children)
+        {
+            // Zone boundary — stop summing
+            if (child.PhysicalOp == "Parallelism") continue;
+
+            var childMode = child.ActualExecutionMode ?? child.ExecutionMode;
+            if (childMode == "Batch" && child.HasActualStats)
+                sum += SumBatchSubtreeElapsedMs(child);
+            else
+                sum += GetEffectiveChildElapsedMs(child);
+        }
         return sum;
     }
 


### PR DESCRIPTION
## Summary
Parallelism (Gather Streams) over a batch-mode zone was reporting bogus self-time because \`GetEffectiveChildElapsedMs\` only subtracted the direct child's elapsed. Batch-mode operators pipeline — each elapsed is standalone, not cumulative — so the correct subtraction sums across the batch pipeline.

## Verified on Joe's plan 5GQmlu6m7W
- Parallelism elapsed = 21,177ms
- Subtree: Compute Scalar (batch, 9ms) → Hash Match Aggregate (batch, 10,294ms) → Clustered Index Scan (batch, 13,761ms)
- Old: self = 21,177 − 9 = 21,168ms (~56% of statement — bogus)
- New: self = max(0, 21,177 − (9 + 10,294 + 13,761)) = 0ms (matches Joe's \`21.177 - 0.009 - 10.294 - 13.761\`)

## Regression check
- \`c1-c5.sqlplan\` (serial row mode): all warnings unchanged
- \`20260415_1.sqlplan\` (parallel batch): all wait benefits + operator warnings unchanged — only triggers when a row-mode parent sits above a batch-mode subtree with stats

## D2 note
Joe also flagged an unhelpful CXPACKET warning on the same plan. That was addressed by v1.7.7's WaitStatsKnowledge content strip; the CXPACKET item now shows raw ms/count only. The deeper concern about CXPACKET double-counting other waits is a future refinement.

Version 1.7.7 → 1.7.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)