### PR TITLE
Drop redundant using in CLI command files

### DIFF
--- a/src/PlanViewer.Cli/Commands/AnalyzeCommand.cs
+++ b/src/PlanViewer.Cli/Commands/AnalyzeCommand.cs
@@ -9,8 +9,6 @@ using PlanViewer.Core.Services;
 
 namespace PlanViewer.Cli.Commands;
 
-using PlanViewer.Cli;
-
 public static class AnalyzeCommand
 {
     private static readonly JsonSerializerOptions JsonOptions = new()

--- a/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
+++ b/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
@@ -8,8 +8,6 @@ using PlanViewer.Core.Services;
 
 namespace PlanViewer.Cli.Commands;
 
-using PlanViewer.Cli;
-
 public static class QueryStoreCommand
 {
     private static readonly JsonSerializerOptions JsonOptions = new()


### PR DESCRIPTION
Tiny cleanup: 'using PlanViewer.Cli;' inside the namespace block in AnalyzeCommand and QueryStoreCommand is redundant (child namespaces have implicit parent access) and oddly placed after the namespace declaration. Two-line removal.