### PR TITLE
Feature/allow application intent read only

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -809,7 +809,9 @@ public partial class QuerySessionControl : UserControl
             _selectedDatabase = dialog.ResultDatabase;
             _connectionString = _serverConnection.GetConnectionString(_credentialService, _selectedDatabase);
 
-            ServerLabel.Text = _serverConnection.ServerName;
+            ServerLabel.Text = _serverConnection.ApplicationIntentReadOnly
+                ? $"{_serverConnection.ServerName} (Secondary)"
+                : _serverConnection.ServerName;
             ServerLabel.Foreground = Brushes.LimeGreen;
             ConnectButton.Content = "Reconnect";
 

--- a/src/PlanViewer.App/Dialogs/ConnectionDialog.axaml
+++ b/src/PlanViewer.App/Dialogs/ConnectionDialog.axaml
@@ -68,14 +68,23 @@
         </StackPanel>
 
         <!-- Connection Options -->
-        <StackPanel Grid.Row="6" Orientation="Horizontal" Margin="0,0,0,12" Spacing="16">
-            <CheckBox x:Name="TrustCertBox" Content="Trust server certificate"
-                      Foreground="{DynamicResource ForegroundBrush}" FontSize="12"/>
-            <ComboBox x:Name="EncryptBox" Height="28" FontSize="11" Width="140">
-                <ComboBoxItem Content="Encrypt: Mandatory" Tag="Mandatory" IsSelected="True"/>
-                <ComboBoxItem Content="Encrypt: Optional" Tag="Optional"/>
-                <ComboBoxItem Content="Encrypt: Strict" Tag="Strict"/>
-            </ComboBox>
+        <StackPanel Grid.Row="6" Margin="0,0,0,12" Spacing="8">
+            <StackPanel Orientation="Horizontal" Spacing="16">
+                <CheckBox x:Name="TrustCertBox" Content="Trust server certificate"
+                          Foreground="{DynamicResource ForegroundBrush}" FontSize="12"/>
+                <ComboBox x:Name="EncryptBox" Height="28" FontSize="11" Width="140">
+                    <ComboBoxItem Content="Encrypt: Mandatory" Tag="Mandatory" IsSelected="True"/>
+                    <ComboBoxItem Content="Encrypt: Optional" Tag="Optional"/>
+                    <ComboBoxItem Content="Encrypt: Strict" Tag="Strict"/>
+                </ComboBox>
+            </StackPanel>
+
+            <!-- Read-Only Intent -->
+            <CheckBox x:Name="ReadOnlyIntentCheckBox"
+                        Content="Read-only intent (for AG listeners and readable replicas - including Query Store on secondary replicas)"
+                        Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,6"
+                        ToolTip.Tip="Sets ApplicationIntent=ReadOnly. Required when connecting via an AG listener or Azure failover group endpoint to route to a readable secondary (including Query Store on secondary replicas)."
+                        FontSize="12"/>                      
         </StackPanel>
 
         <!-- Test Connection + Status -->

--- a/src/PlanViewer.App/Dialogs/ConnectionDialog.axaml.cs
+++ b/src/PlanViewer.App/Dialogs/ConnectionDialog.axaml.cs
@@ -78,6 +78,7 @@ public partial class ConnectionDialog : Window
         }
 
         TrustCertBox.IsChecked = saved.TrustServerCertificate;
+        ReadOnlyIntentCheckBox.IsChecked = saved.ApplicationIntentReadOnly;
 
         // Load stored credentials
         var cred = _credentialService.GetCredential(saved.Id);
@@ -217,7 +218,8 @@ public partial class ConnectionDialog : Window
             DisplayName = serverName,
             AuthenticationType = GetSelectedAuthType(),
             TrustServerCertificate = TrustCertBox.IsChecked == true,
-            EncryptMode = GetSelectedEncryptMode()
+            EncryptMode = GetSelectedEncryptMode(),
+            ApplicationIntentReadOnly = ReadOnlyIntentCheckBox.IsChecked == true
         };
     }
 
@@ -249,7 +251,10 @@ public partial class ConnectionDialog : Window
                 "Optional" => SqlConnectionEncryptOption.Optional,
                 "Strict" => SqlConnectionEncryptOption.Strict,
                 _ => SqlConnectionEncryptOption.Mandatory
-            }
+            },
+            ApplicationIntent = connection.ApplicationIntentReadOnly
+                ? ApplicationIntent.ReadOnly
+                : ApplicationIntent.ReadWrite
         };
 
         switch (connection.AuthenticationType)

--- a/src/PlanViewer.App/Services/ConnectionStore.cs
+++ b/src/PlanViewer.App/Services/ConnectionStore.cs
@@ -53,6 +53,7 @@ public class ConnectionStore
             existing.AuthenticationType = connection.AuthenticationType;
             existing.EncryptMode = connection.EncryptMode;
             existing.TrustServerCertificate = connection.TrustServerCertificate;
+            existing.ApplicationIntentReadOnly = connection.ApplicationIntentReadOnly;
             existing.DisplayName = connection.DisplayName;
             existing.LastConnected = DateTime.Now;
         }

--- a/src/PlanViewer.Core/Models/ServerConnection.cs
+++ b/src/PlanViewer.Core/Models/ServerConnection.cs
@@ -16,6 +16,7 @@ public class ServerConnection
     public bool IsFavorite { get; set; }
     public string EncryptMode { get; set; } = "Mandatory";
     public bool TrustServerCertificate { get; set; } = false;
+    public bool ApplicationIntentReadOnly { get; set; } = false;
 
     [JsonIgnore]
     public string AuthenticationDisplay => AuthenticationType switch
@@ -39,7 +40,10 @@ public class ServerConnection
                 "Optional" => SqlConnectionEncryptOption.Optional,
                 "Strict" => SqlConnectionEncryptOption.Strict,
                 _ => SqlConnectionEncryptOption.Mandatory
-            }
+            },
+            ApplicationIntent = ApplicationIntentReadOnly
+                ? ApplicationIntent.ReadOnly
+                : ApplicationIntent.ReadWrite
         };
 
         if (!string.IsNullOrEmpty(databaseName))


### PR DESCRIPTION
## What does this PR do?

Implements #301 

## Which component(s) does this affect?

- [x] Desktop App (PlanViewer.App)
- [x] Core Library (PlanViewer.Core)
- [ ] CLI Tool (PlanViewer.Cli)
- [ ] SSMS Extension (PlanViewer.Ssms)
- [ ] Tests
- [ ] Documentation

## How was this tested?

The "Connect to Server" dialog:
<img width="478" height="547" alt="image" src="https://github.com/user-attachments/assets/34baa6f3-8b91-49ab-84cc-8224f4bb33dc" />

When connected to a Secondary, visually mention that.
<img width="1329" height="179" alt="image" src="https://github.com/user-attachments/assets/e61ae0f6-ceb7-46ad-b85e-966a26d4a17c" />


## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceStudio/blob/main/CONTRIBUTING.md)
- [x] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] All tests pass (`dotnet test`)
- [x] I have not introduced any hardcoded credentials or server names
