### PR TITLE
Format Options dialog: PascalCase split + suppress spurious dirty state

### DIFF
--- a/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml.cs
+++ b/src/PlanViewer.App/Dialogs/FormatOptionsWindow.axaml.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
@@ -44,6 +45,19 @@ public partial class FormatOptionsWindow : Window
         "NewLineBeforeWhereClause", "NewLineBeforeWindowClause",
     ];
 
+    private static string SplitPascalCase(string name)
+    {
+        var sb = new StringBuilder(name.Length + 8);
+        for (int i = 0; i < name.Length; i++)
+        {
+            var c = name[i];
+            if (i > 0 && char.IsUpper(c) && !char.IsUpper(name[i - 1]))
+                sb.Append(' ');
+            sb.Append(c);
+        }
+        return sb.ToString();
+    }
+
     private static readonly Dictionary<string, string[]> ChoiceOptionsMap = new()
     {
         ["KeywordCasing"] = ["Uppercase", "Lowercase", "PascalCase"],
@@ -73,7 +87,7 @@ public partial class FormatOptionsWindow : Window
 
             _rows.Add(new FormatOptionRow
             {
-                Name = prop.Name,
+                Name = SplitPascalCase(prop.Name),
                 CurrentValue = currentVal?.ToString() ?? "",
                 DefaultValue = defaultVal?.ToString() ?? "",
                 IsBool = isBool,
@@ -289,6 +303,7 @@ public class FormatOptionRow : INotifyPropertyChanged
         get => _boolValue;
         set
         {
+            if (_boolValue == value) return;
             _boolValue = value;
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(BoolValue)));
             // Keep CurrentValue in sync for serialization
@@ -313,6 +328,7 @@ public class FormatOptionRow : INotifyPropertyChanged
         get => _currentValue;
         set
         {
+            if (_currentValue == value) return;
             _currentValue = value;
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CurrentValue)));
         }


### PR DESCRIPTION
## Summary
- The Parameter column showed raw PascalCase property names (e.g. `MultilineInsertSourcesList`); now space-split (`Multiline Insert Sources List`).
- Closing the dialog without changes always prompted "unsaved changes" because TwoWay binding writes during DataGrid row virtualization fired `PropertyChanged` even for unchanged values. Setters now check equality first.

## Test plan
- [x] Open Format Options, verify column reads with spaces between words
- [x] Open Format Options, immediately Close — dialog closes without prompt
- [x] Toggle a setting, Close — prompt appears as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)