### PR TITLE
Bump dependencies and clean up source warnings

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/src/PlanViewer.App/Dialogs/QueryStoreHistoryWindow.axaml.cs
+++ b/src/PlanViewer.App/Dialogs/QueryStoreHistoryWindow.axaml.cs
@@ -7,7 +7,6 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.VisualTree;
 using PlanViewer.Core.Models;
@@ -111,9 +110,9 @@ public partial class QueryStoreHistoryWindow : Window
 
         // Select initial metric in the combo box
         var metricTag = initialMetricTag;
-        foreach (ComboBoxItem item in MetricSelector.Items)
+        foreach (var entry in MetricSelector.Items)
         {
-            if (item.Tag?.ToString() == metricTag)
+            if (entry is ComboBoxItem item && item.Tag?.ToString() == metricTag)
             {
                 MetricSelector.SelectedItem = item;
                 break;
@@ -759,7 +758,7 @@ public partial class QueryStoreHistoryWindow : Window
 
     private void OnHighlightLoadingRow(object? sender, DataGridRowEventArgs e)
     {
-        var idx = e.Row.GetIndex();
+        var idx = e.Row.Index;
         if (_selectedRowIndices.Contains(idx))
         {
             e.Row.Background = new SolidColorBrush(Avalonia.Media.Color.FromArgb(60, 79, 195, 247));

--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -14,23 +14,23 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.12" />
+    <PackageReference Include="Avalonia" Version="11.3.14" />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.4.1" />
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.12" />
-    <PackageReference Include="ScottPlot.Avalonia" Version="5.1.57" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.12" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.13" />
+    <PackageReference Include="ScottPlot.Avalonia" Version="5.1.58" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.14" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.14" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.14" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.12">
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.14">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="AvaloniaEdit.TextMate" Version="11.4.1" />
     <PackageReference Include="AvaloniaEdit.TextMate.Grammars" Version="0.10.12" />
-    <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="1.7.17" />
-    <PackageReference Include="ModelContextProtocol" Version="0.7.0-preview.1" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.7.0-preview.1" />
+    <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="1.7.18" />
+    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
     <PackageReference Include="TextMateSharp.Grammars" Version="2.0.3" />
     <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="170.191.0" />
     <PackageReference Include="Velopack" Version="0.0.1298" />
@@ -40,7 +40,7 @@
          but the managed SkiaSharp 3.x requires native libs in the [119.0, 120.0) range.
          Without these pins, the old 2.88.x .so overwrites the correct one at publish time,
          causing a TypeInitializationException on Linux (GitHub issue #139). -->
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.0" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PlanViewer.Cli/Commands/CredentialCommand.cs
+++ b/src/PlanViewer.Cli/Commands/CredentialCommand.cs
@@ -77,12 +77,15 @@ public static class CredentialCommand
 
         cmd.SetHandler(() =>
         {
-            IReadOnlyList<(string ServerName, string Username)>? creds = credentialService switch
-            {
-                WindowsCredentialService win => win.ListAll(),
-                KeychainCredentialService mac => mac.ListAll(),
-                _ => null
-            };
+            IReadOnlyList<(string ServerName, string Username)>? creds = null;
+            // CA1416: WindowsCredentialService is gated on OperatingSystem.IsWindows().
+            // .NET 8 won't run below Windows 10, so the underlying "windows5.1.2600" requirement is always met.
+#pragma warning disable CA1416
+            if (OperatingSystem.IsWindows() && credentialService is WindowsCredentialService win)
+                creds = win.ListAll();
+#pragma warning restore CA1416
+            if (OperatingSystem.IsMacOS() && credentialService is KeychainCredentialService mac)
+                creds = mac.ListAll();
 
             if (creds == null)
             {

--- a/src/PlanViewer.Core/PlanViewer.Core.csproj
+++ b/src/PlanViewer.Core/PlanViewer.Core.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.1" />
-    <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="1.7.17" />
+    <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="1.7.18" />
     <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="170.191.0" />
   </ItemGroup>
 

--- a/src/PlanViewer.Core/Services/CredentialServiceFactory.cs
+++ b/src/PlanViewer.Core/Services/CredentialServiceFactory.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using PlanViewer.Core.Interfaces;
 
 namespace PlanViewer.Core.Services;
@@ -7,10 +6,14 @@ public static class CredentialServiceFactory
 {
     public static ICredentialService Create()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        // CA1416: the underlying CredentialManager API declares "windows5.1.2600" (XP+);
+        // .NET 8 won't run on anything below Windows 10, so OperatingSystem.IsWindows() is sufficient.
+#pragma warning disable CA1416
+        if (OperatingSystem.IsWindows())
             return new WindowsCredentialService();
+#pragma warning restore CA1416
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (OperatingSystem.IsMacOS())
             return new KeychainCredentialService();
 
         // Linux and other platforms: use in-memory storage (credentials not persisted across sessions)

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.cs
@@ -403,7 +403,7 @@ public static class PlanAnalyzer
 
             if (unsnifffedParams.Count > 0)
             {
-                var hasRecompile = stmt.StatementText.Contains("RECOMPILE", StringComparison.OrdinalIgnoreCase);
+                var hasRecompile = stmt.StatementText?.Contains("RECOMPILE", StringComparison.OrdinalIgnoreCase) == true;
                 if (!hasRecompile)
                 {
                     var names = string.Join(", ", unsnifffedParams.Select(p => p.Name));
@@ -1321,7 +1321,7 @@ public static class PlanAnalyzer
         // Rule 28: Row Count Spool — NOT IN with nullable column
         // Pattern: Row Count Spool with high rewinds, child scan has IS NULL predicate,
         // and statement text contains NOT IN
-        if (!cfg.IsRuleDisabled(28) && node.PhysicalOp.Contains("Row Count Spool"))
+        if (!cfg.IsRuleDisabled(28) && node.PhysicalOp?.Contains("Row Count Spool") == true)
         {
             var rewinds = node.HasActualStats ? (double)node.ActualRewinds : node.EstimateRewinds;
             if (rewinds > 10000 && HasNotInPattern(node, stmt))

--- a/src/PlanViewer.Core/Services/WindowsCredentialService.cs
+++ b/src/PlanViewer.Core/Services/WindowsCredentialService.cs
@@ -1,8 +1,10 @@
+using System.Runtime.Versioning;
 using Meziantou.Framework.Win32;
 using PlanViewer.Core.Interfaces;
 
 namespace PlanViewer.Core.Services;
 
+[SupportedOSPlatform("windows5.1.2600")]
 public class WindowsCredentialService : ICredentialService
 {
     private const string Prefix = "planview:";

--- a/tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj
+++ b/tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Bumps Avalonia (11.3.12 → 11.3.14, DataGrid 11.3.13), `ModelContextProtocol` from 0.7-preview to 1.2.0 GA, the test SDK / xunit / coverlet line, and a handful of patch versions.
- Closes 3 transitive vulnerabilities: `Tmds.DBus.Protocol` (GHSA-xrw6-gwf8-vvr9), `System.Net.Http` 4.3.0 (GHSA-7jgj-8wvc-jh57), `System.Text.RegularExpressions` 4.3.0 (GHSA-cmhx-cq75-c4mj).
- Cleans up all non-AVLN source warnings: nullable derefs in `PlanAnalyzer`, obsolete `DataGridRow.GetIndex()`, unsafe `ComboBoxItem` cast in the QueryStore history dialog, CA1416 platform attributes on the Windows credential service, and a couple of unused `using` directives flagged by LSP.

## Test plan
- [x] `dotnet build PlanViewer.sln -c Debug --no-incremental` — 0 errors, 0 source warnings (only pre-existing AVLN3001 axaml noise on dialogs)
- [x] `dotnet test tests/PlanViewer.Core.Tests` — 71/71 passing on the new SDK
- [x] `dotnet list package --vulnerable --include-transitive` — clean
- [ ] Smoke-test the desktop app: open a plan, run a Query Store query, save/read a credential
- [ ] Smoke-test the CLI: `planview credential list` (Windows path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)