### PR TITLE
Connection dialog cleanup (post-#302)

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -810,7 +810,7 @@ public partial class QuerySessionControl : UserControl
             _connectionString = _serverConnection.GetConnectionString(_credentialService, _selectedDatabase);
 
             ServerLabel.Text = _serverConnection.ApplicationIntentReadOnly
-                ? $"{_serverConnection.ServerName} (Secondary)"
+                ? $"{_serverConnection.ServerName} (Read-only)"
                 : _serverConnection.ServerName;
             ServerLabel.Foreground = Brushes.LimeGreen;
             ConnectButton.Content = "Reconnect";

--- a/src/PlanViewer.App/Dialogs/ConnectionDialog.axaml
+++ b/src/PlanViewer.App/Dialogs/ConnectionDialog.axaml
@@ -81,10 +81,10 @@
 
             <!-- Read-Only Intent -->
             <CheckBox x:Name="ReadOnlyIntentCheckBox"
-                        Content="Read-only intent (for AG listeners and readable replicas - including Query Store on secondary replicas)"
-                        Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,6"
-                        ToolTip.Tip="Sets ApplicationIntent=ReadOnly. Required when connecting via an AG listener or Azure failover group endpoint to route to a readable secondary (including Query Store on secondary replicas)."
-                        FontSize="12"/>                      
+                      Content="Read-only intent (for AG listeners and readable replicas - including Query Store on secondary replicas)"
+                      Foreground="{DynamicResource ForegroundBrush}"
+                      ToolTip.Tip="Sets ApplicationIntent=ReadOnly. Required when connecting via an AG listener or Azure failover group endpoint to route to a readable secondary (including Query Store on secondary replicas)."
+                      FontSize="12"/>
         </StackPanel>
 
         <!-- Test Connection + Status -->

--- a/src/PlanViewer.App/Dialogs/ConnectionDialog.axaml.cs
+++ b/src/PlanViewer.App/Dialogs/ConnectionDialog.axaml.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Microsoft.Data.SqlClient;
@@ -133,7 +132,10 @@ public partial class ConnectionDialog : Window
         try
         {
             var connection = BuildServerConnection();
-            var connectionString = BuildConnectionString(connection);
+            var connectionString = connection.GetConnectionString(
+                LoginBox.Text?.Trim(),
+                PasswordBox.Text,
+                "master");
 
             await using var conn = new SqlConnection(connectionString);
             await conn.OpenAsync();
@@ -237,42 +239,4 @@ public partial class ConnectionDialog : Window
         return "Mandatory";
     }
 
-    private string BuildConnectionString(ServerConnection connection)
-    {
-        var builder = new SqlConnectionStringBuilder
-        {
-            DataSource = connection.ServerName,
-            InitialCatalog = "master",
-            ApplicationName = "PlanViewer",
-            ConnectTimeout = 15,
-            TrustServerCertificate = connection.TrustServerCertificate,
-            Encrypt = connection.EncryptMode switch
-            {
-                "Optional" => SqlConnectionEncryptOption.Optional,
-                "Strict" => SqlConnectionEncryptOption.Strict,
-                _ => SqlConnectionEncryptOption.Mandatory
-            },
-            ApplicationIntent = connection.ApplicationIntentReadOnly
-                ? ApplicationIntent.ReadOnly
-                : ApplicationIntent.ReadWrite
-        };
-
-        switch (connection.AuthenticationType)
-        {
-            case AuthenticationTypes.SqlServer:
-                builder.UserID = LoginBox.Text?.Trim() ?? "";
-                builder.Password = PasswordBox.Text ?? "";
-                break;
-            case AuthenticationTypes.EntraMFA:
-                builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryInteractive;
-                if (!string.IsNullOrEmpty(LoginBox.Text?.Trim()))
-                    builder.UserID = LoginBox.Text!.Trim();
-                break;
-            default:
-                builder.IntegratedSecurity = true;
-                break;
-        }
-
-        return builder.ConnectionString;
-    }
 }

--- a/src/PlanViewer.Core/Models/ServerConnection.cs
+++ b/src/PlanViewer.Core/Models/ServerConnection.cs
@@ -28,6 +28,32 @@ public class ServerConnection
 
     public string GetConnectionString(ICredentialService credentialService, string? databaseName = null)
     {
+        string? username = null;
+        string? password = null;
+
+        switch (AuthenticationType)
+        {
+            case AuthenticationTypes.EntraMFA:
+                var mfaCred = credentialService.GetCredential(Id);
+                if (mfaCred.HasValue)
+                    username = mfaCred.Value.Username;
+                break;
+
+            case AuthenticationTypes.SqlServer:
+                var cred = credentialService.GetCredential(Id);
+                if (!cred.HasValue)
+                    throw new InvalidOperationException(
+                        $"SQL Server authentication credentials are missing for server '{ServerName}'. Please configure credentials before connecting.");
+                username = cred.Value.Username;
+                password = cred.Value.Password;
+                break;
+        }
+
+        return GetConnectionString(username, password, databaseName);
+    }
+
+    public string GetConnectionString(string? username, string? password, string? databaseName = null)
+    {
         var builder = new SqlConnectionStringBuilder
         {
             DataSource = ServerName,
@@ -53,18 +79,13 @@ public class ServerConnection
         {
             case AuthenticationTypes.EntraMFA:
                 builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryInteractive;
-                var mfaCred = credentialService.GetCredential(Id);
-                if (mfaCred.HasValue && !string.IsNullOrEmpty(mfaCred.Value.Username))
-                    builder.UserID = mfaCred.Value.Username;
+                if (!string.IsNullOrEmpty(username))
+                    builder.UserID = username;
                 break;
 
             case AuthenticationTypes.SqlServer:
-                var cred = credentialService.GetCredential(Id);
-                if (!cred.HasValue)
-                    throw new InvalidOperationException(
-                        $"SQL Server authentication credentials are missing for server '{ServerName}'. Please configure credentials before connecting.");
-                builder.UserID = cred.Value.Username;
-                builder.Password = cred.Value.Password;
+                builder.UserID = username ?? "";
+                builder.Password = password ?? "";
                 break;
 
             default: // Windows


### PR DESCRIPTION
Follow-up cleanup after #302 (read-only intent feature by @ClaudioESSilva). No behavior change — just polish.

## Changes

- **Rename `(Secondary)` indicator to `(Read-only)`** in `QuerySessionControl`. `ApplicationIntent=ReadOnly` *requests* secondary routing but doesn't guarantee it — the AG listener will still send the session to the primary if no readable replica is available. The label now reflects what we actually know (the user asked for read-only intent), not an assumption about topology.
- **Deduplicate `SqlConnectionStringBuilder` construction.** Previously the encrypt/trust/intent/auth logic was written twice — once in `ServerConnection.GetConnectionString(ICredentialService, ...)` for the runtime path, and once in `ConnectionDialog.BuildConnectionString` for the test path (which reads creds from the textboxes before they're saved). Added a `GetConnectionString(string? username, string? password, string? databaseName = null)` overload on `ServerConnection`; the credential-service overload now resolves creds and delegates to it, and the dialog calls it directly with textbox values. The dialog's `BuildConnectionString` is gone.
- **XAML nits** on the new Read-only intent checkbox: drop the redundant inner `Margin="0,0,0,6"` (the parent `StackPanel` already has `Margin="0,0,0,12"`) and trim trailing whitespace.

## Test plan

- [x] `dotnet build src/PlanViewer.Core` — clean
- [x] `dotnet build src/PlanViewer.App` — 4 pre-existing AVLN3001 warnings, no new ones
- [x] `dotnet build src/PlanViewer.Web` — clean
- [x] `dotnet test` — 75/75 pass
- [ ] Smoke-test in app: open ConnectionDialog, Test Connection still works for Windows, SQL Server, and Entra MFA auth modes
- [ ] Smoke-test in app: connect with Read-only intent checked, confirm `ServerLabel` shows `(Read-only)` after connect