### PR TITLE
Runtime card refinements (#215 E7-E11)

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml
@@ -110,7 +110,8 @@
                             Background="{DynamicResource BackgroundDarkBrush}"
                             BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,1,0">
                         <StackPanel>
-                            <TextBlock Text="Runtime Summary"
+                            <TextBlock x:Name="RuntimeSummaryTitle"
+                                       Text="Runtime Summary"
                                        FontSize="13"
                                        FontWeight="SemiBold"
                                        Foreground="{DynamicResource ForegroundBrush}"

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -804,6 +804,15 @@ public partial class PlanViewerControl : UserControl
     private static string FormatBenefitPercent(double pct) =>
         pct >= 100 ? $"{pct:N0}" : $"{pct:N1}";
 
+    private static bool HasSpillInPlanTree(PlanNode node)
+    {
+        foreach (var w in node.Warnings)
+            if (w.WarningType.EndsWith(" Spill", StringComparison.Ordinal)) return true;
+        foreach (var child in node.Children)
+            if (HasSpillInPlanTree(child)) return true;
+        return false;
+    }
+
     #endregion
 
     #region Node Selection & Properties Panel
@@ -2809,37 +2818,42 @@ public partial class PlanViewerControl : UserControl
         static string EfficiencyColor(double pct) => pct >= 40 ? "#E4E6EB"
             : pct >= 20 ? "#FFB347" : "#E57373";
 
-        // Runtime stats (actual plans)
+        // Memory grant color tiers (#215 C1 + E8 + E9): over-used grant (red),
+        // any operator spilled (orange), otherwise tier by utilization.
+        static string MemoryGrantColor(double pctUsed, bool hasSpill)
+        {
+            if (pctUsed > 100) return "#E57373";
+            if (hasSpill) return "#FFB347";
+            if (pctUsed >= 40) return "#E4E6EB";
+            if (pctUsed >= 20) return "#FFB347";
+            return "#E57373";
+        }
+
+        // E7: rename the panel title for estimated plans
+        var isEstimated = statement.QueryTimeStats == null;
+        RuntimeSummaryTitle.Text = isEstimated ? "Predicted Runtime" : "Runtime Summary";
+
+        var hasSpillInTree = statement.RootNode != null && HasSpillInPlanTree(statement.RootNode);
+
+        // E11: order — Elapsed → CPU:Elapsed → DOP → CPU → Compile → Memory → Used → Optimization → CE Model → Cost.
+        // Extra Avalonia-only rows (threads, UDF, cached plan size) kept near their logical neighbors.
+
         if (statement.QueryTimeStats != null)
         {
             AddRow("Elapsed", $"{statement.QueryTimeStats.ElapsedTimeMs:N0}ms");
-            AddRow("CPU", $"{statement.QueryTimeStats.CpuTimeMs:N0}ms");
-            if (statement.QueryUdfCpuTimeMs > 0)
-                AddRow("UDF CPU", $"{statement.QueryUdfCpuTimeMs:N0}ms");
-            if (statement.QueryUdfElapsedTimeMs > 0)
-                AddRow("UDF elapsed", $"{statement.QueryUdfElapsedTimeMs:N0}ms");
+            if (statement.QueryTimeStats.ElapsedTimeMs > 0)
+            {
+                long externalWaitMs = 0;
+                foreach (var w in statement.WaitStats)
+                    if (BenefitScorer.IsExternalWait(w.WaitType))
+                        externalWaitMs += w.WaitTimeMs;
+                var effectiveCpu = Math.Max(0L, statement.QueryTimeStats.CpuTimeMs - externalWaitMs);
+                var ratio = (double)effectiveCpu / statement.QueryTimeStats.ElapsedTimeMs;
+                AddRow("CPU:Elapsed", ratio.ToString("N2"));
+            }
         }
 
-        // Compile time — plan-level property (category B). Show regardless of
-        // threshold so it's always visible, not just when Rule 19 fires.
-        if (statement.CompileTimeMs > 0)
-            AddRow("Compile", $"{statement.CompileTimeMs:N0}ms");
-
-        // Memory grant — color by utilization percentage
-        if (statement.MemoryGrant != null)
-        {
-            var mg = statement.MemoryGrant;
-            var grantPct = mg.GrantedMemoryKB > 0
-                ? (double)mg.MaxUsedMemoryKB / mg.GrantedMemoryKB * 100 : 100;
-            var grantColor = EfficiencyColor(grantPct);
-            AddRow("Memory grant",
-                $"{TextFormatter.FormatMemoryGrantKB(mg.GrantedMemoryKB)} granted, {TextFormatter.FormatMemoryGrantKB(mg.MaxUsedMemoryKB)} used ({grantPct:N0}%)",
-                grantColor);
-            if (mg.GrantWaitTimeMs > 0)
-                AddRow("Grant wait", $"{mg.GrantWaitTimeMs:N0}ms", "#E57373");
-        }
-
-        // DOP + parallelism efficiency — color by efficiency
+        // DOP + parallelism efficiency
         if (statement.DegreeOfParallelism > 0)
         {
             var dopText = statement.DegreeOfParallelism.ToString();
@@ -2849,9 +2863,6 @@ public partial class PlanViewerControl : UserControl
                 statement.QueryTimeStats.CpuTimeMs > 0 &&
                 statement.DegreeOfParallelism > 1)
             {
-                // Speedup ratio: CPU/elapsed = 1.0 means serial, = DOP means perfect parallelism.
-                // Subtract external/preemptive wait time from CPU — those waits are CPU-busy
-                // in kernel and inflate the ratio without representing real query work.
                 long externalWaitMs = 0;
                 foreach (var w in statement.WaitStats)
                     if (BenefitScorer.IsExternalWait(w.WaitType))
@@ -2868,7 +2879,37 @@ public partial class PlanViewerControl : UserControl
         else if (statement.NonParallelPlanReason != null)
             AddRow("Serial", statement.NonParallelPlanReason);
 
-        // Thread stats — color by utilization
+        if (statement.QueryTimeStats != null)
+        {
+            AddRow("CPU", $"{statement.QueryTimeStats.CpuTimeMs:N0}ms");
+            if (statement.QueryUdfCpuTimeMs > 0)
+                AddRow("UDF CPU", $"{statement.QueryUdfCpuTimeMs:N0}ms");
+            if (statement.QueryUdfElapsedTimeMs > 0)
+                AddRow("UDF elapsed", $"{statement.QueryUdfElapsedTimeMs:N0}ms");
+        }
+
+        // Compile stats (category B plan-level property)
+        if (statement.CompileTimeMs > 0)
+            AddRow("Compile", $"{statement.CompileTimeMs:N0}ms");
+        if (statement.CachedPlanSizeKB > 0)
+            AddRow("Cached plan size", $"{statement.CachedPlanSizeKB:N0} KB");
+
+        // Memory grant — color per new tiers, spill indicator if any operator spilled
+        if (statement.MemoryGrant != null)
+        {
+            var mg = statement.MemoryGrant;
+            var grantPct = mg.GrantedMemoryKB > 0
+                ? (double)mg.MaxUsedMemoryKB / mg.GrantedMemoryKB * 100 : 100;
+            var grantColor = MemoryGrantColor(grantPct, hasSpillInTree);
+            var spillTag = hasSpillInTree ? " ⚠ spill" : "";
+            AddRow("Memory grant",
+                $"{TextFormatter.FormatMemoryGrantKB(mg.GrantedMemoryKB)} granted, {TextFormatter.FormatMemoryGrantKB(mg.MaxUsedMemoryKB)} used ({grantPct:N0}%){spillTag}",
+                grantColor);
+            if (mg.GrantWaitTimeMs > 0)
+                AddRow("Grant wait", $"{mg.GrantWaitTimeMs:N0}ms", "#E57373");
+        }
+
+        // Thread stats
         if (statement.ThreadStats != null)
         {
             var ts = statement.ThreadStats;
@@ -2889,21 +2930,13 @@ public partial class PlanViewerControl : UserControl
             }
         }
 
-        // CE model
-        if (statement.CardinalityEstimationModelVersion > 0)
-            AddRow("CE model", statement.CardinalityEstimationModelVersion.ToString());
-
-        // Compile stats (always available)
-        if (statement.CompileTimeMs > 0)
-            AddRow("Compile time", $"{statement.CompileTimeMs:N0}ms");
-        if (statement.CachedPlanSizeKB > 0)
-            AddRow("Cached plan size", $"{statement.CachedPlanSizeKB:N0} KB");
-
-        // Optimization level
+        // Optimization + CE model
         if (!string.IsNullOrEmpty(statement.StatementOptmLevel))
             AddRow("Optimization", statement.StatementOptmLevel);
         if (!string.IsNullOrEmpty(statement.StatementOptmEarlyAbortReason))
             AddRow("Early abort", statement.StatementOptmEarlyAbortReason);
+        if (statement.CardinalityEstimationModelVersion > 0)
+            AddRow("CE model", statement.CardinalityEstimationModelVersion.ToString());
 
         if (grid.Children.Count > 0)
         {

--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -6,7 +6,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>EDD.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>1.7.8</Version>
+    <Version>1.8.0</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Core/Output/HtmlExporter.cs
+++ b/src/PlanViewer.Core/Output/HtmlExporter.cs
@@ -189,6 +189,7 @@ pre.mi-create {
 .warn-msg { font-size: 0.8rem; color: var(--text); flex-basis: 100%; }
 .warn-legacy { font-size: 0.65rem; font-weight: 600; color: var(--text-muted); padding: 0.05rem 0.3rem; border-radius: 3px; background: rgba(0,0,0,0.08); text-transform: uppercase; letter-spacing: 0.05em; }
 .warn-fix { font-size: 0.75rem; color: var(--text-secondary); font-style: italic; flex-basis: 100%; border-left: 2px solid var(--border); padding-left: 0.5rem; margin-top: 0.15rem; }
+.spill-tag { font-size: 0.75rem; font-weight: 600; color: var(--orange); margin-left: 0.4rem; }
 
 /* Query text */
 details { margin-bottom: 0.75rem; }
@@ -294,14 +295,18 @@ pre.query-text, pre.text-output {
 
     private static void WriteRuntimeCard(StringBuilder sb, StatementResult stmt)
     {
+        var isEstimated = stmt.QueryTime == null;
+        var hasSpill = HasSpillInTree(stmt.OperatorTree);
         sb.AppendLine("<div class=\"card runtime\">");
-        sb.AppendLine("<h3>Runtime</h3>");
+        sb.AppendLine($"<h3>{(isEstimated ? "Predicted Runtime" : "Runtime")}</h3>");
         sb.AppendLine("<div class=\"card-body\">");
-        WriteRow(sb, "Cost", stmt.EstimatedCost.ToString("N2"));
+
+        // Order per Joe (#215 E11): Elapsed → CPU:Elapsed → DOP → CPU → Compile →
+        // Memory → Used → Optimization → CE Model → Cost. Puts the important
+        // measurements on top and groups related metrics together.
         if (stmt.QueryTime != null)
         {
             WriteRow(sb, "Elapsed", $"{stmt.QueryTime.ElapsedTimeMs:N0} ms");
-            WriteRow(sb, "CPU", $"{stmt.QueryTime.CpuTimeMs:N0} ms");
             if (stmt.QueryTime.ElapsedTimeMs > 0)
             {
                 var effectiveCpu = Math.Max(0, stmt.QueryTime.CpuTimeMs - stmt.QueryTime.ExternalWaitMs);
@@ -309,25 +314,59 @@ pre.query-text, pre.text-output {
                 WriteRow(sb, "CPU:Elapsed", ratio.ToString("N2"));
             }
         }
-        if (stmt.CompileTimeMs > 0)
-            WriteRow(sb, "Compile", $"{stmt.CompileTimeMs:N0} ms");
         if (stmt.DegreeOfParallelism > 0)
             WriteRow(sb, "DOP", stmt.DegreeOfParallelism.ToString());
         if (stmt.NonParallelReason != null)
             WriteRow(sb, "Serial", Encode(stmt.NonParallelReason));
+        if (stmt.QueryTime != null)
+            WriteRow(sb, "CPU", $"{stmt.QueryTime.CpuTimeMs:N0} ms");
+        if (stmt.CompileTimeMs > 0)
+            WriteRow(sb, "Compile", $"{stmt.CompileTimeMs:N0} ms");
         if (stmt.MemoryGrant != null && stmt.MemoryGrant.GrantedKB > 0)
         {
             var pctUsed = (double)stmt.MemoryGrant.MaxUsedKB / stmt.MemoryGrant.GrantedKB * 100;
-            var effClass = pctUsed >= 40 ? "eff-good" : pctUsed >= 20 ? "eff-warn" : "eff-bad";
+            var effClass = GetMemoryGrantColorClass(pctUsed, hasSpill);
             WriteRow(sb, "Memory", FormatKB(stmt.MemoryGrant.GrantedKB) + " granted");
-            sb.AppendLine($"<div class=\"row\"><span class=\"label\">Used</span><span class=\"value {effClass}\">{FormatKB(stmt.MemoryGrant.MaxUsedKB)} ({pctUsed:N0}%)</span></div>");
+            var spillTag = hasSpill ? " <span class=\"spill-tag\" title=\"Operators spilled to tempdb\">⚠ spill</span>" : "";
+            sb.AppendLine($"<div class=\"row\"><span class=\"label\">Used</span><span class=\"value {effClass}\">{FormatKB(stmt.MemoryGrant.MaxUsedKB)} ({pctUsed:N0}%){spillTag}</span></div>");
         }
         if (stmt.OptimizationLevel != null)
             WriteRow(sb, "Optimization", Encode(stmt.OptimizationLevel));
         if (stmt.CardinalityEstimationModel > 0)
             WriteRow(sb, "CE Model", stmt.CardinalityEstimationModel.ToString());
+        WriteRow(sb, "Cost", stmt.EstimatedCost.ToString("N2"));
         sb.AppendLine("</div>");
         sb.AppendLine("</div>");
+    }
+
+    /// <summary>
+    /// Memory grant color tiers (#215 C1 + E8 + E9):
+    /// - > 100% used: eff-bad (grant was too small, may have thrashed memory)
+    /// - any operator spilled: eff-warn (grant was nominally enough but something spilled)
+    /// - >= 40% used: eff-good (healthy utilization)
+    /// - 20-39%: eff-warn (some over-grant)
+    /// - < 20%: eff-bad (significant over-grant)
+    /// </summary>
+    private static string GetMemoryGrantColorClass(double pctUsed, bool hasSpill)
+    {
+        if (pctUsed > 100) return "eff-bad";
+        if (hasSpill) return "eff-warn";
+        if (pctUsed >= 40) return "eff-good";
+        if (pctUsed >= 20) return "eff-warn";
+        return "eff-bad";
+    }
+
+    private static bool HasSpillInTree(OperatorResult? node)
+    {
+        if (node == null) return false;
+        foreach (var w in node.Warnings)
+        {
+            if (w.Type.EndsWith(" Spill", StringComparison.Ordinal))
+                return true;
+        }
+        foreach (var child in node.Children)
+            if (HasSpillInTree(child)) return true;
+        return false;
     }
 
     private static void WriteMissingIndexCard(StringBuilder sb, StatementResult stmt)

--- a/src/PlanViewer.Web/Pages/Index.razor
+++ b/src/PlanViewer.Web/Pages/Index.razor
@@ -144,22 +144,19 @@ else
     <div class="insights-panel">
 
         @* Runtime Summary *@
+        @{
+            var isEstimatedRuntime = ActiveStmt!.QueryTime == null;
+            var hasAnySpill = HasSpillInTree(ActiveStmt!.OperatorTree);
+        }
         <div class="insight-card runtime">
-            <h4>Runtime</h4>
+            <h4>@(isEstimatedRuntime ? "Predicted Runtime" : "Runtime")</h4>
             <div class="insight-body">
-                <div class="insight-row">
-                    <span class="insight-label">Cost</span>
-                    <span class="insight-value">@ActiveStmt!.EstimatedCost.ToString("N2")</span>
-                </div>
+                @* Order per Joe #215 E11: Elapsed → CPU:Elapsed → DOP → CPU → Compile → Memory → Used → Optimization → CE Model → Cost *@
                 @if (ActiveStmt!.QueryTime != null)
                 {
                     <div class="insight-row">
                         <span class="insight-label">Elapsed</span>
                         <span class="insight-value">@ActiveStmt!.QueryTime.ElapsedTimeMs.ToString("N0") ms</span>
-                    </div>
-                    <div class="insight-row">
-                        <span class="insight-label">CPU</span>
-                        <span class="insight-value">@ActiveStmt!.QueryTime.CpuTimeMs.ToString("N0") ms</span>
                     </div>
                     @if (ActiveStmt!.QueryTime.ElapsedTimeMs > 0)
                     {
@@ -170,13 +167,6 @@ else
                             <span class="insight-value">@ratio.ToString("N2")</span>
                         </div>
                     }
-                }
-                @if (ActiveStmt!.CompileTimeMs > 0)
-                {
-                    <div class="insight-row">
-                        <span class="insight-label">Compile</span>
-                        <span class="insight-value">@ActiveStmt!.CompileTimeMs.ToString("N0") ms</span>
-                    </div>
                 }
                 @if (ActiveStmt!.DegreeOfParallelism > 0)
                 {
@@ -192,17 +182,37 @@ else
                         <span class="insight-value">@ActiveStmt!.NonParallelReason</span>
                     </div>
                 }
+                @if (ActiveStmt!.QueryTime != null)
+                {
+                    <div class="insight-row">
+                        <span class="insight-label">CPU</span>
+                        <span class="insight-value">@ActiveStmt!.QueryTime.CpuTimeMs.ToString("N0") ms</span>
+                    </div>
+                }
+                @if (ActiveStmt!.CompileTimeMs > 0)
+                {
+                    <div class="insight-row">
+                        <span class="insight-label">Compile</span>
+                        <span class="insight-value">@ActiveStmt!.CompileTimeMs.ToString("N0") ms</span>
+                    </div>
+                }
                 @if (ActiveStmt!.MemoryGrant != null && ActiveStmt!.MemoryGrant.GrantedKB > 0)
                 {
                     var pctUsed = (double)ActiveStmt!.MemoryGrant.MaxUsedKB / ActiveStmt!.MemoryGrant.GrantedKB * 100;
-                    var effClass = pctUsed >= 40 ? "eff-good" : pctUsed >= 20 ? "eff-warn" : "eff-bad";
+                    var effClass = GetMemoryGrantColorClass(pctUsed, hasAnySpill);
                     <div class="insight-row">
                         <span class="insight-label">Memory</span>
                         <span class="insight-value">@FormatKB(ActiveStmt!.MemoryGrant.GrantedKB) granted</span>
                     </div>
                     <div class="insight-row">
                         <span class="insight-label">Used</span>
-                        <span class="insight-value @effClass">@FormatKB(ActiveStmt!.MemoryGrant.MaxUsedKB) (@pctUsed.ToString("N0")%)</span>
+                        <span class="insight-value @effClass">
+                            @FormatKB(ActiveStmt!.MemoryGrant.MaxUsedKB) (@pctUsed.ToString("N0")%)
+                            @if (hasAnySpill)
+                            {
+                                <span class="spill-tag" title="Operators spilled to tempdb">⚠ spill</span>
+                            }
+                        </span>
                     </div>
                 }
                 @if (ActiveStmt!.OptimizationLevel != null)
@@ -219,6 +229,10 @@ else
                         <span class="insight-value">@ActiveStmt!.CardinalityEstimationModel</span>
                     </div>
                 }
+                <div class="insight-row">
+                    <span class="insight-label">Cost</span>
+                    <span class="insight-value">@ActiveStmt!.EstimatedCost.ToString("N2")</span>
+                </div>
             </div>
         </div>
 
@@ -1682,6 +1696,27 @@ else
     {
         var v = typeof(Index).Assembly.GetName().Version;
         return v == null ? "?" : $"v{v.Major}.{v.Minor}.{v.Build}";
+    }
+
+    // Memory grant color tiers (#215 C1 + E8 + E9):
+    // > 100%: over-used grant (red). Spill in plan: orange. Otherwise: tier by utilization.
+    private static string GetMemoryGrantColorClass(double pctUsed, bool hasSpill)
+    {
+        if (pctUsed > 100) return "eff-bad";
+        if (hasSpill) return "eff-warn";
+        if (pctUsed >= 40) return "eff-good";
+        if (pctUsed >= 20) return "eff-warn";
+        return "eff-bad";
+    }
+
+    private static bool HasSpillInTree(OperatorResult? node)
+    {
+        if (node == null) return false;
+        foreach (var w in node.Warnings)
+            if (w.Type.EndsWith(" Spill", StringComparison.Ordinal)) return true;
+        foreach (var child in node.Children)
+            if (HasSpillInTree(child)) return true;
+        return false;
     }
 
     private string activeTab = "paste";

--- a/src/PlanViewer.Web/wwwroot/css/app.css
+++ b/src/PlanViewer.Web/wwwroot/css/app.css
@@ -834,6 +834,13 @@ textarea::placeholder {
     margin-right: 0.4rem;
 }
 
+.spill-tag {
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: var(--warning-color);
+    margin-left: 0.4rem;
+}
+
 .warn-legacy {
     font-size: 0.65rem;
     font-weight: 600;


### PR DESCRIPTION
## Summary
Five Joe-feedback items on the Runtime card:
- **E7**: title reads "Predicted Runtime" for estimated plans
- **E8**: used grant % > 100 is red (over-used grant, not green)
- **E9**: any operator spill forces grant tier to eff-warn at best
- **E10**: "⚠ spill" indicator next to the Used row when anything spilled
- **E11**: reorder Elapsed → CPU:Elapsed → DOP → CPU → Compile → Memory → Used → Optimization → CE Model → Cost (moves Cost from first to last across all three surfaces; adds CPU:Elapsed to Avalonia)

Version 1.7.8 → 1.8.0 (this is the first PR of a batch — subsequent PRs will stay at 1.8.0 for one bundled release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)