### PR TITLE
Feature/minimap

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml
@@ -286,9 +286,9 @@
                 <Border x:Name="MinimapPanel" IsVisible="False"
                         HorizontalAlignment="Left" VerticalAlignment="Top"
                         Margin="4,26,0,0" ZIndex="10"
-                        Width="300" Height="300"
+                        Width="400" Height="400"
                         Background="{DynamicResource BackgroundDarkBrush}"
-                        BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
+                        BorderBrush="{DynamicResource BorderBrush}" BorderThickness="2"
                         CornerRadius="4" ClipToBounds="True">
                     <Grid>
                         <Grid.RowDefinitions>
@@ -308,6 +308,21 @@
                         <!-- Minimap canvas -->
                         <Canvas x:Name="MinimapCanvas" Grid.Row="1" ClipToBounds="True"
                                 Background="{DynamicResource BackgroundBrush}"/>
+                        <!-- Resize grip (bottom-right corner) -->
+                        <Border x:Name="MinimapResizeGrip" Grid.Row="1"
+                                Width="14" Height="14"
+                                HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                                Background="Transparent"
+                                Cursor="BottomRightCorner">
+                            <Canvas Width="10" Height="10" Margin="1,1,3,3">
+                                <Line StartPoint="6,10" EndPoint="10,6"
+                                      Stroke="{DynamicResource ForegroundBrush}" StrokeThickness="1" Opacity="0.5"/>
+                                <Line StartPoint="3,10" EndPoint="10,3"
+                                      Stroke="{DynamicResource ForegroundBrush}" StrokeThickness="1" Opacity="0.5"/>
+                                <Line StartPoint="0,10" EndPoint="10,0"
+                                      Stroke="{DynamicResource ForegroundBrush}" StrokeThickness="1" Opacity="0.5"/>
+                            </Canvas>
+                        </Border>
                     </Grid>
                 </Border>
             </Grid>

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml
@@ -190,7 +190,7 @@
         </Border>
 
         <!-- Statements Panel + Plan Canvas + Properties Panel -->
-        <Grid Grid.Row="2">
+        <Grid x:Name="PlanGrid" Grid.Row="2">
             <Grid.ColumnDefinitions>
                 <!-- Col 0: Statements Panel (hidden by default) -->
                 <ColumnDefinition Width="0"/>

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml
@@ -287,8 +287,8 @@
                         HorizontalAlignment="Left" VerticalAlignment="Top"
                         Margin="4,26,0,0" ZIndex="10"
                         Width="400" Height="400"
-                        Background="#1A1D23"
-                        BorderBrush="#3A3D45" BorderThickness="5"
+                        Background="{DynamicResource BackgroundBrush}"
+                        BorderBrush="{DynamicResource BorderBrush}" BorderThickness="5"
                         CornerRadius="4" ClipToBounds="True">
                     <Grid>
                         <Grid.RowDefinitions>
@@ -296,7 +296,7 @@
                             <RowDefinition Height="*"/>
                         </Grid.RowDefinitions>
                         <!-- Minimap header with close button -->
-                        <DockPanel Grid.Row="0" Background="#1A1D23">
+                        <DockPanel Grid.Row="0" Background="{DynamicResource BackgroundBrush}">
                             <Button DockPanel.Dock="Right" Content="&#x2715;" Click="MinimapClose_Click"
                                     Width="18" Height="18" Padding="0" FontSize="10"
                                     VerticalAlignment="Center" Margin="0,0,2,0"
@@ -307,7 +307,7 @@
                         </DockPanel>
                         <!-- Minimap canvas -->
                         <Canvas x:Name="MinimapCanvas" Grid.Row="1" ClipToBounds="True"
-                                Background="#1A1D23"/>
+                                Background="{DynamicResource BackgroundBrush}"/>
                         <!-- Resize grip (bottom-right corner) -->
                         <Border x:Name="MinimapResizeGrip" Grid.Row="1"
                                 Width="14" Height="14"

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml
@@ -287,8 +287,8 @@
                         HorizontalAlignment="Left" VerticalAlignment="Top"
                         Margin="4,26,0,0" ZIndex="10"
                         Width="400" Height="400"
-                        Background="{DynamicResource BackgroundDarkBrush}"
-                        BorderBrush="{DynamicResource BorderBrush}" BorderThickness="2"
+                        Background="#1A1D23"
+                        BorderBrush="#3A3D45" BorderThickness="5"
                         CornerRadius="4" ClipToBounds="True">
                     <Grid>
                         <Grid.RowDefinitions>
@@ -296,7 +296,7 @@
                             <RowDefinition Height="*"/>
                         </Grid.RowDefinitions>
                         <!-- Minimap header with close button -->
-                        <DockPanel Grid.Row="0" Background="{DynamicResource BackgroundBrush}">
+                        <DockPanel Grid.Row="0" Background="#1A1D23">
                             <Button DockPanel.Dock="Right" Content="&#x2715;" Click="MinimapClose_Click"
                                     Width="18" Height="18" Padding="0" FontSize="10"
                                     VerticalAlignment="Center" Margin="0,0,2,0"
@@ -307,7 +307,7 @@
                         </DockPanel>
                         <!-- Minimap canvas -->
                         <Canvas x:Name="MinimapCanvas" Grid.Row="1" ClipToBounds="True"
-                                Background="{DynamicResource BackgroundBrush}"/>
+                                Background="#1A1D23"/>
                         <!-- Resize grip (bottom-right corner) -->
                         <Border x:Name="MinimapResizeGrip" Grid.Row="1"
                                 Width="14" Height="14"

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml
@@ -255,21 +255,62 @@
                           Background="{DynamicResource BorderBrush}"
                           IsVisible="False"/>
 
-            <!-- Plan Canvas -->
-            <ScrollViewer Grid.Column="2" x:Name="PlanScrollViewer"
-                          HorizontalScrollBarVisibility="Auto"
-                          VerticalScrollBarVisibility="Auto"
-                          HorizontalContentAlignment="Left"
-                          VerticalContentAlignment="Top"
-                          Background="{DynamicResource BackgroundBrush}">
-                <LayoutTransformControl x:Name="PlanLayoutTransform"
-                                        HorizontalAlignment="Left" VerticalAlignment="Top">
-                    <LayoutTransformControl.LayoutTransform>
-                        <ScaleTransform ScaleX="1" ScaleY="1"/>
-                    </LayoutTransformControl.LayoutTransform>
-                    <Canvas x:Name="PlanCanvas" ClipToBounds="False"/>
-                </LayoutTransformControl>
-            </ScrollViewer>
+            <!-- Plan Canvas + Minimap overlay -->
+            <Grid Grid.Column="2">
+                <ScrollViewer x:Name="PlanScrollViewer"
+                              HorizontalScrollBarVisibility="Auto"
+                              VerticalScrollBarVisibility="Auto"
+                              HorizontalContentAlignment="Left"
+                              VerticalContentAlignment="Top"
+                              Background="{DynamicResource BackgroundBrush}">
+                    <LayoutTransformControl x:Name="PlanLayoutTransform"
+                                            HorizontalAlignment="Left" VerticalAlignment="Top">
+                        <LayoutTransformControl.LayoutTransform>
+                            <ScaleTransform ScaleX="1" ScaleY="1"/>
+                        </LayoutTransformControl.LayoutTransform>
+                        <Canvas x:Name="PlanCanvas" ClipToBounds="False"/>
+                    </LayoutTransformControl>
+                </ScrollViewer>
+
+                <!-- Minimap toggle button (top-left, always visible) -->
+                <Button x:Name="MinimapToggleButton" Content="minimap"
+                        Click="MinimapToggle_Click"
+                        HorizontalAlignment="Left" VerticalAlignment="Top"
+                        Margin="4,4,0,0" Padding="4,1" FontSize="9"
+                        Height="18" MinWidth="0" MinHeight="0"
+                        Opacity="0.8" ZIndex="10"
+                        Theme="{StaticResource AppButton}"
+                        ToolTip.Tip="Show/hide minimap"/>
+
+                <!-- Minimap panel -->
+                <Border x:Name="MinimapPanel" IsVisible="False"
+                        HorizontalAlignment="Left" VerticalAlignment="Top"
+                        Margin="4,26,0,0" ZIndex="10"
+                        Width="300" Height="300"
+                        Background="{DynamicResource BackgroundDarkBrush}"
+                        BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
+                        CornerRadius="4" ClipToBounds="True">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <!-- Minimap header with close button -->
+                        <DockPanel Grid.Row="0" Background="{DynamicResource BackgroundBrush}">
+                            <Button DockPanel.Dock="Right" Content="&#x2715;" Click="MinimapClose_Click"
+                                    Width="18" Height="18" Padding="0" FontSize="10"
+                                    VerticalAlignment="Center" Margin="0,0,2,0"
+                                    Theme="{StaticResource AppButton}" ToolTip.Tip="Close minimap"/>
+                            <TextBlock Text="Minimap" FontSize="10" VerticalAlignment="Center"
+                                       Margin="4,1,0,1"
+                                       Foreground="{DynamicResource ForegroundBrush}"/>
+                        </DockPanel>
+                        <!-- Minimap canvas -->
+                        <Canvas x:Name="MinimapCanvas" Grid.Row="1" ClipToBounds="True"
+                                Background="{DynamicResource BackgroundBrush}"/>
+                    </Grid>
+                </Border>
+            </Grid>
 
             <!-- Empty State -->
             <StackPanel x:Name="EmptyState" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Center">

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -118,6 +118,21 @@ public partial class PlanViewerControl : UserControl
     private double _panStartOffsetX;
     private double _panStartOffsetY;
 
+    // Minimap state
+    private static double _minimapWidth = 300;
+    private static double _minimapHeight = 300;
+    private const double MinimapDefaultSize = 300;
+    private const double MinimapMinSize = 200;
+    private const double MinimapMaxSize = 500;
+    private bool _minimapDragging;
+    private Point _minimapDragStart;
+    private Border? _minimapViewportBox;
+    private bool _minimapResizing;
+    private Point _minimapResizeStart;
+    private double _minimapResizeStartW;
+    private double _minimapResizeStartH;
+    private readonly Dictionary<Border, PlanNode> _minimapNodeMap = new();
+
     public PlanViewerControl()
     {
         InitializeComponent();
@@ -127,11 +142,13 @@ public partial class PlanViewerControl : UserControl
         PlanScrollViewer.AddHandler(PointerPressedEvent, PlanScrollViewer_PointerPressed, Avalonia.Interactivity.RoutingStrategies.Tunnel);
         PlanScrollViewer.AddHandler(PointerMovedEvent, PlanScrollViewer_PointerMoved, Avalonia.Interactivity.RoutingStrategies.Tunnel);
         PlanScrollViewer.AddHandler(PointerReleasedEvent, PlanScrollViewer_PointerReleased, Avalonia.Interactivity.RoutingStrategies.Tunnel);
+        PlanScrollViewer.ScrollChanged += (_, _) => UpdateMinimapViewportBox();
 
         // Resolve non-control elements by traversal (Avalonia doesn't support x:Name on these types)
-        // The Grid in Row 4 has 5 ColumnDefinitions:
+        // The 5-column Grid in Row 2 is now the grandparent of PlanScrollViewer
+        // (PlanScrollViewer sits inside a minimap wrapper Grid at Column 2).
         //   [0]=Statements(0), [1]=StmtSplitter(0), [2]=Canvas(*), [3]=PropsSplitter(0), [4]=Props(0)
-        var planGrid = (Grid)PlanScrollViewer.Parent!;
+        var planGrid = (Grid)PlanScrollViewer.Parent!.Parent!;
         _statementsColumn = planGrid.ColumnDefinitions[0];
         _statementsSplitterColumn = planGrid.ColumnDefinitions[1];
         _splitterColumn = planGrid.ColumnDefinitions[3];
@@ -342,6 +359,7 @@ public partial class PlanViewerControl : UserControl
         StatementsButton.IsVisible = false;
         StatementsButtonSeparator.IsVisible = false;
         ClosePropertiesPanel();
+        CloseMinimapPanel();
     }
 
     private static void CountNodeWarnings(PlanNode node, ref int total, ref int critical)
@@ -390,6 +408,10 @@ public partial class PlanViewerControl : UserControl
         PlanScrollViewer.ContextMenu = BuildCanvasContextMenu();
 
         CostText.Text = "";
+
+        // Update minimap if visible
+        if (MinimapPanel.IsVisible)
+            Avalonia.Threading.Dispatcher.UIThread.Post(RenderMinimap, Avalonia.Threading.DispatcherPriority.Loaded);
     }
 
     #region Node Rendering
@@ -3095,6 +3117,7 @@ public partial class PlanViewerControl : UserControl
         _zoomTransform.ScaleX = _zoomLevel;
         _zoomTransform.ScaleY = _zoomLevel;
         ZoomLevelText.Text = $"{(int)(_zoomLevel * 100)}%";
+        UpdateMinimapViewportBox();
     }
 
     /// <summary>
@@ -3121,6 +3144,7 @@ public partial class PlanViewerControl : UserControl
         Avalonia.Threading.Dispatcher.UIThread.Post(() =>
         {
             PlanScrollViewer.Offset = new Vector(newOffsetX, newOffsetY);
+            UpdateMinimapViewportBox();
         });
     }
 
@@ -3172,6 +3196,7 @@ public partial class PlanViewerControl : UserControl
         Avalonia.Threading.Dispatcher.UIThread.Post(() =>
         {
             PlanScrollViewer.Offset = new Vector(newX, newY);
+            UpdateMinimapViewportBox();
         });
 
         e.Handled = true;
@@ -3460,6 +3485,457 @@ public partial class PlanViewerControl : UserControl
         StatementsSplitter.IsVisible = false;
         _statementsColumn.Width = new GridLength(0);
         _statementsSplitterColumn.Width = new GridLength(0);
+    }
+
+    #endregion
+
+    #region Minimap
+
+    private void MinimapToggle_Click(object? sender, RoutedEventArgs e)
+    {
+        if (MinimapPanel.IsVisible)
+            CloseMinimapPanel();
+        else
+            OpenMinimapPanel();
+    }
+
+    private void MinimapClose_Click(object? sender, RoutedEventArgs e)
+    {
+        CloseMinimapPanel();
+    }
+
+    private void OpenMinimapPanel()
+    {
+        MinimapPanel.Width = _minimapWidth;
+        MinimapPanel.Height = _minimapHeight;
+        MinimapPanel.IsVisible = true;
+        RenderMinimap();
+    }
+
+    private void CloseMinimapPanel()
+    {
+        MinimapPanel.IsVisible = false;
+        _minimapDragging = false;
+        _minimapResizing = false;
+    }
+
+    private void RenderMinimap()
+    {
+        MinimapCanvas.Children.Clear();
+        _minimapNodeMap.Clear();
+        _minimapViewportBox = null;
+
+        if (_currentStatement?.RootNode == null || PlanCanvas.Width <= 0 || PlanCanvas.Height <= 0)
+            return;
+
+        var canvasW = MinimapCanvas.Bounds.Width;
+        var canvasH = MinimapCanvas.Bounds.Height;
+        if (canvasW <= 0 || canvasH <= 0)
+        {
+            // Defer until layout is ready
+            Avalonia.Threading.Dispatcher.UIThread.Post(RenderMinimap, Avalonia.Threading.DispatcherPriority.Loaded);
+            return;
+        }
+
+        var scaleX = canvasW / PlanCanvas.Width;
+        var scaleY = canvasH / PlanCanvas.Height;
+        var scale = Math.Min(scaleX, scaleY);
+
+        // Render branch areas with transparent colored backgrounds
+        RenderMinimapBranches(_currentStatement.RootNode, scale);
+
+        // Render edges
+        RenderMinimapEdges(_currentStatement.RootNode, scale);
+
+        // Render nodes
+        RenderMinimapNodes(_currentStatement.RootNode, scale);
+
+        // Render viewport indicator
+        RenderMinimapViewportBox(scale);
+
+        // Attach resize via bottom-right 8px drag area
+        var resizeGrip = new Border
+        {
+            Width = 10,
+            Height = 10,
+            Background = Brushes.Transparent,
+            Cursor = new Cursor(StandardCursorType.BottomRightCorner)
+        };
+        Canvas.SetLeft(resizeGrip, canvasW - 10);
+        Canvas.SetTop(resizeGrip, canvasH - 10);
+        resizeGrip.PointerPressed += MinimapResizeGrip_PointerPressed;
+        resizeGrip.PointerMoved += MinimapResizeGrip_PointerMoved;
+        resizeGrip.PointerReleased += MinimapResizeGrip_PointerReleased;
+        MinimapCanvas.Children.Add(resizeGrip);
+
+        // Attach interaction handlers to the canvas
+        MinimapCanvas.PointerPressed -= MinimapCanvas_PointerPressed;
+        MinimapCanvas.PointerMoved -= MinimapCanvas_PointerMoved;
+        MinimapCanvas.PointerReleased -= MinimapCanvas_PointerReleased;
+        MinimapCanvas.PointerPressed += MinimapCanvas_PointerPressed;
+        MinimapCanvas.PointerMoved += MinimapCanvas_PointerMoved;
+        MinimapCanvas.PointerReleased += MinimapCanvas_PointerReleased;
+    }
+
+    private void RenderMinimapBranches(PlanNode root, double scale)
+    {
+        // Assign unique branch colors to each child subtree of the root
+        var branchColors = new[]
+        {
+            Color.FromArgb(0x30, 0x4F, 0xA3, 0xFF), // blue
+            Color.FromArgb(0x30, 0x7B, 0xCF, 0x7B), // green
+            Color.FromArgb(0x30, 0xFF, 0xB3, 0x47), // orange
+            Color.FromArgb(0x30, 0xE5, 0x73, 0x73), // red
+            Color.FromArgb(0x30, 0xCF, 0x7B, 0xCF), // purple
+            Color.FromArgb(0x30, 0x7B, 0xCF, 0xCF), // teal
+            Color.FromArgb(0x30, 0xFF, 0xE0, 0x4F), // yellow
+            Color.FromArgb(0x30, 0xFF, 0x7B, 0xA5), // pink
+        };
+
+        for (int i = 0; i < root.Children.Count; i++)
+        {
+            var child = root.Children[i];
+            var color = branchColors[i % branchColors.Length];
+
+            // Collect bounds of all nodes in this subtree
+            double minX = double.MaxValue, minY = double.MaxValue;
+            double maxX = double.MinValue, maxY = double.MinValue;
+            CollectSubtreeBounds(child, ref minX, ref minY, ref maxX, ref maxY);
+
+            var rect = new Avalonia.Controls.Shapes.Rectangle
+            {
+                Width = (maxX - minX + PlanLayoutEngine.NodeWidth) * scale + 4,
+                Height = (maxY - minY + PlanLayoutEngine.GetNodeHeight(child)) * scale + 4,
+                Fill = new SolidColorBrush(color),
+                RadiusX = 2,
+                RadiusY = 2
+            };
+            Canvas.SetLeft(rect, minX * scale - 2);
+            Canvas.SetTop(rect, minY * scale - 2);
+            MinimapCanvas.Children.Add(rect);
+        }
+    }
+
+    private static void CollectSubtreeBounds(PlanNode node, ref double minX, ref double minY, ref double maxX, ref double maxY)
+    {
+        if (node.X < minX) minX = node.X;
+        if (node.Y < minY) minY = node.Y;
+        if (node.X > maxX) maxX = node.X;
+        var bottom = node.Y + PlanLayoutEngine.GetNodeHeight(node);
+        if (bottom > maxY) maxY = bottom;
+
+        foreach (var child in node.Children)
+            CollectSubtreeBounds(child, ref minX, ref minY, ref maxX, ref maxY);
+    }
+
+    private void RenderMinimapEdges(PlanNode node, double scale)
+    {
+        foreach (var child in node.Children)
+        {
+            var parentRight = (node.X + PlanLayoutEngine.NodeWidth) * scale;
+            var parentCenterY = (node.Y + PlanLayoutEngine.GetNodeHeight(node) / 2) * scale;
+            var childLeft = child.X * scale;
+            var childCenterY = (child.Y + PlanLayoutEngine.GetNodeHeight(child) / 2) * scale;
+            var midX = (parentRight + childLeft) / 2;
+
+            var geometry = new PathGeometry();
+            var figure = new PathFigure { StartPoint = new Point(parentRight, parentCenterY), IsClosed = false };
+            figure.Segments!.Add(new LineSegment { Point = new Point(midX, parentCenterY) });
+            figure.Segments.Add(new LineSegment { Point = new Point(midX, childCenterY) });
+            figure.Segments.Add(new LineSegment { Point = new Point(childLeft, childCenterY) });
+            geometry.Figures!.Add(figure);
+
+            var path = new AvaloniaPath
+            {
+                Data = geometry,
+                Stroke = EdgeBrush,
+                StrokeThickness = 1,
+                StrokeJoin = PenLineJoin.Round
+            };
+            MinimapCanvas.Children.Add(path);
+
+            RenderMinimapEdges(child, scale);
+        }
+    }
+
+    private void RenderMinimapNodes(PlanNode node, double scale)
+    {
+        var w = PlanLayoutEngine.NodeWidth * scale;
+        var h = PlanLayoutEngine.GetNodeHeight(node) * scale;
+        var bgBrush = node.IsExpensive
+            ? new SolidColorBrush(Color.FromArgb(0x60, 0xE5, 0x73, 0x73))
+            : new SolidColorBrush(Color.FromArgb(0x80, 0x30, 0x34, 0x3F));
+        var borderBrush = node.IsExpensive ? OrangeRedBrush : EdgeBrush;
+
+        var border = new Border
+        {
+            Width = Math.Max(2, w),
+            Height = Math.Max(2, h),
+            Background = bgBrush,
+            BorderBrush = borderBrush,
+            BorderThickness = new Thickness(0.5),
+            CornerRadius = new CornerRadius(1)
+        };
+        Canvas.SetLeft(border, node.X * scale);
+        Canvas.SetTop(border, node.Y * scale);
+        MinimapCanvas.Children.Add(border);
+
+        _minimapNodeMap[border] = node;
+
+        foreach (var child in node.Children)
+            RenderMinimapNodes(child, scale);
+    }
+
+    private void RenderMinimapViewportBox(double scale)
+    {
+        var viewW = PlanScrollViewer.Bounds.Width;
+        var viewH = PlanScrollViewer.Bounds.Height;
+        if (viewW <= 0 || viewH <= 0) return;
+
+        var contentW = PlanCanvas.Width * _zoomLevel;
+        var contentH = PlanCanvas.Height * _zoomLevel;
+
+        var boxW = Math.Min(viewW / contentW, 1.0) * PlanCanvas.Width * scale;
+        var boxH = Math.Min(viewH / contentH, 1.0) * PlanCanvas.Height * scale;
+        var boxX = (PlanScrollViewer.Offset.X / _zoomLevel) * scale;
+        var boxY = (PlanScrollViewer.Offset.Y / _zoomLevel) * scale;
+
+        var themeBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x4F, 0xA3, 0xFF));
+        var borderBrush = new SolidColorBrush(Color.FromArgb(0xB0, 0x4F, 0xA3, 0xFF));
+
+        _minimapViewportBox = new Border
+        {
+            Width = Math.Max(4, boxW),
+            Height = Math.Max(4, boxH),
+            Background = themeBrush,
+            BorderBrush = borderBrush,
+            BorderThickness = new Thickness(1.5),
+            CornerRadius = new CornerRadius(1),
+            Cursor = new Cursor(StandardCursorType.SizeAll)
+        };
+        Canvas.SetLeft(_minimapViewportBox, boxX);
+        Canvas.SetTop(_minimapViewportBox, boxY);
+        MinimapCanvas.Children.Add(_minimapViewportBox);
+    }
+
+    private void UpdateMinimapViewportBox()
+    {
+        if (!MinimapPanel.IsVisible || _minimapViewportBox == null || _currentStatement?.RootNode == null)
+            return;
+        if (PlanCanvas.Width <= 0 || PlanCanvas.Height <= 0) return;
+
+        var canvasW = MinimapCanvas.Bounds.Width;
+        var canvasH = MinimapCanvas.Bounds.Height;
+        if (canvasW <= 0 || canvasH <= 0) return;
+
+        var scaleX = canvasW / PlanCanvas.Width;
+        var scaleY = canvasH / PlanCanvas.Height;
+        var scale = Math.Min(scaleX, scaleY);
+
+        var viewW = PlanScrollViewer.Bounds.Width;
+        var viewH = PlanScrollViewer.Bounds.Height;
+        if (viewW <= 0 || viewH <= 0) return;
+
+        var contentW = PlanCanvas.Width * _zoomLevel;
+        var contentH = PlanCanvas.Height * _zoomLevel;
+
+        _minimapViewportBox.Width = Math.Max(4, Math.Min(viewW / contentW, 1.0) * PlanCanvas.Width * scale);
+        _minimapViewportBox.Height = Math.Max(4, Math.Min(viewH / contentH, 1.0) * PlanCanvas.Height * scale);
+        Canvas.SetLeft(_minimapViewportBox, (PlanScrollViewer.Offset.X / _zoomLevel) * scale);
+        Canvas.SetTop(_minimapViewportBox, (PlanScrollViewer.Offset.Y / _zoomLevel) * scale);
+    }
+
+    private double GetMinimapScale()
+    {
+        if (PlanCanvas.Width <= 0 || PlanCanvas.Height <= 0) return 1;
+        var canvasW = MinimapCanvas.Bounds.Width;
+        var canvasH = MinimapCanvas.Bounds.Height;
+        if (canvasW <= 0 || canvasH <= 0) return 1;
+        return Math.Min(canvasW / PlanCanvas.Width, canvasH / PlanCanvas.Height);
+    }
+
+    private void MinimapCanvas_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        var point = e.GetCurrentPoint(MinimapCanvas);
+        if (!point.Properties.IsLeftButtonPressed) return;
+
+        var pos = point.Position;
+        var scale = GetMinimapScale();
+
+        // Check if clicking on a node (single click = center, double click = zoom)
+        if (e.ClickCount == 2)
+        {
+            // Double click: find node under pointer and zoom to it
+            var node = FindMinimapNodeAt(pos);
+            if (node != null)
+            {
+                ZoomToNode(node);
+                e.Handled = true;
+                return;
+            }
+        }
+
+        if (e.ClickCount == 1)
+        {
+            // Check if over a minimap node for single-click centering
+            var node = FindMinimapNodeAt(pos);
+            if (node != null)
+            {
+                CenterOnNode(node);
+                e.Handled = true;
+                return;
+            }
+        }
+
+        // Start viewport box drag
+        _minimapDragging = true;
+        _minimapDragStart = pos;
+
+        // Move viewport center to click position
+        ScrollPlanViewerToMinimapPoint(pos, scale);
+
+        e.Pointer.Capture(MinimapCanvas);
+        e.Handled = true;
+    }
+
+    private void MinimapCanvas_PointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (!_minimapDragging) return;
+
+        var pos = e.GetPosition(MinimapCanvas);
+        var scale = GetMinimapScale();
+        ScrollPlanViewerToMinimapPoint(pos, scale);
+        e.Handled = true;
+    }
+
+    private void MinimapCanvas_PointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (!_minimapDragging) return;
+        _minimapDragging = false;
+        e.Pointer.Capture(null);
+        e.Handled = true;
+    }
+
+    private void ScrollPlanViewerToMinimapPoint(Point minimapPoint, double scale)
+    {
+        if (scale <= 0) return;
+        // Convert minimap coords to plan content coords
+        var contentX = minimapPoint.X / scale;
+        var contentY = minimapPoint.Y / scale;
+
+        // Center the viewport on this content point
+        var viewW = PlanScrollViewer.Bounds.Width;
+        var viewH = PlanScrollViewer.Bounds.Height;
+        var offsetX = Math.Max(0, contentX * _zoomLevel - viewW / 2);
+        var offsetY = Math.Max(0, contentY * _zoomLevel - viewH / 2);
+
+        Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+        {
+            PlanScrollViewer.Offset = new Vector(offsetX, offsetY);
+        });
+    }
+
+    private PlanNode? FindMinimapNodeAt(Point pos)
+    {
+        foreach (var (border, node) in _minimapNodeMap)
+        {
+            var left = Canvas.GetLeft(border);
+            var top = Canvas.GetTop(border);
+            if (pos.X >= left && pos.X <= left + border.Width &&
+                pos.Y >= top && pos.Y <= top + border.Height)
+                return node;
+        }
+        return null;
+    }
+
+    private void CenterOnNode(PlanNode node)
+    {
+        var nodeW = PlanLayoutEngine.NodeWidth;
+        var nodeH = PlanLayoutEngine.GetNodeHeight(node);
+        var viewW = PlanScrollViewer.Bounds.Width;
+        var viewH = PlanScrollViewer.Bounds.Height;
+        var centerX = (node.X + nodeW / 2) * _zoomLevel - viewW / 2;
+        var centerY = (node.Y + nodeH / 2) * _zoomLevel - viewH / 2;
+        centerX = Math.Max(0, centerX);
+        centerY = Math.Max(0, centerY);
+
+        Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+        {
+            PlanScrollViewer.Offset = new Vector(centerX, centerY);
+        });
+    }
+
+    private void ZoomToNode(PlanNode node)
+    {
+        var viewW = PlanScrollViewer.Bounds.Width;
+        var viewH = PlanScrollViewer.Bounds.Height;
+        if (viewW <= 0 || viewH <= 0) return;
+
+        var nodeW = PlanLayoutEngine.NodeWidth;
+        var nodeH = PlanLayoutEngine.GetNodeHeight(node);
+
+        // Zoom so the node takes about 1/3 of the viewport
+        var fitZoom = Math.Min(viewW / (nodeW * 3), viewH / (nodeH * 3));
+        fitZoom = Math.Max(MinZoom, Math.Min(MaxZoom, fitZoom));
+        SetZoom(fitZoom);
+
+        // Center on the node
+        var centerX = (node.X + nodeW / 2) * _zoomLevel - viewW / 2;
+        var centerY = (node.Y + nodeH / 2) * _zoomLevel - viewH / 2;
+
+        Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+        {
+            PlanScrollViewer.Offset = new Vector(Math.Max(0, centerX), Math.Max(0, centerY));
+        });
+
+        // Also select the node in the plan
+        foreach (var (border, n) in _nodeBorderMap)
+        {
+            if (n == node)
+            {
+                SelectNode(border, node);
+                break;
+            }
+        }
+    }
+
+    private void MinimapResizeGrip_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        var point = e.GetCurrentPoint(MinimapPanel);
+        if (!point.Properties.IsLeftButtonPressed) return;
+        _minimapResizing = true;
+        _minimapResizeStart = point.Position;
+        _minimapResizeStartW = MinimapPanel.Width;
+        _minimapResizeStartH = MinimapPanel.Height;
+        e.Pointer.Capture((Control)sender!);
+        e.Handled = true;
+    }
+
+    private void MinimapResizeGrip_PointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (!_minimapResizing) return;
+        var current = e.GetPosition(MinimapPanel);
+        var dx = current.X - _minimapResizeStart.X;
+        var dy = current.Y - _minimapResizeStart.Y;
+        var newW = Math.Max(MinimapMinSize, Math.Min(MinimapMaxSize, _minimapResizeStartW + dx));
+        var newH = Math.Max(MinimapMinSize, Math.Min(MinimapMaxSize, _minimapResizeStartH + dy));
+        MinimapPanel.Width = newW;
+        MinimapPanel.Height = newH;
+        _minimapWidth = newW;
+        _minimapHeight = newH;
+        e.Handled = true;
+
+        // Re-render after resize
+        Avalonia.Threading.Dispatcher.UIThread.Post(RenderMinimap, Avalonia.Threading.DispatcherPriority.Background);
+    }
+
+    private void MinimapResizeGrip_PointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (!_minimapResizing) return;
+        _minimapResizing = false;
+        e.Pointer.Capture(null);
+        e.Handled = true;
+        RenderMinimap();
     }
 
     #endregion

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -93,6 +93,7 @@ public partial class PlanViewerControl : UserControl
     private static readonly SolidColorBrush PropSeparatorBrush = new(Color.FromRgb(0x2A, 0x2D, 0x35));
     private static readonly SolidColorBrush OrangeRedBrush = new(Colors.OrangeRed);
     private static readonly SolidColorBrush OrangeBrush = new(Colors.Orange);
+    private static readonly SolidColorBrush MinimapExpensiveNodeBgBrush = new(Color.FromArgb(0x60, 0xE5, 0x73, 0x73));
 
 
     // Track all property section grids for synchronized column resize
@@ -3674,7 +3675,7 @@ public partial class PlanViewerControl : UserControl
         var h = PlanLayoutEngine.GetNodeHeight(node) * scale;
         // Use theme background colors with transparency
         var bgBrush = node.IsExpensive
-            ? new SolidColorBrush(Color.FromArgb(0x60, 0xE5, 0x73, 0x73))
+            ? MinimapExpensiveNodeBgBrush
             : FindBrushResource("BackgroundLightBrush");
         var borderBrush = node.IsExpensive ? OrangeRedBrush : _minimapNodeBorderBrushCache;
 

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -132,6 +132,8 @@ public partial class PlanViewerControl : UserControl
     private double _minimapResizeStartW;
     private double _minimapResizeStartH;
     private readonly Dictionary<Border, PlanNode> _minimapNodeMap = new();
+    private Border? _minimapSelectedNode;
+    private PlanNode? _selectedNode;
 
     public PlanViewerControl()
     {
@@ -871,7 +873,9 @@ public partial class PlanViewerControl : UserControl
         border.BorderBrush = SelectionBrush;
         border.BorderThickness = new Thickness(2);
 
+        _selectedNode = node;
         ShowPropertiesPanel(node);
+        UpdateMinimapSelection(node);
     }
 
     private ContextMenu BuildNodeContextMenu(PlanNode node)
@@ -3529,6 +3533,7 @@ public partial class PlanViewerControl : UserControl
         MinimapCanvas.Children.Clear();
         _minimapNodeMap.Clear();
         _minimapViewportBox = null;
+        _minimapSelectedNode = null;
 
         if (_currentStatement?.RootNode == null || PlanCanvas.Width <= 0 || PlanCanvas.Height <= 0)
             return;
@@ -3557,6 +3562,10 @@ public partial class PlanViewerControl : UserControl
 
         // Render viewport indicator
         RenderMinimapViewportBox(scale);
+
+        // Re-apply selection highlight if a node is selected
+        if (_selectedNode != null)
+            UpdateMinimapSelection(_selectedNode);
 
         // Attach interaction handlers to the canvas
         MinimapCanvas.PointerPressed -= MinimapCanvas_PointerPressed;
@@ -3628,6 +3637,11 @@ public partial class PlanViewerControl : UserControl
             var childCenterY = (child.Y + PlanLayoutEngine.GetNodeHeight(child) / 2) * scale;
             var midX = (parentRight + childLeft) / 2;
 
+            // Proportional thickness matching the plan viewer (logarithmic, scaled down)
+            var rows = child.HasActualStats ? child.ActualRows : child.EstimateRows;
+            var fullThickness = Math.Max(2, Math.Min(Math.Floor(Math.Log(Math.Max(1, rows))), 12));
+            var thickness = Math.Max(0.5, fullThickness * scale);
+
             var geometry = new PathGeometry();
             var figure = new PathFigure { StartPoint = new Point(parentRight, parentCenterY), IsClosed = false };
             figure.Segments!.Add(new LineSegment { Point = new Point(midX, parentCenterY) });
@@ -3639,7 +3653,7 @@ public partial class PlanViewerControl : UserControl
             {
                 Data = geometry,
                 Stroke = EdgeBrush,
-                StrokeThickness = 1,
+                StrokeThickness = thickness,
                 StrokeJoin = PenLineJoin.Round
             };
             MinimapCanvas.Children.Add(path);
@@ -3763,6 +3777,32 @@ public partial class PlanViewerControl : UserControl
         var canvasH = MinimapCanvas.Bounds.Height;
         if (canvasW <= 0 || canvasH <= 0) return 1;
         return Math.Min(canvasW / PlanCanvas.Width, canvasH / PlanCanvas.Height);
+    }
+
+    private void UpdateMinimapSelection(PlanNode node)
+    {
+        if (!MinimapPanel.IsVisible) return;
+
+        // Reset previous selection highlight
+        if (_minimapSelectedNode != null)
+        {
+            var prevNode = _minimapNodeMap.GetValueOrDefault(_minimapSelectedNode);
+            _minimapSelectedNode.BorderBrush = prevNode is { IsExpensive: true } ? OrangeRedBrush : MinimapNodeBorderBrush;
+            _minimapSelectedNode.BorderThickness = new Thickness(0.5);
+            _minimapSelectedNode = null;
+        }
+
+        // Find and highlight the new node
+        foreach (var (border, n) in _minimapNodeMap)
+        {
+            if (n == node)
+            {
+                border.BorderBrush = SelectionBrush;
+                border.BorderThickness = new Thickness(2);
+                _minimapSelectedNode = border;
+                break;
+            }
+        }
     }
 
     private void MinimapCanvas_PointerPressed(object? sender, PointerPressedEventArgs e)

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -3662,16 +3662,19 @@ public partial class PlanViewerControl : UserControl
         }
     }
 
-    private static readonly SolidColorBrush MinimapNodeBorderBrush = new(Color.FromRgb(0xA0, 0xA4, 0xAB));
-
     private void RenderMinimapNodes(PlanNode node, double scale)
     {
         var w = PlanLayoutEngine.NodeWidth * scale;
         var h = PlanLayoutEngine.GetNodeHeight(node) * scale;
+        // Use theme background colors with transparency
         var bgBrush = node.IsExpensive
             ? new SolidColorBrush(Color.FromArgb(0x60, 0xE5, 0x73, 0x73))
-            : new SolidColorBrush(Color.FromArgb(0x80, 0x30, 0x34, 0x3F));
-        var borderBrush = node.IsExpensive ? OrangeRedBrush : MinimapNodeBorderBrush;
+            : FindBrushResource("BackgroundLightBrush");
+        var borderBrush = node.IsExpensive
+            ? OrangeRedBrush
+            : FindBrushResource("ForegroundBrush") is SolidColorBrush fg
+                ? new SolidColorBrush(Color.FromArgb(0x80, fg.Color.R, fg.Color.G, fg.Color.B))
+                : (IBrush)FindBrushResource("BorderBrush");
 
         var border = new Border
         {
@@ -3725,8 +3728,11 @@ public partial class PlanViewerControl : UserControl
         var boxX = (PlanScrollViewer.Offset.X / _zoomLevel) * scale;
         var boxY = (PlanScrollViewer.Offset.Y / _zoomLevel) * scale;
 
-        var themeBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x4F, 0xA3, 0xFF));
-        var borderBrush = new SolidColorBrush(Color.FromArgb(0xB0, 0x4F, 0xA3, 0xFF));
+        var accentColor = FindBrushResource("AccentBrush") is SolidColorBrush ab
+            ? ab.Color
+            : Color.FromRgb(0x2E, 0xAE, 0xF1);
+        var themeBrush = new SolidColorBrush(Color.FromArgb(0x40, accentColor.R, accentColor.G, accentColor.B));
+        var borderBrush = new SolidColorBrush(Color.FromArgb(0xB0, accentColor.R, accentColor.G, accentColor.B));
 
         _minimapViewportBox = new Border
         {
@@ -3787,7 +3793,9 @@ public partial class PlanViewerControl : UserControl
         if (_minimapSelectedNode != null)
         {
             var prevNode = _minimapNodeMap.GetValueOrDefault(_minimapSelectedNode);
-            _minimapSelectedNode.BorderBrush = prevNode is { IsExpensive: true } ? OrangeRedBrush : MinimapNodeBorderBrush;
+            _minimapSelectedNode.BorderBrush = prevNode is { IsExpensive: true }
+                ? OrangeRedBrush
+                : FindBrushResource("BorderBrush");
             _minimapSelectedNode.BorderThickness = new Thickness(0.5);
             _minimapSelectedNode = null;
         }

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -121,11 +121,9 @@ public partial class PlanViewerControl : UserControl
     // Minimap state
     private static double _minimapWidth = 400;
     private static double _minimapHeight = 400;
-    private const double MinimapDefaultSize = 400;
     private const double MinimapMinSize = 200;
     private const double MinimapMaxSize = 500;
     private bool _minimapDragging;
-    private Point _minimapDragStart;
     private Border? _minimapViewportBox;
     private bool _minimapResizing;
     private Point _minimapResizeStart;
@@ -166,6 +164,11 @@ public partial class PlanViewerControl : UserControl
         MinimapResizeGrip.PointerPressed += MinimapResizeGrip_PointerPressed;
         MinimapResizeGrip.PointerMoved += MinimapResizeGrip_PointerMoved;
         MinimapResizeGrip.PointerReleased += MinimapResizeGrip_PointerReleased;
+
+        // Wire minimap canvas interaction handlers once
+        MinimapCanvas.PointerPressed += MinimapCanvas_PointerPressed;
+        MinimapCanvas.PointerMoved += MinimapCanvas_PointerMoved;
+        MinimapCanvas.PointerReleased += MinimapCanvas_PointerReleased;
     }
 
     /// <summary>
@@ -358,6 +361,7 @@ public partial class PlanViewerControl : UserControl
         _currentStatement = null;
         _queryText = null;
         _selectedNodeBorder = null;
+        _selectedNode = null;
         EmptyState.IsVisible = true;
         PlanScrollViewer.IsVisible = false;
         InsightsPanel.IsVisible = false;
@@ -383,6 +387,7 @@ public partial class PlanViewerControl : UserControl
         PlanCanvas.Children.Clear();
         _nodeBorderMap.Clear();
         _selectedNodeBorder = null;
+        _selectedNode = null;
 
         if (statement.RootNode == null) return;
 
@@ -3535,6 +3540,9 @@ public partial class PlanViewerControl : UserControl
         _minimapViewportBox = null;
         _minimapSelectedNode = null;
 
+        // Guard: don't render if the panel was closed between a deferred post and execution
+        if (!MinimapPanel.IsVisible) return;
+
         if (_currentStatement?.RootNode == null || PlanCanvas.Width <= 0 || PlanCanvas.Height <= 0)
             return;
 
@@ -3551,6 +3559,11 @@ public partial class PlanViewerControl : UserControl
         var scaleY = canvasH / PlanCanvas.Height;
         var scale = Math.Min(scaleX, scaleY);
 
+        // Cache the non-expensive node border brush for this render cycle
+        _minimapNodeBorderBrushCache = FindBrushResource("ForegroundBrush") is SolidColorBrush fg
+            ? new SolidColorBrush(Color.FromArgb(0x80, fg.Color.R, fg.Color.G, fg.Color.B))
+            : FindBrushResource("BorderBrush");
+
         // Render branch areas with transparent colored backgrounds
         RenderMinimapBranches(_currentStatement.RootNode, scale);
 
@@ -3566,35 +3579,27 @@ public partial class PlanViewerControl : UserControl
         // Re-apply selection highlight if a node is selected
         if (_selectedNode != null)
             UpdateMinimapSelection(_selectedNode);
-
-        // Attach interaction handlers to the canvas
-        MinimapCanvas.PointerPressed -= MinimapCanvas_PointerPressed;
-        MinimapCanvas.PointerMoved -= MinimapCanvas_PointerMoved;
-        MinimapCanvas.PointerReleased -= MinimapCanvas_PointerReleased;
-        MinimapCanvas.PointerPressed += MinimapCanvas_PointerPressed;
-        MinimapCanvas.PointerMoved += MinimapCanvas_PointerMoved;
-        MinimapCanvas.PointerReleased += MinimapCanvas_PointerReleased;
     }
+
+    private static readonly Color[] MinimapBranchColors =
+    {
+        Color.FromArgb(0x30, 0x4F, 0xA3, 0xFF), // blue
+        Color.FromArgb(0x30, 0x7B, 0xCF, 0x7B), // green
+        Color.FromArgb(0x30, 0xFF, 0xB3, 0x47), // orange
+        Color.FromArgb(0x30, 0xE5, 0x73, 0x73), // red
+        Color.FromArgb(0x30, 0xCF, 0x7B, 0xCF), // purple
+        Color.FromArgb(0x30, 0x7B, 0xCF, 0xCF), // teal
+        Color.FromArgb(0x30, 0xFF, 0xE0, 0x4F), // yellow
+        Color.FromArgb(0x30, 0xFF, 0x7B, 0xA5), // pink
+    };
 
     private void RenderMinimapBranches(PlanNode root, double scale)
     {
-        // Assign unique branch colors to each child subtree of the root
-        var branchColors = new[]
-        {
-            Color.FromArgb(0x30, 0x4F, 0xA3, 0xFF), // blue
-            Color.FromArgb(0x30, 0x7B, 0xCF, 0x7B), // green
-            Color.FromArgb(0x30, 0xFF, 0xB3, 0x47), // orange
-            Color.FromArgb(0x30, 0xE5, 0x73, 0x73), // red
-            Color.FromArgb(0x30, 0xCF, 0x7B, 0xCF), // purple
-            Color.FromArgb(0x30, 0x7B, 0xCF, 0xCF), // teal
-            Color.FromArgb(0x30, 0xFF, 0xE0, 0x4F), // yellow
-            Color.FromArgb(0x30, 0xFF, 0x7B, 0xA5), // pink
-        };
 
         for (int i = 0; i < root.Children.Count; i++)
         {
             var child = root.Children[i];
-            var color = branchColors[i % branchColors.Length];
+            var color = MinimapBranchColors[i % MinimapBranchColors.Length];
 
             // Collect bounds of all nodes in this subtree
             double minX = double.MaxValue, minY = double.MaxValue;
@@ -3662,6 +3667,9 @@ public partial class PlanViewerControl : UserControl
         }
     }
 
+    // Cached per render cycle in RenderMinimap() to avoid per-node brush creation
+    private IBrush _minimapNodeBorderBrushCache = Brushes.Gray;
+
     private void RenderMinimapNodes(PlanNode node, double scale)
     {
         var w = PlanLayoutEngine.NodeWidth * scale;
@@ -3670,11 +3678,7 @@ public partial class PlanViewerControl : UserControl
         var bgBrush = node.IsExpensive
             ? new SolidColorBrush(Color.FromArgb(0x60, 0xE5, 0x73, 0x73))
             : FindBrushResource("BackgroundLightBrush");
-        var borderBrush = node.IsExpensive
-            ? OrangeRedBrush
-            : FindBrushResource("ForegroundBrush") is SolidColorBrush fg
-                ? new SolidColorBrush(Color.FromArgb(0x80, fg.Color.R, fg.Color.G, fg.Color.B))
-                : (IBrush)FindBrushResource("BorderBrush");
+        var borderBrush = node.IsExpensive ? OrangeRedBrush : _minimapNodeBorderBrushCache;
 
         var border = new Border
         {
@@ -3795,7 +3799,7 @@ public partial class PlanViewerControl : UserControl
             var prevNode = _minimapNodeMap.GetValueOrDefault(_minimapSelectedNode);
             _minimapSelectedNode.BorderBrush = prevNode is { IsExpensive: true }
                 ? OrangeRedBrush
-                : FindBrushResource("BorderBrush");
+                : _minimapNodeBorderBrushCache;
             _minimapSelectedNode.BorderThickness = new Thickness(0.5);
             _minimapSelectedNode = null;
         }
@@ -3848,7 +3852,6 @@ public partial class PlanViewerControl : UserControl
 
         // Start viewport box drag
         _minimapDragging = true;
-        _minimapDragStart = pos;
 
         // Move viewport center to click position
         ScrollPlanViewerToMinimapPoint(pos, scale);

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -119,9 +119,9 @@ public partial class PlanViewerControl : UserControl
     private double _panStartOffsetY;
 
     // Minimap state
-    private static double _minimapWidth = 300;
-    private static double _minimapHeight = 300;
-    private const double MinimapDefaultSize = 300;
+    private static double _minimapWidth = 400;
+    private static double _minimapHeight = 400;
+    private const double MinimapDefaultSize = 400;
     private const double MinimapMinSize = 200;
     private const double MinimapMaxSize = 500;
     private bool _minimapDragging;
@@ -159,6 +159,11 @@ public partial class PlanViewerControl : UserControl
         _zoomTransform = (ScaleTransform)layoutTransform.LayoutTransform!;
 
         Helpers.DataGridBehaviors.Attach(StatementsGrid);
+
+        // Wire minimap resize grip (defined in AXAML, not in canvas)
+        MinimapResizeGrip.PointerPressed += MinimapResizeGrip_PointerPressed;
+        MinimapResizeGrip.PointerMoved += MinimapResizeGrip_PointerMoved;
+        MinimapResizeGrip.PointerReleased += MinimapResizeGrip_PointerReleased;
     }
 
     /// <summary>
@@ -3553,21 +3558,6 @@ public partial class PlanViewerControl : UserControl
         // Render viewport indicator
         RenderMinimapViewportBox(scale);
 
-        // Attach resize via bottom-right 8px drag area
-        var resizeGrip = new Border
-        {
-            Width = 10,
-            Height = 10,
-            Background = Brushes.Transparent,
-            Cursor = new Cursor(StandardCursorType.BottomRightCorner)
-        };
-        Canvas.SetLeft(resizeGrip, canvasW - 10);
-        Canvas.SetTop(resizeGrip, canvasH - 10);
-        resizeGrip.PointerPressed += MinimapResizeGrip_PointerPressed;
-        resizeGrip.PointerMoved += MinimapResizeGrip_PointerMoved;
-        resizeGrip.PointerReleased += MinimapResizeGrip_PointerReleased;
-        MinimapCanvas.Children.Add(resizeGrip);
-
         // Attach interaction handlers to the canvas
         MinimapCanvas.PointerPressed -= MinimapCanvas_PointerPressed;
         MinimapCanvas.PointerMoved -= MinimapCanvas_PointerMoved;
@@ -3658,6 +3648,8 @@ public partial class PlanViewerControl : UserControl
         }
     }
 
+    private static readonly SolidColorBrush MinimapNodeBorderBrush = new(Color.FromRgb(0xA0, 0xA4, 0xAB));
+
     private void RenderMinimapNodes(PlanNode node, double scale)
     {
         var w = PlanLayoutEngine.NodeWidth * scale;
@@ -3665,17 +3657,36 @@ public partial class PlanViewerControl : UserControl
         var bgBrush = node.IsExpensive
             ? new SolidColorBrush(Color.FromArgb(0x60, 0xE5, 0x73, 0x73))
             : new SolidColorBrush(Color.FromArgb(0x80, 0x30, 0x34, 0x3F));
-        var borderBrush = node.IsExpensive ? OrangeRedBrush : EdgeBrush;
+        var borderBrush = node.IsExpensive ? OrangeRedBrush : MinimapNodeBorderBrush;
 
         var border = new Border
         {
-            Width = Math.Max(2, w),
-            Height = Math.Max(2, h),
+            Width = Math.Max(4, w),
+            Height = Math.Max(4, h),
             Background = bgBrush,
             BorderBrush = borderBrush,
             BorderThickness = new Thickness(0.5),
             CornerRadius = new CornerRadius(1)
         };
+
+        // Show a small icon inside the node if space allows
+        var iconBitmap = IconHelper.LoadIcon(node.IconName);
+        if (iconBitmap != null)
+        {
+            var iconSize = Math.Min(Math.Min(w * 0.7, h * 0.7), 16);
+            if (iconSize >= 6)
+            {
+                border.Child = new Image
+                {
+                    Source = iconBitmap,
+                    Width = iconSize,
+                    Height = iconSize,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center
+                };
+            }
+        }
+
         Canvas.SetLeft(border, node.X * scale);
         Canvas.SetTop(border, node.Y * scale);
         MinimapCanvas.Children.Add(border);

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -144,15 +144,13 @@ public partial class PlanViewerControl : UserControl
         PlanScrollViewer.AddHandler(PointerReleasedEvent, PlanScrollViewer_PointerReleased, Avalonia.Interactivity.RoutingStrategies.Tunnel);
         PlanScrollViewer.ScrollChanged += (_, _) => UpdateMinimapViewportBox();
 
-        // Resolve non-control elements by traversal (Avalonia doesn't support x:Name on these types)
-        // The 5-column Grid in Row 2 is now the grandparent of PlanScrollViewer
-        // (PlanScrollViewer sits inside a minimap wrapper Grid at Column 2).
+        // Resolve ColumnDefinitions from the named 5-column layout Grid.
+        // (x:Name works on Grid but not on ColumnDefinition, so we index into the definitions.)
         //   [0]=Statements(0), [1]=StmtSplitter(0), [2]=Canvas(*), [3]=PropsSplitter(0), [4]=Props(0)
-        var planGrid = (Grid)PlanScrollViewer.Parent!.Parent!;
-        _statementsColumn = planGrid.ColumnDefinitions[0];
-        _statementsSplitterColumn = planGrid.ColumnDefinitions[1];
-        _splitterColumn = planGrid.ColumnDefinitions[3];
-        _propertiesColumn = planGrid.ColumnDefinitions[4];
+        _statementsColumn = PlanGrid.ColumnDefinitions[0];
+        _statementsSplitterColumn = PlanGrid.ColumnDefinitions[1];
+        _splitterColumn = PlanGrid.ColumnDefinitions[3];
+        _propertiesColumn = PlanGrid.ColumnDefinitions[4];
 
         // ScaleTransform is the LayoutTransform of the wrapper around PlanCanvas
         var layoutTransform = this.FindControl<Avalonia.Controls.LayoutTransformControl>("PlanLayoutTransform")!;

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -1299,11 +1299,10 @@ public partial class MainWindow : Window
                 }
             }
         };
+		dialog.ShowDialog(this);
+	}
 
-            dialog.ShowDialog(this);
-    }
-
-    private async Task CheckForUpdatesOnStartupAsync()
+	private async Task CheckForUpdatesOnStartupAsync()
     {
         try
         {

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -1299,7 +1299,11 @@ public partial class MainWindow : Window
                 }
             }
         };
-        dialog.ShowDialog(this);
+
+        if (IsVisible)
+            dialog.ShowDialog(this);
+        else
+            dialog.Show();
     }
 
     private async Task CheckForUpdatesOnStartupAsync()

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -1300,10 +1300,7 @@ public partial class MainWindow : Window
             }
         };
 
-        if (IsVisible)
             dialog.ShowDialog(this);
-        else
-            dialog.Show();
     }
 
     private async Task CheckForUpdatesOnStartupAsync()


### PR DESCRIPTION
## What does this PR do?

### Minimap for Plan Viewer
Adds an interactive minimap overlay to the plan viewer, providing a bird's-eye view of the entire execution plan for easier navigation in large plans. Each plan tab maintains its own independent minimap state.
### Features
#### Toggle & Positioning
•	Small "minimap" button always visible at the top-left corner of the plan canvas (4px margin)
•	Click to open/close; minimap appears directly below the button as a floating overlay (ZIndex 10)
•	Close button (✕) in the minimap header bar
•	Minimap automatically closes when the plan is cleared
#### Rendering
•	Entire plan tree rendered in miniature: nodes, elbow connector edges, and operator icons
•	Nodes show their operator icon scaled to fit (up to 16px, hidden below 6px)
•	Expensive nodes highlighted with red-tinted background and OrangeRed border
•	Edge thickness is proportional to row counts using the same logarithmic formula as the main plan, scaled down to minimap coordinates
•	Branch visualization: each child subtree of the root node gets a transparent colored background area (8 cycling colors) making it easy to distinguish plan branches at a glance
#### Viewport Indicator
•	Semi-transparent accent-colored rectangle shows the currently visible portion of the plan
•	Updates in real-time on scroll, pan (mouse drag / middle-click), and zoom (Ctrl+wheel, buttons, fit-to-view)
Navigation Interactions
•	Click & drag on empty area: moves the plan viewer viewport to follow the pointer — the main plan scrolls in real-time
•	Single click on a node: centers the plan viewer on that node
•	Double click on a node: zooms to ~1/3 viewport size, centers on the node, and selects it (shows properties panel)
#### Selected Node Highlight
•	When a node is selected in the main plan viewer (click or via properties), the corresponding minimap node is highlighted with the selection brush (blue, 2px border)
•	Highlight persists through minimap re-renders and is correctly cleared on statement switch or plan clear
#### Resizing
•	Diagonal grip lines in the bottom-right corner indicate resizability
•	Drag the grip to resize between 200×200 (min) and 500×500 (max)
•	Default size: 400×400
•	Last used dimensions are preserved in memory (static fields) across plan tabs within the same session, but not persisted to disk
#### Theming
•	All colors derived from theme resources (BackgroundBrush, BorderBrush, ForegroundBrush, AccentBrush, BackgroundLightBrush) — no hardcoded hex values except the decorative branch overlay palette
•	Minimap panel border, header, and canvas background all follow the dark theme
•	Viewport box fill/border derived from AccentBrush with alpha transparency
•	Node border brush derived from ForegroundBrush at 50% opacity, cached per render cycle
#### Technical Notes
•	The minimap wrapper Grid was inserted between the 5-column layout Grid and the PlanScrollViewer, changing the parent traversal path for column definition resolution (Parent instead of Parent)
•	Canvas pointer handlers (PointerPressed/Moved/Released) are wired once in the constructor, not per render
•	RenderMinimap() guards against deferred execution after panel close
•	_selectedNode is properly cleared in both Clear() and RenderStatement() to prevent stale references
•	Branch colors extracted to a static readonly Color[] to avoid per-render allocation
•	Non-expensive node border brush is computed once per render cycle and cached in _minimapNodeBorderBrushCache



## Which component(s) does this affect?

- [x] Desktop App (PlanViewer.App)
- [ ] Core Library (PlanViewer.Core)
- [ ] CLI Tool (PlanViewer.Cli)
- [ ] SSMS Extension (PlanViewer.Ssms)
- [ ] Tests
- [ ] Documentation

## How was this tested?

<img width="1464" height="878" alt="2026-04-25_23h20_28" src="https://github.com/user-attachments/assets/9c0c4684-46ee-4c75-bd23-2414f520dbde" />

<img width="1464" height="878" alt="2026-04-25_23h22_53" src="https://github.com/user-attachments/assets/5d847ad7-83e8-4e3e-aaef-75855357fef6" />





Describe the testing you've done. Include:
- Plan files tested : estimated, actual, qs
- Platforms tested : Windows Only

## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceStudio/blob/main/CONTRIBUTING.md)
- [x] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] All tests pass (`dotnet test`)
- [x] I have not introduced any hardcoded credentials or server names
