### PR TITLE
Features/colored links

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -3698,10 +3698,13 @@ public partial class PlanViewerControl : UserControl
             figure.Segments.Add(new LineSegment { Point = new Point(childLeft, childCenterY) });
             geometry.Figures!.Add(figure);
 
+            var settings = AppSettingsService.Load();
+            var linkBrush = GetLinkColorBrush(child, settings.AccuracyRatioDivergenceLimit);
+
             var path = new AvaloniaPath
             {
                 Data = geometry,
-                Stroke = EdgeBrush,
+                Stroke = linkBrush,
                 StrokeThickness = thickness,
                 StrokeJoin = PenLineJoin.Round
             };

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -403,7 +403,8 @@ public partial class PlanViewerControl : UserControl
         PlanCanvas.Height = height;
 
         // Render edges first (behind nodes)
-        RenderEdges(statement.RootNode);
+        var divergenceLimit = Math.Max(2.0, AppSettingsService.Load().AccuracyRatioDivergenceLimit);
+        RenderEdges(statement.RootNode, divergenceLimit);
 
         // Render nodes — pass total warning count to root node for badge
         var allWarnings = new List<PlanWarning>();
@@ -656,10 +657,11 @@ public partial class PlanViewerControl : UserControl
                 HorizontalAlignment = HorizontalAlignment.Center
             });
 
-            // Actual rows of Estimated rows (accuracy %) -- red if off by 10x+
+            // Actual rows of Estimated rows (accuracy %) -- red if off by divergence limit
             var estRows = node.EstimateRows;
             var accuracyRatio = estRows > 0 ? node.ActualRows / estRows : (node.ActualRows > 0 ? double.MaxValue : 1.0);
-            IBrush rowBrush = (accuracyRatio < 0.1 || accuracyRatio > 10.0) ? OrangeRedBrush : fgBrush;
+            var nodeDivLimit = Math.Max(2.0, AppSettingsService.Load().AccuracyRatioDivergenceLimit);
+            IBrush rowBrush = (accuracyRatio < 1.0 / nodeDivLimit || accuracyRatio > nodeDivLimit) ? OrangeRedBrush : fgBrush;
             var accuracy = estRows > 0
                 ? $" ({accuracyRatio * 100:F0}%)"
                 : "";
@@ -727,14 +729,14 @@ public partial class PlanViewerControl : UserControl
 
     #region Edge Rendering
 
-    private void RenderEdges(PlanNode node)
+    private void RenderEdges(PlanNode node, double divergenceLimit)
     {
         foreach (var child in node.Children)
         {
-            var path = CreateElbowConnector(node, child);
+            var path = CreateElbowConnector(node, child, divergenceLimit);
             PlanCanvas.Children.Add(path);
 
-            RenderEdges(child);
+            RenderEdges(child, divergenceLimit);
         }
     }
 
@@ -747,6 +749,7 @@ public partial class PlanViewerControl : UserControl
         if (!child.HasActualStats)
             return EdgeBrush;
 
+        divergenceLimit = Math.Max(2.0, divergenceLimit);
         var estRows = child.EstimateRows;
         var accuracyRatio = estRows > 0
             ? child.ActualRows / estRows
@@ -774,7 +777,7 @@ public partial class PlanViewerControl : UserControl
         return LinkBlueBrush;
     }
 
-    private AvaloniaPath CreateElbowConnector(PlanNode parent, PlanNode child)
+    private AvaloniaPath CreateElbowConnector(PlanNode parent, PlanNode child, double divergenceLimit)
     {
         var parentRight = parent.X + PlanLayoutEngine.NodeWidth;
         var parentCenterY = parent.Y + PlanLayoutEngine.GetNodeHeight(parent) / 2;
@@ -798,8 +801,7 @@ public partial class PlanViewerControl : UserControl
         figure.Segments.Add(new LineSegment { Point = new Point(childLeft, childCenterY) });
         geometry.Figures!.Add(figure);
 
-        var settings = AppSettingsService.Load();
-        var linkBrush = GetLinkColorBrush(child, settings.AccuracyRatioDivergenceLimit);
+        var linkBrush = GetLinkColorBrush(child, divergenceLimit);
 
         var path = new AvaloniaPath
         {
@@ -3612,7 +3614,8 @@ public partial class PlanViewerControl : UserControl
         RenderMinimapBranches(_currentStatement.RootNode, scale);
 
         // Render edges
-        RenderMinimapEdges(_currentStatement.RootNode, scale);
+        var minimapDivergenceLimit = Math.Max(2.0, AppSettingsService.Load().AccuracyRatioDivergenceLimit);
+        RenderMinimapEdges(_currentStatement.RootNode, scale, minimapDivergenceLimit);
 
         // Render nodes
         RenderMinimapNodes(_currentStatement.RootNode, scale);
@@ -3676,7 +3679,7 @@ public partial class PlanViewerControl : UserControl
             CollectSubtreeBounds(child, ref minX, ref minY, ref maxX, ref maxY);
     }
 
-    private void RenderMinimapEdges(PlanNode node, double scale)
+    private void RenderMinimapEdges(PlanNode node, double scale, double divergenceLimit)
     {
         foreach (var child in node.Children)
         {
@@ -3698,8 +3701,7 @@ public partial class PlanViewerControl : UserControl
             figure.Segments.Add(new LineSegment { Point = new Point(childLeft, childCenterY) });
             geometry.Figures!.Add(figure);
 
-            var settings = AppSettingsService.Load();
-            var linkBrush = GetLinkColorBrush(child, settings.AccuracyRatioDivergenceLimit);
+            var linkBrush = GetLinkColorBrush(child, divergenceLimit);
 
             var path = new AvaloniaPath
             {
@@ -3710,7 +3712,7 @@ public partial class PlanViewerControl : UserControl
             };
             MinimapCanvas.Children.Add(path);
 
-            RenderMinimapEdges(child, scale);
+            RenderMinimapEdges(child, scale, divergenceLimit);
         }
     }
 

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -409,7 +409,7 @@ public partial class PlanViewerControl : UserControl
         // Render nodes — pass total warning count to root node for badge
         var allWarnings = new List<PlanWarning>();
         CollectWarnings(statement.RootNode, allWarnings);
-        RenderNodes(statement.RootNode, allWarnings.Count);
+        RenderNodes(statement.RootNode, divergenceLimit, allWarnings.Count);
 
         // Update banners
         ShowMissingIndexes(statement.MissingIndexes);
@@ -434,18 +434,18 @@ public partial class PlanViewerControl : UserControl
 
     #region Node Rendering
 
-    private void RenderNodes(PlanNode node, int totalWarningCount = -1)
+    private void RenderNodes(PlanNode node, double divergenceLimit, int totalWarningCount = -1)
     {
-        var visual = CreateNodeVisual(node, totalWarningCount);
+        var visual = CreateNodeVisual(node, divergenceLimit, totalWarningCount);
         Canvas.SetLeft(visual, node.X);
         Canvas.SetTop(visual, node.Y);
         PlanCanvas.Children.Add(visual);
 
         foreach (var child in node.Children)
-            RenderNodes(child);
+            RenderNodes(child, divergenceLimit);
     }
 
-    private Border CreateNodeVisual(PlanNode node, int totalWarningCount = -1)
+    private Border CreateNodeVisual(PlanNode node, double divergenceLimit, int totalWarningCount = -1)
     {
         var isExpensive = node.IsExpensive;
 
@@ -660,8 +660,7 @@ public partial class PlanViewerControl : UserControl
             // Actual rows of Estimated rows (accuracy %) -- red if off by divergence limit
             var estRows = node.EstimateRows;
             var accuracyRatio = estRows > 0 ? node.ActualRows / estRows : (node.ActualRows > 0 ? double.MaxValue : 1.0);
-            var nodeDivLimit = Math.Max(2.0, AppSettingsService.Load().AccuracyRatioDivergenceLimit);
-            IBrush rowBrush = (accuracyRatio < 1.0 / nodeDivLimit || accuracyRatio > nodeDivLimit) ? OrangeRedBrush : fgBrush;
+            IBrush rowBrush = (accuracyRatio < 1.0 / divergenceLimit || accuracyRatio > divergenceLimit) ? OrangeRedBrush : fgBrush;
             var accuracy = estRows > 0
                 ? $" ({accuracyRatio * 100:F0}%)"
                 : "";

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -93,6 +93,14 @@ public partial class PlanViewerControl : UserControl
     private static readonly SolidColorBrush OrangeBrush = new(Colors.Orange);
     private static readonly SolidColorBrush MinimapExpensiveNodeBgBrush = new(Color.FromArgb(0x60, 0xE5, 0x73, 0x73));
 
+    // Link accuracy coloring brushes (Dark theme)
+    private static readonly SolidColorBrush LinkFluoBlueBrush = new(Color.FromRgb(0x00, 0xE5, 0xFF));
+    private static readonly SolidColorBrush LinkLightBlueBrush = new(Color.FromRgb(0x64, 0xB5, 0xF6));
+    private static readonly SolidColorBrush LinkBlueBrush = new(Color.FromRgb(0x42, 0x8B, 0xCA));
+    private static readonly SolidColorBrush LinkLightOrangeBrush = new(Color.FromRgb(0xFF, 0xB7, 0x4D));
+    private static readonly SolidColorBrush LinkFluoOrangeBrush = new(Color.FromRgb(0xFF, 0x8C, 0x00));
+    private static readonly SolidColorBrush LinkFluoRedBrush = new(Color.FromRgb(0xFF, 0x17, 0x44));
+
 
     // Track all property section grids for synchronized column resize
     private readonly List<ColumnDefinition> _sectionLabelColumns = new();
@@ -730,6 +738,42 @@ public partial class PlanViewerControl : UserControl
         }
     }
 
+    /// <summary>
+    /// Returns a color brush for a link based on the accuracy ratio of the child node.
+    /// Only applies to actual plans; estimated plans use the default edge brush.
+    /// </summary>
+    private static IBrush GetLinkColorBrush(PlanNode child, double divergenceLimit)
+    {
+        if (!child.HasActualStats)
+            return EdgeBrush;
+
+        var estRows = child.EstimateRows;
+        var accuracyRatio = estRows > 0
+            ? child.ActualRows / estRows
+            : (child.ActualRows > 0 ? double.MaxValue : 1.0);
+
+        // Within the neutral band — keep default color
+        if (accuracyRatio >= 1.0 / divergenceLimit && accuracyRatio <= divergenceLimit)
+            return EdgeBrush;
+
+        // Underestimated bands (accuracyRatio > 1 means more actual rows than estimated)
+        if (accuracyRatio > divergenceLimit)
+        {
+            if (accuracyRatio >= divergenceLimit * 100)
+                return LinkFluoRedBrush;
+            if (accuracyRatio >= divergenceLimit * 10)
+                return LinkFluoOrangeBrush;
+            return LinkLightOrangeBrush;
+        }
+
+        // Overestimated bands (accuracyRatio < 1 means fewer actual rows than estimated)
+        if (accuracyRatio < 1.0 / (divergenceLimit * 100))
+            return LinkFluoBlueBrush;
+        if (accuracyRatio < 1.0 / (divergenceLimit * 10))
+            return LinkLightBlueBrush;
+        return LinkBlueBrush;
+    }
+
     private AvaloniaPath CreateElbowConnector(PlanNode parent, PlanNode child)
     {
         var parentRight = parent.X + PlanLayoutEngine.NodeWidth;
@@ -754,10 +798,13 @@ public partial class PlanViewerControl : UserControl
         figure.Segments.Add(new LineSegment { Point = new Point(childLeft, childCenterY) });
         geometry.Figures!.Add(figure);
 
+        var settings = AppSettingsService.Load();
+        var linkBrush = GetLinkColorBrush(child, settings.AccuracyRatioDivergenceLimit);
+
         var path = new AvaloniaPath
         {
             Data = geometry,
-            Stroke = EdgeBrush,
+            Stroke = linkBrush,
             StrokeThickness = thickness,
             StrokeJoin = PenLineJoin.Round
         };

--- a/src/PlanViewer.App/Services/AppSettingsService.cs
+++ b/src/PlanViewer.App/Services/AppSettingsService.cs
@@ -119,4 +119,11 @@ internal sealed class AppSettings
     /// </summary>
     [JsonPropertyName("query_store_slicer_days")]
     public int QueryStoreSlicerDays { get; set; } = 30;
+
+    /// <summary>
+    /// Divergence limit for accuracy ratio coloring on plan links. Default 10.
+    /// Links with accuracy ratio between 1/limit and limit keep the default edge color.
+    /// </summary>
+    [JsonPropertyName("accuracy_ratio_divergence_limit")]
+    public double AccuracyRatioDivergenceLimit { get; set; } = 10;
 }


### PR DESCRIPTION
## What does this PR do?

## Accuracy-ratio colored links for plan viewer

<img width="1919" height="1149" alt="image" src="https://github.com/user-attachments/assets/1ba0eef9-9fef-4715-b2ba-19405dec6786" />


### Summary

Adds visual feedback on plan viewer links (edges) by coloring them according to the divergence between actual and estimated row counts. This helps immediately spot cardinality estimation issues in actual execution plans.

### How it works

A new setting `accuracy_ratio_divergence_limit` (default: **10**) defines the neutral band. Links where the accuracy ratio (`ActualRows / EstimateRows`) falls between `1/limit` and `limit` keep the standard theme color. Outside that band, links are colored across 6 severity levels:

| Accuracy ratio range | Meaning | Color |
|---|---|---|
| `[0, 1/(limit×100))` | Severe overestimation | Fluo Blue |
| `[1/(limit×100), 1/(limit×10))` | Moderate overestimation | Light Blue |
| `[1/(limit×10), 1/limit)` | Mild overestimation | Blue |
| `[1/limit, limit]` | Within tolerance | Default (grey) |
| `(limit, limit×10)` | Mild underestimation | Light Orange |
| `[limit×10, limit×100)` | Moderate underestimation | Fluo Orange |
| `[limit×100, +∞)` | Severe underestimation | Fluo Red |

*"Overestimation" = optimizer estimated more rows than actually produced; "Underestimation" = the opposite.*

The coloring only activates on **actual** execution plans (where `HasActualStats` is true). Estimated plans are unaffected.

### Changes

**`AppSettingsService.cs`**
- Added `AccuracyRatioDivergenceLimit` property to `AppSettings` (persisted as `accuracy_ratio_divergence_limit`, default `10`).

**`PlanViewerControl.axaml.cs`**
- Added 6 new `SolidColorBrush` fields for link accuracy coloring (dark theme).
- Added `GetLinkColorBrush(PlanNode, double)` — maps a child node's accuracy ratio to the appropriate color band.
- `RenderEdges` / `CreateElbowConnector` — links now use accuracy-based coloring instead of the static `EdgeBrush`.
- `RenderMinimapEdges` — minimap links use the same accuracy-based coloring.
- Node-level row accuracy highlighting now uses the same `AccuracyRatioDivergenceLimit` setting instead of hardcoded `10`/`0.1` thresholds.
- Settings are loaded once per render pass (not per edge) and the divergence limit is clamped to `≥ 2.0` to prevent degenerate band boundaries.

### Not in scope

- Blazor/WebAssembly (`Index.razor`) connector coloring — the web project still uses a static CSS class for links. This can be addressed in a follow-up.
- Light theme link colors — only dark theme brushes are defined for now.
- UI for editing the `accuracy_ratio_divergence_limit` setting (currently requires manual edit of `appsettings.json`).

### Testing

- Verified on actual execution plans with known cardinality skew: links correctly transition through the 6 color bands.
- Estimated plans render with unchanged default edge color.
- Build passes with no errors or warnings.

## Which component(s) does this affect?

- [x] Desktop App (PlanViewer.App)
- [ ] Core Library (PlanViewer.Core)
- [ ] CLI Tool (PlanViewer.Cli)
- [ ] SSMS Extension (PlanViewer.Ssms)
- [ ] Tests
- [ ] Documentation

## How was this tested?

<img width="1516" height="878" alt="2026-04-26_18h50_57" src="https://github.com/user-attachments/assets/cdec912f-5587-4054-bde8-1e751d280fbf" />

Describe the testing you've done. Include:
- Plan files tested (estimated, actual, Query Store, etc.) : actual.  estimated not impacted (tested)
- Platforms tested (Windows, macOS, Linux) : windows only

## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceStudio/blob/main/CONTRIBUTING.md)
- [x] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] All tests pass (`dotnet test`)
- [x] I have not introduced any hardcoded credentials or server names
