### PR TITLE
Connection dialog: bump test-status row spacing 6 -> 8

### DIFF
--- a/src/PlanViewer.App/Dialogs/ConnectionDialog.axaml
+++ b/src/PlanViewer.App/Dialogs/ConnectionDialog.axaml
@@ -79,7 +79,7 @@
         </StackPanel>
 
         <!-- Test Connection + Status -->
-        <StackPanel Grid.Row="7" Margin="0,0,0,12" Spacing="6">
+        <StackPanel Grid.Row="7" Margin="0,0,0,12" Spacing="8">
             <Button x:Name="TestButton" Content="Test Connection" Click="TestConnection_Click"
                     Height="32" Padding="12,0" FontSize="12" HorizontalAlignment="Left"
                     Theme="{StaticResource AppButton}"/>


### PR DESCRIPTION
Follow-up nit from the review of #298. Bumps the test-status row's StackPanel `Spacing` from 6 to 8 to match the visual rhythm of the surrounding rows in the dialog (which use `Margin="0,0,0,12"` / inter-control `Spacing="16"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)