### PR TITLE
Migrate System.CommandLine beta4 -> 2.0.7 GA

### DIFF
--- a/src/PlanViewer.Cli/Commands/AnalyzeCommand.cs
+++ b/src/PlanViewer.Cli/Commands/AnalyzeCommand.cs
@@ -1,5 +1,4 @@
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.Diagnostics;
 using System.Text.Json;
 using Microsoft.Data.SqlClient;
@@ -27,83 +26,94 @@ public static class AnalyzeCommand
 
     public static Command Create(ICredentialService? credentialService = null)
     {
-        var fileArg = new Argument<FileInfo?>(
-            "file",
-            description: "Path to a .sqlplan file, .sql file, or directory of .sql files")
+        var fileArg = new Argument<FileInfo?>("file")
         {
+            Description = "Path to a .sqlplan file, .sql file, or directory of .sql files",
             Arity = ArgumentArity.ZeroOrOne
         };
 
-        var stdinOption = new Option<bool>(
-            "--stdin",
-            "Read plan XML from stdin");
+        var stdinOption = new Option<bool>("--stdin")
+        {
+            Description = "Read plan XML from stdin"
+        };
 
-        var outputOption = new Option<string>(
-            "--output",
-            getDefaultValue: () => "json",
-            description: "Output format: json or text");
-        outputOption.AddAlias("-o");
+        var outputOption = new Option<string>("--output", "-o")
+        {
+            Description = "Output format: json or text",
+            DefaultValueFactory = _ => "json"
+        };
 
-        var compactOption = new Option<bool>(
-            "--compact",
-            "Compact JSON output (no indentation)");
+        var compactOption = new Option<bool>("--compact")
+        {
+            Description = "Compact JSON output (no indentation)"
+        };
 
-        var warningsOnlyOption = new Option<bool>(
-            "--warnings-only",
-            "Only output warnings and missing indexes, skip operator tree");
+        var warningsOnlyOption = new Option<bool>("--warnings-only")
+        {
+            Description = "Only output warnings and missing indexes, skip operator tree"
+        };
 
         // Live execution options
-        var serverOption = new Option<string?>(
-            "--server",
-            "Server name (matches credential store key)");
-        serverOption.AddAlias("-s");
+        var serverOption = new Option<string?>("--server", "-s")
+        {
+            Description = "Server name (matches credential store key)"
+        };
 
-        var databaseOption = new Option<string?>(
-            "--database",
-            "Database context for execution");
-        databaseOption.AddAlias("-d");
+        var databaseOption = new Option<string?>("--database", "-d")
+        {
+            Description = "Database context for execution"
+        };
 
-        var queryOption = new Option<string?>(
-            "--query",
-            "Inline SQL text to execute");
-        queryOption.AddAlias("-q");
+        var queryOption = new Option<string?>("--query", "-q")
+        {
+            Description = "Inline SQL text to execute"
+        };
 
-        var outputDirOption = new Option<DirectoryInfo?>(
-            "--output-dir",
-            "Directory for output files (default: current directory)");
+        var outputDirOption = new Option<DirectoryInfo?>("--output-dir")
+        {
+            Description = "Directory for output files (default: current directory)"
+        };
 
-        var estimatedOption = new Option<bool>(
-            "--estimated",
-            "Use estimated plan (SET SHOWPLAN XML ON) instead of actual plan");
+        var estimatedOption = new Option<bool>("--estimated")
+        {
+            Description = "Use estimated plan (SET SHOWPLAN XML ON) instead of actual plan"
+        };
 
-        var authOption = new Option<string?>(
-            "--auth",
-            "Authentication type: windows, sql, entra (default: auto-detect)");
+        var authOption = new Option<string?>("--auth")
+        {
+            Description = "Authentication type: windows, sql, entra (default: auto-detect)"
+        };
 
-        var trustCertOption = new Option<bool>(
-            "--trust-cert",
-            "Trust the server certificate (for dev/test environments)");
+        var trustCertOption = new Option<bool>("--trust-cert")
+        {
+            Description = "Trust the server certificate (for dev/test environments)"
+        };
 
-        var timeoutOption = new Option<int>(
-            "--timeout",
-            getDefaultValue: () => 60,
-            description: "Query timeout in seconds");
+        var timeoutOption = new Option<int>("--timeout")
+        {
+            Description = "Query timeout in seconds",
+            DefaultValueFactory = _ => 60
+        };
 
-        var loginOption = new Option<string?>(
-            "--login",
-            "SQL Server login name (bypasses credential store)");
+        var loginOption = new Option<string?>("--login")
+        {
+            Description = "SQL Server login name (bypasses credential store)"
+        };
 
-        var passwordOption = new Option<string?>(
-            "--password",
-            "SQL Server password (bypasses credential store). Visible in process listings — prefer --password-stdin.");
+        var passwordOption = new Option<string?>("--password")
+        {
+            Description = "SQL Server password (bypasses credential store). Visible in process listings — prefer --password-stdin."
+        };
 
-        var passwordStdinOption = new Option<bool>(
-            "--password-stdin",
-            "Read the SQL Server password from stdin (avoids process-listing exposure). Mutually exclusive with --password.");
+        var passwordStdinOption = new Option<bool>("--password-stdin")
+        {
+            Description = "Read the SQL Server password from stdin (avoids process-listing exposure). Mutually exclusive with --password."
+        };
 
-        var configOption = new Option<string?>(
-            "--config",
-            "Path to .planview.json config file (overrides auto-discovery)");
+        var configOption = new Option<string?>("--config")
+        {
+            Description = "Path to .planview.json config file (overrides auto-discovery)"
+        };
 
         var cmd = new Command("analyze", "Analyze a SQL Server execution plan")
         {
@@ -126,25 +136,25 @@ public static class AnalyzeCommand
             configOption
         };
 
-        cmd.SetHandler(async (ctx) =>
+        cmd.SetAction(async (parseResult, ct) =>
         {
-            var file = ctx.ParseResult.GetValueForArgument(fileArg);
-            var stdin = ctx.ParseResult.GetValueForOption(stdinOption);
-            var output = ctx.ParseResult.GetValueForOption(outputOption) ?? "json";
-            var compact = ctx.ParseResult.GetValueForOption(compactOption);
-            var warningsOnly = ctx.ParseResult.GetValueForOption(warningsOnlyOption);
-            var server = ctx.ParseResult.GetValueForOption(serverOption);
-            var database = ctx.ParseResult.GetValueForOption(databaseOption);
-            var query = ctx.ParseResult.GetValueForOption(queryOption);
-            var outputDir = ctx.ParseResult.GetValueForOption(outputDirOption);
-            var estimated = ctx.ParseResult.GetValueForOption(estimatedOption);
-            var auth = ctx.ParseResult.GetValueForOption(authOption);
-            var trustCert = ctx.ParseResult.GetValueForOption(trustCertOption);
-            var timeout = ctx.ParseResult.GetValueForOption(timeoutOption);
-            var login = ctx.ParseResult.GetValueForOption(loginOption);
-            var passwordInline = ctx.ParseResult.GetValueForOption(passwordOption);
-            var passwordStdin = ctx.ParseResult.GetValueForOption(passwordStdinOption);
-            var configPath = ctx.ParseResult.GetValueForOption(configOption);
+            var file = parseResult.GetValue(fileArg);
+            var stdin = parseResult.GetValue(stdinOption);
+            var output = parseResult.GetValue(outputOption) ?? "json";
+            var compact = parseResult.GetValue(compactOption);
+            var warningsOnly = parseResult.GetValue(warningsOnlyOption);
+            var server = parseResult.GetValue(serverOption);
+            var database = parseResult.GetValue(databaseOption);
+            var query = parseResult.GetValue(queryOption);
+            var outputDir = parseResult.GetValue(outputDirOption);
+            var estimated = parseResult.GetValue(estimatedOption);
+            var auth = parseResult.GetValue(authOption);
+            var trustCert = parseResult.GetValue(trustCertOption);
+            var timeout = parseResult.GetValue(timeoutOption);
+            var login = parseResult.GetValue(loginOption);
+            var passwordInline = parseResult.GetValue(passwordOption);
+            var passwordStdin = parseResult.GetValue(passwordStdinOption);
+            var configPath = parseResult.GetValue(configOption);
 
             // Load analyzer config
             var analyzerConfig = ConfigLoader.Load(configPath);

--- a/src/PlanViewer.Cli/Commands/CredentialCommand.cs
+++ b/src/PlanViewer.Cli/Commands/CredentialCommand.cs
@@ -11,28 +11,40 @@ public static class CredentialCommand
     {
         var cmd = new Command("credential", "Manage stored server credentials");
 
-        cmd.AddCommand(CreateAddCommand(credentialService));
-        cmd.AddCommand(CreateListCommand(credentialService));
-        cmd.AddCommand(CreateRemoveCommand(credentialService));
+        cmd.Subcommands.Add(CreateAddCommand(credentialService));
+        cmd.Subcommands.Add(CreateListCommand(credentialService));
+        cmd.Subcommands.Add(CreateRemoveCommand(credentialService));
 
         return cmd;
     }
 
     private static Command CreateAddCommand(ICredentialService credentialService)
     {
-        var serverArg = new Argument<string>("server-name", "Server name to store credentials for");
-        var userOption = new Option<string>("--user", "Username") { IsRequired = true };
-        userOption.AddAlias("-u");
-        var passwordOption = new Option<string?>("--password", "Password (if omitted, prompts interactively)");
-        passwordOption.AddAlias("-p");
+        var serverArg = new Argument<string>("server-name")
+        {
+            Description = "Server name to store credentials for"
+        };
+        var userOption = new Option<string>("--user", "-u")
+        {
+            Description = "Username",
+            Required = true
+        };
+        var passwordOption = new Option<string?>("--password", "-p")
+        {
+            Description = "Password (if omitted, prompts interactively)"
+        };
 
         var cmd = new Command("add", "Add or update credentials for a server")
         {
             serverArg, userOption, passwordOption
         };
 
-        cmd.SetHandler((string server, string user, string? passwordArg) =>
+        cmd.SetAction(parseResult =>
         {
+            var server = parseResult.GetValue(serverArg)!;
+            var user = parseResult.GetValue(userOption)!;
+            var passwordArg = parseResult.GetValue(passwordOption);
+
             string password;
             if (!string.IsNullOrEmpty(passwordArg))
             {
@@ -66,7 +78,7 @@ public static class CredentialCommand
                 Console.Error.WriteLine($"Failed to save credential for {server}");
                 Environment.ExitCode = 1;
             }
-        }, serverArg, userOption, passwordOption);
+        });
 
         return cmd;
     }
@@ -75,7 +87,7 @@ public static class CredentialCommand
     {
         var cmd = new Command("list", "List stored credentials");
 
-        cmd.SetHandler(() =>
+        cmd.SetAction(_ =>
         {
             IReadOnlyList<(string ServerName, string Username)>? creds = null;
             // CA1416: WindowsCredentialService is gated on OperatingSystem.IsWindows().
@@ -110,15 +122,19 @@ public static class CredentialCommand
 
     private static Command CreateRemoveCommand(ICredentialService credentialService)
     {
-        var serverArg = new Argument<string>("server-name", "Server name to remove credentials for");
+        var serverArg = new Argument<string>("server-name")
+        {
+            Description = "Server name to remove credentials for"
+        };
 
         var cmd = new Command("remove", "Remove stored credentials for a server")
         {
             serverArg
         };
 
-        cmd.SetHandler((string server) =>
+        cmd.SetAction(parseResult =>
         {
+            var server = parseResult.GetValue(serverArg)!;
             if (credentialService.CredentialExists(server))
             {
                 credentialService.DeleteCredential(server);
@@ -129,7 +145,7 @@ public static class CredentialCommand
                 Console.Error.WriteLine($"No credential found for {server}");
                 Environment.ExitCode = 1;
             }
-        }, serverArg);
+        });
 
         return cmd;
     }

--- a/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
+++ b/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
@@ -25,73 +25,111 @@ public static class QueryStoreCommand
 
     public static Command Create(ICredentialService? credentialService = null)
     {
-        var serverOption = new Option<string>(
-            "--server", "SQL Server instance name") { IsRequired = true };
-        serverOption.AddAlias("-s");
+        var serverOption = new Option<string>("--server", "-s")
+        {
+            Description = "SQL Server instance name",
+            Required = true
+        };
 
-        var databaseOption = new Option<string>(
-            "--database", "Database with Query Store enabled") { IsRequired = true };
-        databaseOption.AddAlias("-d");
+        var databaseOption = new Option<string>("--database", "-d")
+        {
+            Description = "Database with Query Store enabled",
+            Required = true
+        };
 
-        var topOption = new Option<int>(
-            "--top", getDefaultValue: () => 25,
-            description: "Number of top queries to analyze");
+        var topOption = new Option<int>("--top")
+        {
+            Description = "Number of top queries to analyze",
+            DefaultValueFactory = _ => 25
+        };
 
-        var orderByOption = new Option<string>(
-            "--order-by", getDefaultValue: () => "cpu",
-            description: "Ranking metric (total or avg): cpu, avg-cpu, duration, avg-duration, reads, avg-reads, writes, avg-writes, physical-reads, avg-physical-reads, memory, avg-memory, executions");
+        var orderByOption = new Option<string>("--order-by")
+        {
+            Description = "Ranking metric (total or avg): cpu, avg-cpu, duration, avg-duration, reads, avg-reads, writes, avg-writes, physical-reads, avg-physical-reads, memory, avg-memory, executions",
+            DefaultValueFactory = _ => "cpu"
+        };
 
-        var hoursBackOption = new Option<int>(
-            "--hours-back", getDefaultValue: () => 24,
-            description: "Hours of history to analyze");
+        var hoursBackOption = new Option<int>("--hours-back")
+        {
+            Description = "Hours of history to analyze",
+            DefaultValueFactory = _ => 24
+        };
 
-        var outputDirOption = new Option<DirectoryInfo?>(
-            "--output-dir", "Directory for output files (default: current directory)");
+        var outputDirOption = new Option<DirectoryInfo?>("--output-dir")
+        {
+            Description = "Directory for output files (default: current directory)"
+        };
 
-        var outputOption = new Option<string>(
-            "--output", getDefaultValue: () => "text",
-            description: "Output format: json or text");
-        outputOption.AddAlias("-o");
+        var outputOption = new Option<string>("--output", "-o")
+        {
+            Description = "Output format: json or text",
+            DefaultValueFactory = _ => "text"
+        };
 
-        var compactOption = new Option<bool>(
-            "--compact", "Compact JSON output");
+        var compactOption = new Option<bool>("--compact")
+        {
+            Description = "Compact JSON output"
+        };
 
-        var warningsOnlyOption = new Option<bool>(
-            "--warnings-only", "Skip operator tree in output");
+        var warningsOnlyOption = new Option<bool>("--warnings-only")
+        {
+            Description = "Skip operator tree in output"
+        };
 
-        var configOption = new Option<string?>(
-            "--config", "Path to .planview.json config file");
+        var configOption = new Option<string?>("--config")
+        {
+            Description = "Path to .planview.json config file"
+        };
 
-        var authOption = new Option<string?>(
-            "--auth", "Authentication: windows, sql, entra");
+        var authOption = new Option<string?>("--auth")
+        {
+            Description = "Authentication: windows, sql, entra"
+        };
 
-        var trustCertOption = new Option<bool>(
-            "--trust-cert", "Trust the server certificate");
+        var trustCertOption = new Option<bool>("--trust-cert")
+        {
+            Description = "Trust the server certificate"
+        };
 
-        var loginOption = new Option<string?>(
-            "--login", "SQL Server login (bypasses credential store)");
+        var loginOption = new Option<string?>("--login")
+        {
+            Description = "SQL Server login (bypasses credential store)"
+        };
 
-        var passwordOption = new Option<string?>(
-            "--password", "SQL Server password. Visible in process listings — prefer --password-stdin.");
+        var passwordOption = new Option<string?>("--password")
+        {
+            Description = "SQL Server password. Visible in process listings — prefer --password-stdin."
+        };
 
-        var passwordStdinOption = new Option<bool>(
-            "--password-stdin",
-            "Read the SQL Server password from stdin (avoids process-listing exposure). Mutually exclusive with --password.");
+        var passwordStdinOption = new Option<bool>("--password-stdin")
+        {
+            Description = "Read the SQL Server password from stdin (avoids process-listing exposure). Mutually exclusive with --password."
+        };
 
-        var queryIdOption = new Option<long?>(
-            "--query-id", "Filter by Query Store query ID");
+        var queryIdOption = new Option<long?>("--query-id")
+        {
+            Description = "Filter by Query Store query ID"
+        };
 
-        var planIdOption = new Option<long?>(
-            "--plan-id", "Filter by Query Store plan ID");
+        var planIdOption = new Option<long?>("--plan-id")
+        {
+            Description = "Filter by Query Store plan ID"
+        };
 
-        var queryHashOption = new Option<string?>(
-            "--query-hash", "Filter by query hash (hex, e.g. 0x1AB2C3D4)");
+        var queryHashOption = new Option<string?>("--query-hash")
+        {
+            Description = "Filter by query hash (hex, e.g. 0x1AB2C3D4)"
+        };
 
-        var planHashOption = new Option<string?>(
-            "--plan-hash", "Filter by query plan hash (hex, e.g. 0x1AB2C3D4)");
+        var planHashOption = new Option<string?>("--plan-hash")
+        {
+            Description = "Filter by query plan hash (hex, e.g. 0x1AB2C3D4)"
+        };
 
-        var moduleOption = new Option<string?>(
-            "--module", "Filter by module name (schema.name, supports % wildcards)");
+        var moduleOption = new Option<string?>("--module")
+        {
+            Description = "Filter by module name (schema.name, supports % wildcards)"
+        };
 
         var cmd = new Command("query-store", "Analyze top queries from Query Store")
         {
@@ -101,28 +139,28 @@ public static class QueryStoreCommand
             queryIdOption, planIdOption, queryHashOption, planHashOption, moduleOption
         };
 
-        cmd.SetHandler(async (ctx) =>
+        cmd.SetAction(async (parseResult, ct) =>
         {
-            var server = ctx.ParseResult.GetValueForOption(serverOption)!;
-            var database = ctx.ParseResult.GetValueForOption(databaseOption)!;
-            var top = ctx.ParseResult.GetValueForOption(topOption);
-            var orderBy = ctx.ParseResult.GetValueForOption(orderByOption) ?? "cpu";
-            var hoursBack = ctx.ParseResult.GetValueForOption(hoursBackOption);
-            var outputDir = ctx.ParseResult.GetValueForOption(outputDirOption);
-            var output = ctx.ParseResult.GetValueForOption(outputOption) ?? "text";
-            var compact = ctx.ParseResult.GetValueForOption(compactOption);
-            var warningsOnly = ctx.ParseResult.GetValueForOption(warningsOnlyOption);
-            var configPath = ctx.ParseResult.GetValueForOption(configOption);
-            var auth = ctx.ParseResult.GetValueForOption(authOption);
-            var trustCert = ctx.ParseResult.GetValueForOption(trustCertOption);
-            var login = ctx.ParseResult.GetValueForOption(loginOption);
-            var passwordInline = ctx.ParseResult.GetValueForOption(passwordOption);
-            var passwordStdin = ctx.ParseResult.GetValueForOption(passwordStdinOption);
-            var filterQueryId = ctx.ParseResult.GetValueForOption(queryIdOption);
-            var filterPlanId = ctx.ParseResult.GetValueForOption(planIdOption);
-            var filterQueryHash = ctx.ParseResult.GetValueForOption(queryHashOption);
-            var filterPlanHash = ctx.ParseResult.GetValueForOption(planHashOption);
-            var filterModule = ctx.ParseResult.GetValueForOption(moduleOption);
+            var server = parseResult.GetValue(serverOption)!;
+            var database = parseResult.GetValue(databaseOption)!;
+            var top = parseResult.GetValue(topOption);
+            var orderBy = parseResult.GetValue(orderByOption) ?? "cpu";
+            var hoursBack = parseResult.GetValue(hoursBackOption);
+            var outputDir = parseResult.GetValue(outputDirOption);
+            var output = parseResult.GetValue(outputOption) ?? "text";
+            var compact = parseResult.GetValue(compactOption);
+            var warningsOnly = parseResult.GetValue(warningsOnlyOption);
+            var configPath = parseResult.GetValue(configOption);
+            var auth = parseResult.GetValue(authOption);
+            var trustCert = parseResult.GetValue(trustCertOption);
+            var login = parseResult.GetValue(loginOption);
+            var passwordInline = parseResult.GetValue(passwordOption);
+            var passwordStdin = parseResult.GetValue(passwordStdinOption);
+            var filterQueryId = parseResult.GetValue(queryIdOption);
+            var filterPlanId = parseResult.GetValue(planIdOption);
+            var filterQueryHash = parseResult.GetValue(queryHashOption);
+            var filterPlanHash = parseResult.GetValue(planHashOption);
+            var filterModule = parseResult.GetValue(moduleOption);
 
             // Load .env file if present (CLI args take precedence)
             var env = ConnectionHelper.LoadEnvFile();

--- a/src/PlanViewer.Cli/PlanViewer.Cli.csproj
+++ b/src/PlanViewer.Cli/PlanViewer.Cli.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/PlanViewer.Cli/Program.cs
+++ b/src/PlanViewer.Cli/Program.cs
@@ -26,5 +26,5 @@ if (credentialService != null)
 // System.CommandLine's InvokeAsync returns 0 for successful dispatch even when a
 // handler set Environment.ExitCode = 1 to signal a validation error. Honor either
 // signal so scripts can tell success from failure.
-var code = await root.InvokeAsync(args);
+var code = await root.Parse(args).InvokeAsync();
 return code != 0 ? code : Environment.ExitCode;


### PR DESCRIPTION
## Summary
Mechanical API rename pass on the CLI. The library was effectively rewritten between beta4 (2022) and GA, but the CLI doesn't use any of the deeper-impact features (no `Parser`/`CommandLineBuilder`, no `IConsole`, no middleware, no validators, no completions, no hosting integration), so the migration is just find-and-replace.

Pattern changes:
- `new Option<T>(name, description)` → `new Option<T>(name, ...aliases) { Description = ..., DefaultValueFactory = _ => v, Required = true }`
- `AddAlias("-x")` → constructor params or `Aliases.Add("-x")`
- `IsRequired` → `Required`
- `AddCommand(c)` → `Subcommands.Add(c)`
- `SetHandler(async ctx => ...)` / `SetHandler(binder, opts...)` → `SetAction(parseResult => ...)` / `SetAction(async (parseResult, ct) => ...)`
- `ctx.ParseResult.GetValueForOption/Argument(x)` → `parseResult.GetValue(x)`
- `root.InvokeAsync(args)` → `root.Parse(args).InvokeAsync()`

## Test plan
- [x] `dotnet build` — 0 errors, 0 source warnings
- [x] `dotnet test` — 71/71 passing
- [x] `planview --help`, `planview analyze --help`, `planview credential --help` — all render with correct descriptions, defaults, and aliases
- [x] `planview analyze <plan.sqlplan> --warnings-only` — emits the expected JSON
- [ ] Smoke: `planview analyze --server X --database Y --query "..."` against a real server
- [ ] Smoke: `planview query-store --server X --database Y --top 5`
- [ ] Smoke: `planview credential add/list/remove`

🤖 Generated with [Claude Code](https://claude.com/claude-code)