### PR TITLE
Estimated plan info on Runtime card (#215 E4, E5, E6)

### DIFF
--- a/src/PlanViewer.Core/Output/AnalysisResult.cs
+++ b/src/PlanViewer.Core/Output/AnalysisResult.cs
@@ -167,6 +167,20 @@ public class MemoryGrantResult
 
     [JsonPropertyName("estimated_available_memory_grant_kb")]
     public long EstimatedAvailableMemoryGrantKB { get; set; }
+
+    /// <summary>
+    /// Optimizer's pre-execution "desired" grant (parallel-adjusted).
+    /// Non-zero on estimated plans; pairs with DesiredKB serial-required as fallback
+    /// when no runtime-granted memory exists (#215 E6).
+    /// </summary>
+    [JsonPropertyName("desired_kb")]
+    public long DesiredKB { get; set; }
+
+    /// <summary>
+    /// Optimizer's pre-execution serial-required grant (memory minimum before DOP scaling).
+    /// </summary>
+    [JsonPropertyName("serial_required_kb")]
+    public long SerialRequiredKB { get; set; }
 }
 
 public class QueryTimeResult

--- a/src/PlanViewer.Core/Output/HtmlExporter.cs
+++ b/src/PlanViewer.Core/Output/HtmlExporter.cs
@@ -335,6 +335,13 @@ pre.query-text, pre.text-output {
             var spillTag = hasSpill ? " <span class=\"spill-tag\" title=\"Operators spilled to tempdb\">⚠ spill</span>" : "";
             sb.AppendLine($"<div class=\"row\"><span class=\"label\">Used</span><span class=\"value {effClass}\">{FormatKB(stmt.MemoryGrant.MaxUsedKB)} ({pctUsed:N0}%){spillTag}</span></div>");
         }
+        else if (isEstimated && stmt.MemoryGrant != null && stmt.MemoryGrant.DesiredKB > 0)
+        {
+            // #215 E6: estimated plans — show the optimizer's pre-execution desired grant
+            WriteRow(sb, "Memory (estimated)", FormatKB(stmt.MemoryGrant.DesiredKB) + " desired");
+            if (stmt.MemoryGrant.SerialRequiredKB > 0 && stmt.MemoryGrant.SerialRequiredKB != stmt.MemoryGrant.DesiredKB)
+                WriteRow(sb, "Serial required", FormatKB(stmt.MemoryGrant.SerialRequiredKB));
+        }
         if (stmt.OptimizationLevel != null)
             WriteRow(sb, "Optimization", Encode(stmt.OptimizationLevel));
         if (stmt.CardinalityEstimationModel > 0)

--- a/src/PlanViewer.Core/Output/ResultMapper.cs
+++ b/src/PlanViewer.Core/Output/ResultMapper.cs
@@ -105,7 +105,9 @@ public static class ResultMapper
                 MaxUsedKB = stmt.MemoryGrant.MaxUsedMemoryKB,
                 GrantWaitMs = stmt.MemoryGrant.GrantWaitTimeMs,
                 FeedbackAdjusted = stmt.MemoryGrant.IsMemoryGrantFeedbackAdjusted,
-                EstimatedAvailableMemoryGrantKB = stmt.HardwareProperties?.EstimatedAvailableMemoryGrant ?? 0
+                EstimatedAvailableMemoryGrantKB = stmt.HardwareProperties?.EstimatedAvailableMemoryGrant ?? 0,
+                DesiredKB = stmt.MemoryGrant.DesiredMemoryKB,
+                SerialRequiredKB = stmt.MemoryGrant.SerialRequiredMemoryKB
             };
         }
 

--- a/src/PlanViewer.Web/Pages/Index.razor
+++ b/src/PlanViewer.Web/Pages/Index.razor
@@ -215,6 +215,20 @@ else
                         </span>
                     </div>
                 }
+                else if (isEstimatedRuntime && ActiveStmt!.MemoryGrant != null && ActiveStmt!.MemoryGrant.DesiredKB > 0)
+                {
+                    <div class="insight-row">
+                        <span class="insight-label">Memory (estimated)</span>
+                        <span class="insight-value">@FormatKB(ActiveStmt!.MemoryGrant.DesiredKB) desired</span>
+                    </div>
+                    @if (ActiveStmt!.MemoryGrant.SerialRequiredKB > 0 && ActiveStmt!.MemoryGrant.SerialRequiredKB != ActiveStmt!.MemoryGrant.DesiredKB)
+                    {
+                        <div class="insight-row">
+                            <span class="insight-label">Serial required</span>
+                            <span class="insight-value">@FormatKB(ActiveStmt!.MemoryGrant.SerialRequiredKB)</span>
+                        </div>
+                    }
+                }
                 @if (ActiveStmt!.OptimizationLevel != null)
                 {
                     <div class="insight-row">


### PR DESCRIPTION
## Summary
- **E6**: MemoryGrantResult exposes DesiredKB + SerialRequiredKB. Estimated plans with a desired grant > 0 now show a "Memory (estimated)" row with the optimizer's desired amount, plus "Serial required" when it differs.
- **E4**: compile time already renders on estimated plans when > 0 (existing behavior). Joe's cursor plan has CompileTimeMs=0 on its inner ops, so nothing displays there — that's the actual data.
- **E5**: predicted DOP already shows when > 0 (existing). Host-level EstimatedAvailableDOP deliberately not shown — it describes the host, not the plan, and would mislead for explicitly-serial plans.

Part of the v1.8.0 batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)