### PR TITLE
Bump SqlClient 6 -> 7 and ScriptDom 170 -> 180

### DIFF
--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
     <PackageReference Include="TextMateSharp.Grammars" Version="2.0.3" />
-    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="170.191.0" />
+    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="180.6.0" />
     <PackageReference Include="Velopack" Version="0.0.1298" />
 
     <!-- Pin SkiaSharp native assets to match SkiaSharp 3.119.0.

--- a/src/PlanViewer.Core/PlanViewer.Core.csproj
+++ b/src/PlanViewer.Core/PlanViewer.Core.csproj
@@ -13,9 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="1.7.18" />
-    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="170.191.0" />
+    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="180.6.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- `Microsoft.Data.SqlClient` 6.0.1 → 7.0.1
- `Microsoft.SqlServer.TransactSql.ScriptDom` 170.191.0 → 180.6.0 (Core + App)

Zero source code changes — the API surface in use carries forward unchanged. `ActiveDirectoryInteractive` (Entra MFA) remains in the core SqlClient package in 7.0.1.

## Test plan
- [x] `dotnet build` — 0 errors, 0 source warnings
- [x] `dotnet test` — 71/71 passing
- [ ] Smoke: connect with Windows auth, SQL auth, and Entra MFA against a server requiring TLS
- [ ] Smoke: open a `.sqlplan` and use the SQL formatter / object resolver

🤖 Generated with [Claude Code](https://claude.com/claude-code)