### PR TITLE
Restore 4-space indentation in MainWindow.axaml.cs

### DIFF
--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -1299,10 +1299,10 @@ public partial class MainWindow : Window
                 }
             }
         };
-		dialog.ShowDialog(this);
-	}
+        dialog.ShowDialog(this);
+    }
 
-	private async Task CheckForUpdatesOnStartupAsync()
+    private async Task CheckForUpdatesOnStartupAsync()
     {
         try
         {


### PR DESCRIPTION
Cleanup follow-up to #276. Three lines around ShowError got left with tab indentation instead of the surrounding 4-space style; restoring.