### PR TITLE
Add rule 38 for standard edition limitation on batch mode when dop=2

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -275,7 +275,7 @@ public partial class PlanViewerControl : UserControl
         // separate expander — it's already visible in the Statements grid.
 
         _currentPlan = ShowPlanParser.Parse(planXml);
-        PlanAnalyzer.Analyze(_currentPlan, ConfigLoader.Load());
+        PlanAnalyzer.Analyze(_currentPlan, ConfigLoader.Load(), _serverMetadata);
         BenefitScorer.Score(_currentPlan);
 
         var allStatements = _currentPlan.Batches

--- a/src/PlanViewer.App/Mcp/McpQueryStoreTools.cs
+++ b/src/PlanViewer.App/Mcp/McpQueryStoreTools.cs
@@ -112,6 +112,19 @@ public sealed class McpQueryStoreTools
             if (plans.Count == 0)
                 return $"No Query Store data found in [{database}] for the last {hours_back} hours.";
 
+            // Fetch server metadata for Rule 38 (Standard Edition DOP limitation)
+            ServerMetadata? serverMetadata = null;
+            try
+            {
+                var isAzure = conn.ServerName.Contains(".database.windows.net", StringComparison.OrdinalIgnoreCase) ||
+                              conn.ServerName.Contains(".database.azure.com", StringComparison.OrdinalIgnoreCase);
+                serverMetadata = await ServerMetadataService.FetchServerMetadataAsync(connectionString, isAzure);
+            }
+            catch
+            {
+                // Non-fatal: analysis continues without server context
+            }
+
             // Parse and register each plan with PlanSessionManager
             var results = plans.Select(qsPlan =>
             {
@@ -123,7 +136,7 @@ public sealed class McpQueryStoreTools
                     var xml = qsPlan.PlanXml
                         .Replace("encoding=\"utf-16\"", "encoding=\"utf-8\"");
                     var parsed = ShowPlanParser.Parse(xml);
-                    PlanAnalyzer.Analyze(parsed);
+                    PlanAnalyzer.Analyze(parsed, serverMetadata: serverMetadata);
                     BenefitScorer.Score(parsed);
 
                     var allStatements = parsed.Batches.SelectMany(b => b.Statements).ToList();

--- a/src/PlanViewer.Cli/Commands/AnalyzeCommand.cs
+++ b/src/PlanViewer.Cli/Commands/AnalyzeCommand.cs
@@ -369,6 +369,18 @@ public static class AnalyzeCommand
         var isAzure = IsAzureSqlDb(server);
         var planType = estimated ? "estimated" : "actual";
         Console.Error.WriteLine($"Capturing {planType} plans from {server}/{database}");
+
+        // Fetch server metadata for Rule 38 (Standard Edition DOP limitation)
+        ServerMetadata? serverMetadata = null;
+        try
+        {
+            serverMetadata = await ServerMetadataService.FetchServerMetadataAsync(connectionString, isAzure);
+        }
+        catch
+        {
+            // Non-fatal: analysis continues without server context
+        }
+
         Console.Error.WriteLine();
 
         // Process each SQL input sequentially
@@ -416,7 +428,7 @@ public static class AnalyzeCommand
 
                 // Parse, analyze, map result
                 var plan = ShowPlanParser.Parse(planXml);
-                PlanAnalyzer.Analyze(plan, analyzerConfig);
+                PlanAnalyzer.Analyze(plan, analyzerConfig, serverMetadata);
                 BenefitScorer.Score(plan);
                 var result = ResultMapper.Map(plan, $"{name}.sql");
 

--- a/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
+++ b/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
@@ -257,6 +257,19 @@ public static class QueryStoreCommand
         Console.Error.WriteLine($"{plans.Count} plans");
         Console.Error.WriteLine();
 
+        // Fetch server metadata for Rule 38 (Standard Edition DOP limitation)
+        ServerMetadata? serverMetadata = null;
+        try
+        {
+            var isAzure = server.Contains(".database.windows.net", StringComparison.OrdinalIgnoreCase) ||
+                          server.Contains(".database.azure.com", StringComparison.OrdinalIgnoreCase);
+            serverMetadata = await ServerMetadataService.FetchServerMetadataAsync(connectionString, isAzure);
+        }
+        catch
+        {
+            // Non-fatal: analysis continues without server context
+        }
+
         // Resolve output directory
         var outDir = outputDir?.FullName ?? Directory.GetCurrentDirectory();
         Directory.CreateDirectory(outDir);
@@ -286,7 +299,7 @@ public static class QueryStoreCommand
 
                 // Parse, analyze, map
                 var plan = ShowPlanParser.Parse(qsPlan.PlanXml);
-                PlanAnalyzer.Analyze(plan, analyzerConfig);
+                PlanAnalyzer.Analyze(plan, analyzerConfig, serverMetadata);
                 BenefitScorer.Score(plan);
                 var result = ResultMapper.Map(plan, $"{label}.sqlplan");
 

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.cs
@@ -482,9 +482,9 @@ public static class PlanAnalyzer
         if (!cfg.IsRuleDisabled(38) && stmt.DegreeOfParallelism == 2 && stmt.RootNode != null
             && HasBatchModeNode(stmt.RootNode))
         {
-            if (serverMetadata != null
-                && !string.IsNullOrEmpty(serverMetadata.Edition)
-                && serverMetadata.Edition.Contains("Standard", StringComparison.OrdinalIgnoreCase))
+            var editionKnown = !string.IsNullOrEmpty(serverMetadata?.Edition);
+            if (editionKnown
+                && serverMetadata!.Edition!.Contains("Standard", StringComparison.OrdinalIgnoreCase))
             {
                 // Server context confirms Standard Edition — check MAXDOP
                 if (serverMetadata.MaxDop > 2)
@@ -497,9 +497,9 @@ public static class PlanAnalyzer
                     });
                 }
             }
-            else if (serverMetadata == null)
+            else if (!editionKnown)
             {
-                // No server context (e.g. .sqlplan file) — suspect the limitation
+                // No server context, or edition unknown (e.g. collection failure) — suspect the limitation
                 stmt.PlanWarnings.Add(new PlanWarning
                 {
                     WarningType = "Standard Edition DOP Limitation",

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.cs
@@ -24,14 +24,14 @@ public static class PlanAnalyzer
         @"\bCASE\s+(WHEN\b|$)",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-    public static void Analyze(ParsedPlan plan, AnalyzerConfig? config = null)
+    public static void Analyze(ParsedPlan plan, AnalyzerConfig? config = null, ServerMetadata? serverMetadata = null)
     {
         var cfg = config ?? AnalyzerConfig.Default;
         foreach (var batch in plan.Batches)
         {
             foreach (var stmt in batch.Statements)
             {
-                AnalyzeStatement(stmt, cfg);
+                AnalyzeStatement(stmt, cfg, serverMetadata);
 
                 if (stmt.RootNode != null)
                     AnalyzeNodeTree(stmt.RootNode, stmt, cfg);
@@ -114,7 +114,8 @@ public static class PlanAnalyzer
         [29] = "Implicit Conversion", [30] = "Wide Index Suggestion",
         [31] = "Parallel Wait Bottleneck",
         [32] = "Scan Cardinality Misestimate",
-        [33] = "Estimated Plan CE Guess"
+        [33] = "Estimated Plan CE Guess",
+        [38] = "Standard Edition DOP Limitation"
     };
 
     // Reverse lookup: WarningType → rule number
@@ -173,7 +174,7 @@ public static class PlanAnalyzer
             warning.Severity = severity;
     }
 
-    private static void AnalyzeStatement(PlanStatement stmt, AnalyzerConfig cfg)
+    private static void AnalyzeStatement(PlanStatement stmt, AnalyzerConfig cfg, ServerMetadata? serverMetadata = null)
     {
         // Rule 3: Serial plan with reason
         // Skip: cost < 1 (CTFP is an integer so cost < 1 can never go parallel),
@@ -476,6 +477,38 @@ public static class PlanAnalyzer
             }
         }
 
+        // Rule 38: Standard Edition DOP 2 limitation with batch mode
+        // SQL Server Standard Edition limits DOP to 2 when batch mode operators are present.
+        if (!cfg.IsRuleDisabled(38) && stmt.DegreeOfParallelism == 2 && stmt.RootNode != null
+            && HasBatchModeNode(stmt.RootNode))
+        {
+            if (serverMetadata != null
+                && !string.IsNullOrEmpty(serverMetadata.Edition)
+                && serverMetadata.Edition.Contains("Standard", StringComparison.OrdinalIgnoreCase))
+            {
+                // Server context confirms Standard Edition — check MAXDOP
+                if (serverMetadata.MaxDop > 2)
+                {
+                    stmt.PlanWarnings.Add(new PlanWarning
+                    {
+                        WarningType = "Standard Edition DOP Limitation",
+                        Message = $"DOP is limited to 2 because SQL Server Standard Edition caps parallelism at 2 when batch mode operators are present, even though MAXDOP is set to {serverMetadata.MaxDop}. Developer or Enterprise Edition would allow higher DOP in the same conditions.",
+                        Severity = PlanWarningSeverity.Warning
+                    });
+                }
+            }
+            else if (serverMetadata == null)
+            {
+                // No server context (e.g. .sqlplan file) — suspect the limitation
+                stmt.PlanWarnings.Add(new PlanWarning
+                {
+                    WarningType = "Standard Edition DOP Limitation",
+                    Message = "DOP is limited to 2 and the plan uses batch mode operators. This may be caused by the SQL Server Standard Edition limitation, which caps parallelism at 2 when batch mode is in use. If this server runs Standard Edition, Developer or Enterprise Edition would allow higher DOP.",
+                    Severity = PlanWarningSeverity.Info
+                });
+            }
+        }
+
         // Rules 25 (Ineffective Parallelism) and 31 (Parallel Wait Bottleneck) were removed.
         // The CPU:Elapsed ratio is now shown in the runtime summary, and wait stats speak
         // for themselves — no need for meta-warnings guessing at causes.
@@ -571,6 +604,19 @@ public static class PlanAnalyzer
                 });
             }
         }
+    }
+
+    private static bool HasBatchModeNode(PlanNode node)
+    {
+        var mode = node.ActualExecutionMode ?? node.ExecutionMode;
+        if (string.Equals(mode, "Batch", StringComparison.OrdinalIgnoreCase))
+            return true;
+        foreach (var child in node.Children)
+        {
+            if (HasBatchModeNode(child))
+                return true;
+        }
+        return false;
     }
 
     private static void CheckForTableVariables(PlanNode node, bool isModification,

--- a/tests/PlanViewer.Core.Tests/PlanAnalyzerTests.cs
+++ b/tests/PlanViewer.Core.Tests/PlanAnalyzerTests.cs
@@ -892,4 +892,102 @@ public class PlanAnalyzerTests
         Assert.NotEmpty(warnings);
         Assert.All(warnings, w => Assert.Equal(PlanWarningSeverity.Warning, w.Severity));
     }
+
+    #region Rule 38 — Standard Edition DOP Limitation
+
+    private static PlanStatement BuildBatchModeDop2Statement()
+    {
+        var batchNode = new PlanNode
+        {
+            NodeId = 1,
+            PhysicalOp = "Hash Match",
+            LogicalOp = "Inner Join",
+            ExecutionMode = "Batch"
+        };
+        var root = new PlanNode
+        {
+            NodeId = 0,
+            PhysicalOp = "Columnstore Index Scan",
+            LogicalOp = "Columnstore Index Scan",
+            ExecutionMode = "Batch",
+            Children = { batchNode }
+        };
+        return new PlanStatement
+        {
+            RootNode = root,
+            DegreeOfParallelism = 2,
+            StatementSubTreeCost = 10.0
+        };
+    }
+
+    [Fact]
+    public void Rule38_StandardEdition_Dop2_BatchMode_MaxDopAbove2_EmitsWarning()
+    {
+        var stmt = BuildBatchModeDop2Statement();
+        var plan = BuildSyntheticPlan(stmt);
+        var metadata = new ServerMetadata
+        {
+            Edition = "Standard Edition (64-bit)",
+            MaxDop = 8
+        };
+        PlanAnalyzer.Analyze(plan, serverMetadata: metadata);
+
+        var warnings = stmt.PlanWarnings
+            .Where(w => w.WarningType == "Standard Edition DOP Limitation").ToList();
+        Assert.Single(warnings);
+        Assert.Equal(PlanWarningSeverity.Warning, warnings[0].Severity);
+        Assert.Contains("MAXDOP is set to 8", warnings[0].Message);
+    }
+
+    [Fact]
+    public void Rule38_StandardEdition_Dop2_BatchMode_MaxDop2_NoWarning()
+    {
+        // MAXDOP=2 means the limitation isn't biting — DOP matches MAXDOP
+        var stmt = BuildBatchModeDop2Statement();
+        var plan = BuildSyntheticPlan(stmt);
+        var metadata = new ServerMetadata
+        {
+            Edition = "Standard Edition (64-bit)",
+            MaxDop = 2
+        };
+        PlanAnalyzer.Analyze(plan, serverMetadata: metadata);
+
+        var warnings = stmt.PlanWarnings
+            .Where(w => w.WarningType == "Standard Edition DOP Limitation").ToList();
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void Rule38_NoServerMetadata_Dop2_BatchMode_EmitsInfo()
+    {
+        var stmt = BuildBatchModeDop2Statement();
+        var plan = BuildSyntheticPlan(stmt);
+        PlanAnalyzer.Analyze(plan);
+
+        var warnings = stmt.PlanWarnings
+            .Where(w => w.WarningType == "Standard Edition DOP Limitation").ToList();
+        Assert.Single(warnings);
+        Assert.Equal(PlanWarningSeverity.Info, warnings[0].Severity);
+    }
+
+    [Fact]
+    public void Rule38_ServerMetadataWithNullEdition_Dop2_BatchMode_EmitsInfo()
+    {
+        // Edge case: serverMetadata present but Edition is null (collection failure)
+        var stmt = BuildBatchModeDop2Statement();
+        var plan = BuildSyntheticPlan(stmt);
+        var metadata = new ServerMetadata
+        {
+            Edition = null,
+            MaxDop = 8
+        };
+        PlanAnalyzer.Analyze(plan, serverMetadata: metadata);
+
+        var warnings = stmt.PlanWarnings
+            .Where(w => w.WarningType == "Standard Edition DOP Limitation").ToList();
+        Assert.Single(warnings);
+        Assert.Equal(PlanWarningSeverity.Info, warnings[0].Severity);
+    }
+
+    #endregion
 }

--- a/tests/PlanViewer.Core.Tests/PlanTestHelper.cs
+++ b/tests/PlanViewer.Core.Tests/PlanTestHelper.cs
@@ -15,6 +15,15 @@ public static class PlanTestHelper
     /// </summary>
     public static ParsedPlan LoadAndAnalyze(string planFileName)
     {
+        return LoadAndAnalyze(planFileName, serverMetadata: null);
+    }
+
+    /// <summary>
+    /// Loads a .sqlplan file from the Plans directory, parses it, and runs the analyzer
+    /// with optional server metadata (for rules that depend on server context).
+    /// </summary>
+    public static ParsedPlan LoadAndAnalyze(string planFileName, ServerMetadata? serverMetadata)
+    {
         var path = Path.Combine("Plans", planFileName);
         Assert.True(File.Exists(path), $"Test plan not found: {path}");
 
@@ -23,7 +32,7 @@ public static class PlanTestHelper
         // File.ReadAllText auto-detects BOM, but XDocument.Parse chokes on the declaration.
         xml = xml.Replace("encoding=\"utf-16\"", "encoding=\"utf-8\"");
         var plan = ShowPlanParser.Parse(xml);
-        PlanAnalyzer.Analyze(plan);
+        PlanAnalyzer.Analyze(plan, serverMetadata: serverMetadata);
         BenefitScorer.Score(plan);
         return plan;
     }


### PR DESCRIPTION
## What does this PR do?

Add Rule 38: **Standard Edition DOP 2 Limitation**
1.	Analyze(ParsedPlan, AnalyzerConfig?, ServerMetadata?) method — Added optional ServerMetadata? serverMetadata parameter, passed through to AnalyzeStatement(PlanStatement, AnalyzerConfig, ServerMetadata?)
2.	Rule 38 logic in AnalyzeStatement(PlanStatement, AnalyzerConfig, ServerMetadata?) — Two scenarios:
•	With server context (repro/query session): When Edition="Standard", batch mode nodes exist, DOP=2, and MAXDOP>2 → emits a Warning confirming the Standard Edition limitation and noting that Developer/Enterprise Edition would allow higher DOP
•	Without server context (.sqlplan file): When batch mode nodes exist and DOP=2 → emits an Info suggesting the limitation may apply
3.	HasBatchModeNode(PlanNode) helper — Recursively walks the plan tree checking ActualExecutionMode or ExecutionMode for "Batch"
4.	RuleWarningTypes dictionary — Added [38] = "Standard Edition DOP Limitation" for severity override support

## Which component(s) does this affect?

- [x] Desktop App (PlanViewer.App)
- [x] Core Library (PlanViewer.Core)
- [ ] CLI Tool (PlanViewer.Cli)
- [ ] SSMS Extension (PlanViewer.Ssms)
- [ ] Tests
- [ ] Documentation

## How was this tested?
<img width="1190" height="720" alt="image" src="https://github.com/user-attachments/assets/2fac0492-9ac0-4728-9815-c14f3a5c7edd" />

<img width="1050" height="1133" alt="image" src="https://github.com/user-attachments/assets/c5db237c-46fb-470f-b838-22ea42bba8c2" />




Describe the testing you've done. Include:
- Plan files tested (estimated, actual, Query Store, etc.) : Actual disconnected
- Platforms tested (Windows, macOS, Linux) : Windows Only

## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceStudio/blob/main/CONTRIBUTING.md)
- [x] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] All tests pass (`dotnet test`)
- [x] I have not introduced any hardcoded credentials or server names
