### PR TITLE
Migrate xunit to v3

### DIFF
--- a/tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj
+++ b/tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Swaps `xunit` 2.9.3 for `xunit.v3` 3.2.2. Single .csproj line. The runner (`xunit.runner.visualstudio` 3.1.5) already supports v3.

## Test plan
- [x] `dotnet test` — 71/71 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)