### PR TITLE
Bump version to 1.9.0

### DIFF
--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -6,7 +6,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>EDD.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>1.8.0</Version>
+    <Version>1.9.0</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>


### PR DESCRIPTION
## Summary
Bumps `<Version>` in PlanViewer.App.csproj from 1.8.0 to 1.9.0 in preparation for the release in #292.

Required by the `check-version` CI gate before dev can be merged to main.

## Test plan
- [ ] CI green
- [ ] Merge into dev so #292 (dev -> main release) can pass `check-version`