### PR TITLE
Revert insight card style refactor (#294)

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml
@@ -2,22 +2,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="PlanViewer.App.Controls.PlanViewerControl"
              Background="{DynamicResource BackgroundBrush}">
-    <UserControl.Styles>
-        <Style Selector="Border.InsightCard">
-            <Setter Property="Background" Value="{DynamicResource InsightCardBackgroundBrush}"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource InsightCardBorderBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="CornerRadius" Value="8"/>
-            <Setter Property="BoxShadow" Value="0 4 12 0 #60000000"/>
-            <Setter Property="Padding" Value="12,8,12,10"/>
-            <Setter Property="Margin" Value="0,0,8,0"/>
-        </Style>
-        <Style Selector="TextBlock.InsightHeader">
-            <Setter Property="FontSize" Value="14"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Margin" Value="0,0,0,8"/>
-        </Style>
-    </UserControl.Styles>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -90,7 +74,7 @@
                                FontWeight="SemiBold"
                                Foreground="{DynamicResource ForegroundBrush}"/>
                 </Expander.Header>
-                <Grid MaxHeight="240" Margin="8,4,8,8" HorizontalAlignment="Stretch">
+                <Grid MaxHeight="220" HorizontalAlignment="Stretch">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" MinWidth="0"/>
                         <ColumnDefinition Width="Auto" MinWidth="180"/>
@@ -100,14 +84,18 @@
                     </Grid.ColumnDefinitions>
 
                     <!-- Server Context (first, placeholder when no metadata) -->
-                    <Border x:Name="ServerContextBorder" Grid.Column="0" Classes="InsightCard"
+                    <Border x:Name="ServerContextBorder" Grid.Column="0" Padding="10,4,10,8"
+                            Background="#1A1A2D"
+                            BorderBrush="#3A3A5A" BorderThickness="0,0,1,0"
                             IsVisible="False">
                         <ScrollViewer VerticalScrollBarVisibility="Auto"
                                       HorizontalScrollBarVisibility="Disabled">
                             <StackPanel>
-                                <TextBlock Classes="InsightHeader"
-                                           Text="Server Context"
-                                           Foreground="#9B9BFF"/>
+                                <TextBlock Text="Server Context"
+                                           FontSize="13"
+                                           FontWeight="SemiBold"
+                                           Foreground="#9B9BFF"
+                                           Margin="0,0,0,6"/>
                                 <StackPanel x:Name="ServerContextContent"/>
                                 <TextBlock x:Name="ServerContextEmpty"
                                            Text="Run Repro Script to capture server context"
@@ -118,12 +106,16 @@
                     </Border>
 
                     <!-- Runtime Summary -->
-                    <Border Grid.Column="1" Classes="InsightCard">
+                    <Border Grid.Column="1" Padding="10,4,10,8"
+                            Background="{DynamicResource BackgroundDarkBrush}"
+                            BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,1,0">
                         <StackPanel>
                             <TextBlock x:Name="RuntimeSummaryTitle"
-                                       Classes="InsightHeader"
                                        Text="Runtime Summary"
-                                       Foreground="{DynamicResource ForegroundBrush}"/>
+                                       FontSize="13"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource ForegroundBrush}"
+                                       Margin="0,0,0,4"/>
                             <StackPanel x:Name="RuntimeSummaryContent"/>
                             <TextBlock x:Name="RuntimeSummaryEmpty"
                                        Text="Estimated plan — no runtime stats"
@@ -133,14 +125,17 @@
                     </Border>
 
                     <!-- Missing Indexes (center) -->
-                    <Border Grid.Column="2" Classes="InsightCard">
+                    <Border Grid.Column="2" Padding="10,4,10,8"
+                            Background="#3D2A0E"
+                            BorderBrush="#7A5A1E" BorderThickness="0,0,1,0">
                         <ScrollViewer VerticalScrollBarVisibility="Auto"
                                       HorizontalScrollBarVisibility="Disabled">
                             <StackPanel>
                                 <TextBlock x:Name="MissingIndexHeader"
-                                           Classes="InsightHeader"
                                            Text="Missing Index Suggestions"
-                                           Foreground="#FFB347"/>
+                                           FontSize="13"
+                                           FontWeight="SemiBold" Foreground="#FFB347"
+                                           Margin="0,0,0,6"/>
                                 <StackPanel x:Name="MissingIndexContent"/>
                                 <TextBlock x:Name="MissingIndexEmpty"
                                            Text="No missing index suggestions"
@@ -151,14 +146,17 @@
                     </Border>
 
                     <!-- Parameters -->
-                    <Border Grid.Column="3" Classes="InsightCard">
+                    <Border Grid.Column="3" Padding="10,4,10,8"
+                            Background="#1A2D1A"
+                            BorderBrush="#3A5A3A" BorderThickness="0,0,1,0">
                         <ScrollViewer VerticalScrollBarVisibility="Auto"
                                       HorizontalScrollBarVisibility="Disabled">
                             <StackPanel>
                                 <TextBlock x:Name="ParametersHeader"
-                                           Classes="InsightHeader"
                                            Text="Parameters"
-                                           Foreground="#7BCF7B"/>
+                                           FontSize="13"
+                                           FontWeight="SemiBold" Foreground="#7BCF7B"
+                                           Margin="0,0,0,6"/>
                                 <StackPanel x:Name="ParametersContent"/>
                                 <TextBlock x:Name="ParametersEmpty"
                                            Text="No parameters"
@@ -169,14 +167,16 @@
                     </Border>
 
                     <!-- Wait Stats (right, fills remaining space) -->
-                    <Border Grid.Column="4" Classes="InsightCard" Margin="0">
+                    <Border Grid.Column="4" Padding="10,4,10,8"
+                            Background="#1A2A3D">
                         <ScrollViewer VerticalScrollBarVisibility="Auto"
                                       HorizontalScrollBarVisibility="Auto">
                             <StackPanel>
                                 <TextBlock x:Name="WaitStatsHeader"
-                                           Classes="InsightHeader"
                                            Text="Wait Stats"
-                                           Foreground="#4FA3FF"/>
+                                           FontSize="13"
+                                           FontWeight="SemiBold" Foreground="#4FA3FF"
+                                           Margin="0,0,0,6"/>
                                 <StackPanel x:Name="WaitStatsContent"/>
                                 <TextBlock x:Name="WaitStatsEmpty"
                                            Text="No wait stats (estimated plan)"

--- a/src/PlanViewer.App/Themes/DarkTheme.axaml
+++ b/src/PlanViewer.App/Themes/DarkTheme.axaml
@@ -8,10 +8,6 @@
     <SolidColorBrush x:Key="BorderBrush" Color="#3A3D45"/>
     <SolidColorBrush x:Key="AccentBrush" Color="#2eaef1"/>
 
-    <!-- Insight card surfaces (lifted from BackgroundDarkBrush so cards visibly float) -->
-    <SolidColorBrush x:Key="InsightCardBackgroundBrush" Color="#1E2228"/>
-    <SolidColorBrush x:Key="InsightCardBorderBrush" Color="#353942"/>
-
     <!-- Fluent theme accent override: TabItem selected underline, focus rings, etc. -->
     <Color x:Key="SystemAccentColor">#2eaef1</Color>
     <Color x:Key="SystemAccentColorDark1">#2596d4</Color>


### PR DESCRIPTION
Reverts #294. The unified card style didn't read as well as the prior tinted-section layout in practice — empty cards looked broken on the neutral surface, the box-shadow was too subtle to register, and the Wait Stats column ballooned with whitespace. Restoring the original per-section backgrounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)