### PR TITLE
Release v1.7.8 — batch-mode pipelined self-time (#215 D1)

### DIFF
--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -6,7 +6,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>EDD.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>1.7.7</Version>
+    <Version>1.7.8</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.cs
@@ -1731,6 +1731,14 @@ public static class PlanAnalyzer
         if (child.PhysicalOp == "Parallelism" && child.Children.Count > 0)
             return child.Children.Max(GetEffectiveChildElapsedMs);
 
+        // Batch mode pipelines — each operator's elapsed stands alone rather than
+        // rolling up its descendants the way row-mode does. For a parent computing
+        // self-time above a batch-mode subtree, subtract the whole pipeline's time
+        // (Joe #215 D1: Parallelism gather-streams above three batch operators).
+        var mode = child.ActualExecutionMode ?? child.ExecutionMode;
+        if (mode == "Batch" && child.HasActualStats)
+            return SumBatchSubtreeElapsedMs(child);
+
         // Child has its own stats: use them
         if (child.ActualElapsedMs > 0)
             return child.ActualElapsedMs;
@@ -1742,6 +1750,30 @@ public static class PlanAnalyzer
         var sum = 0L;
         foreach (var grandchild in child.Children)
             sum += GetEffectiveChildElapsedMs(grandchild);
+        return sum;
+    }
+
+    /// <summary>
+    /// Sums ActualElapsedMs across a contiguous batch-mode subtree (stops at
+    /// Parallelism exchange zone boundaries). Batch operators pipeline — elapsed
+    /// times are standalone, not cumulative — so summing gives the total work the
+    /// zone did, which is what a row-mode parent above the zone should subtract
+    /// to get its own self-time.
+    /// </summary>
+    private static long SumBatchSubtreeElapsedMs(PlanNode node)
+    {
+        long sum = node.ActualElapsedMs;
+        foreach (var child in node.Children)
+        {
+            // Zone boundary — stop summing
+            if (child.PhysicalOp == "Parallelism") continue;
+
+            var childMode = child.ActualExecutionMode ?? child.ExecutionMode;
+            if (childMode == "Batch" && child.HasActualStats)
+                sum += SumBatchSubtreeElapsedMs(child);
+            else
+                sum += GetEffectiveChildElapsedMs(child);
+        }
         return sum;
     }
 


### PR DESCRIPTION
## Summary
Fix for Joe's #215 D1: Parallelism (Gather Streams) over a batch-mode zone was reporting bogus 21s self-time. Batch-mode operators pipeline, so the correct self-time subtracts sum across the batch subtree, not just the direct child. On Joe's plan 5GQmlu6m7W, Parallelism self goes from 21,168ms to 0ms (matches his `21.177 − 0.009 − 10.294 − 13.761` exactly).

See PR #268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)