### PR TITLE
Fix #286: Query Store query_id filter excludes target before applying

### DIFF
--- a/src/PlanViewer.Core/Services/QueryStoreService.cs
+++ b/src/PlanViewer.Core/Services/QueryStoreService.cs
@@ -86,23 +86,29 @@ FROM sys.database_query_store_options;";
         };
 
         // Build optional WHERE clauses from filter (parameterized for safety).
+        // Filters are applied in Phase 3 (BEFORE TOP N) so the user's target
+        // query isn't excluded just because it's not in the top N by CPU.
+        // Aliases here reference Phase 3's CTE: ps (#plan_stats),
+        // p (sys.query_store_plan), q (sys.query_store_query).
         var filterClauses = new List<string>();
         var parameters = new List<SqlParameter>();
+        var needsQueryJoin = false;
 
         if (filter?.QueryId != null)
         {
-            filterClauses.Add("AND q.query_id = @filterQueryId");
+            filterClauses.Add("AND p.query_id = @filterQueryId");
             parameters.Add(new SqlParameter("@filterQueryId", filter.QueryId.Value));
         }
         if (filter?.PlanId != null)
         {
-            filterClauses.Add("AND tp.plan_id = @filterPlanId");
+            filterClauses.Add("AND ps.plan_id = @filterPlanId");
             parameters.Add(new SqlParameter("@filterPlanId", filter.PlanId.Value));
         }
         if (!string.IsNullOrWhiteSpace(filter?.QueryHash))
         {
             filterClauses.Add("AND q.query_hash = CONVERT(binary(8), @filterQueryHash, 1)");
             parameters.Add(new SqlParameter("@filterQueryHash", filter.QueryHash.Trim()));
+            needsQueryJoin = true;
         }
         if (!string.IsNullOrWhiteSpace(filter?.QueryPlanHash))
         {
@@ -122,11 +128,15 @@ FROM sys.database_query_store_options;";
                 filterClauses.Add("AND OBJECT_SCHEMA_NAME(q.object_id) + N'.' + OBJECT_NAME(q.object_id) = @filterModule");
             }
             parameters.Add(new SqlParameter("@filterModule", moduleVal));
+            needsQueryJoin = true;
         }
 
         var rnClause = filter?.PlanId != null ? "" : "AND r.rn = 1";
         var filterSql = filterClauses.Count > 0
-            ? "\n" + string.Join("\n", filterClauses)
+            ? "\n        " + string.Join("\n        ", filterClauses)
+            : "";
+        var phase3QueryJoin = needsQueryJoin
+            ? "    JOIN sys.query_store_query AS q ON p.query_id = q.query_id\n"
             : "";
 
         // Time-range filter: always filter on interval start_time (indexed).
@@ -241,6 +251,7 @@ WITH ranked AS (
         ROW_NUMBER() OVER (PARTITION BY p.query_id ORDER BY {orderClause} DESC) AS rn
     FROM #plan_stats AS ps
     JOIN sys.query_store_plan AS p ON ps.plan_id = p.plan_id
+{phase3QueryJoin}    WHERE 1 = 1{filterSql}
 )
 SELECT TOP ({topN})
     r.query_id,
@@ -295,7 +306,6 @@ FROM #top_plans AS tp
 JOIN sys.query_store_plan AS p ON tp.plan_id = p.plan_id
 JOIN sys.query_store_query AS q ON p.query_id = q.query_id
 JOIN sys.query_store_query_text AS qt ON q.query_text_id = qt.query_text_id
-WHERE 1 = 1{filterSql}
 ORDER BY {outerOrder} DESC;";
 
         var plans = new List<QueryStorePlan>();


### PR DESCRIPTION
Closes #286.

## Root cause
`FetchTopPlansAsync` applies user filters (`--query-id`, `--plan-id`, `--query-hash`, `--query-plan-hash`, `--module`) only in Phase 4, AFTER Phase 3 has already selected TOP N plans by CPU across the entire database. When the user's target query isn't in the top N by CPU for the window, it gets cut from `#top_plans` *before* the filter runs — and the result set comes back empty even though Query Store / SSMS / `sp_QuickieStore` can see the query fine.

## Fix
Push the filter into Phase 3's CTE so TOP N is selected from the filtered universe. Conditionally JOIN `sys.query_store_query` only when the filter touches `query_hash` or `object_id` — the unfiltered code path is unchanged and pays no extra cost.

The hash-tree and module-tree fetch methods already applied filters pre-TOP-N correctly; they were not touched.

## Test plan
- [x] Build clean
- [x] 75/75 tests passing
- [ ] Repro on a server: pick a low-CPU query, verify `--query-id` finds it
- [ ] Spot-check unfiltered top-25 path looks unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)