### PR TITLE
Fix/MFA authentication

### DIFF
--- a/src/PlanViewer.App/Dialogs/ConnectionDialog.axaml
+++ b/src/PlanViewer.App/Dialogs/ConnectionDialog.axaml
@@ -79,11 +79,11 @@
         </StackPanel>
 
         <!-- Test Connection + Status -->
-        <StackPanel Grid.Row="7" Orientation="Horizontal" Margin="0,0,0,12" Spacing="8">
+        <StackPanel Grid.Row="7" Margin="0,0,0,12" Spacing="6">
             <Button x:Name="TestButton" Content="Test Connection" Click="TestConnection_Click"
-                    Height="32" Padding="12,0" FontSize="12"
+                    Height="32" Padding="12,0" FontSize="12" HorizontalAlignment="Left"
                     Theme="{StaticResource AppButton}"/>
-            <TextBlock x:Name="StatusText" VerticalAlignment="Center" FontSize="12"
+            <TextBlock x:Name="StatusText" FontSize="12" TextWrapping="Wrap"
                        Foreground="{DynamicResource ForegroundBrush}"/>
         </StackPanel>
 

--- a/src/PlanViewer.App/Dialogs/ConnectionDialog.axaml.cs
+++ b/src/PlanViewer.App/Dialogs/ConnectionDialog.axaml.cs
@@ -158,7 +158,7 @@ public partial class ConnectionDialog : Window
         }
         catch (Exception ex)
         {
-            StatusText.Text = ex.Message.Length > 80 ? ex.Message[..80] + "..." : ex.Message;
+            StatusText.Text = ex.Message;
             StatusText.Foreground = Avalonia.Media.Brushes.OrangeRed;
             DatabaseBox.IsEnabled = false;
             ConnectButton.IsEnabled = false;

--- a/src/PlanViewer.Core/PlanViewer.Core.csproj
+++ b/src/PlanViewer.Core/PlanViewer.Core.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="1.7.18" />
+    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0" />
     <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="180.6.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## What does this PR do?

Fixes #297 

🤖 says:

> Root cause: Microsoft.Data.SqlClient 7.0.0 introduced a breaking change — it extracted all Entra ID / Azure Active Directory authentication code into a separate package (Microsoft.Data.SqlClient.Extensions.Azure). Without it, attempting to use ActiveDirectoryInteractive (Entra MFA) throws the error you saw.
> 
> Fix applied: Added Microsoft.Data.SqlClient.Extensions.Azure (v1.0.0) to PlanViewer.Core.csproj. This package contains ActiveDirectoryAuthenticationProvider and all related Entra/Azure auth types that were removed from the core Microsoft.Data.SqlClient package. No code changes were required — just the missing dependency.

## Which component(s) does this affect?

- [x] Desktop App (PlanViewer.App)
- [ ] Core Library (PlanViewer.Core)
- [ ] CLI Tool (PlanViewer.Cli)
- [ ] SSMS Extension (PlanViewer.Ssms)
- [ ] Tests
- [ ] Documentation

## How was this tested?

Tested to connect and succeeded
<img width="470" height="540" alt="image" src="https://github.com/user-attachments/assets/5464f49b-e830-4fd1-9b80-9a052d34096a" />


## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceStudio/blob/main/CONTRIBUTING.md)
- [x] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] All tests pass (`dotnet test`)
- [x] I have not introduced any hardcoded credentials or server names
