### PR TITLE
Rule 38: suppress when query has explicit MAXDOP 2 hint

### DIFF
--- a/src/PlanViewer.Core/Services/PlanAnalyzer.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.cs
@@ -482,30 +482,38 @@ public static class PlanAnalyzer
         if (!cfg.IsRuleDisabled(38) && stmt.DegreeOfParallelism == 2 && stmt.RootNode != null
             && HasBatchModeNode(stmt.RootNode))
         {
-            var editionKnown = !string.IsNullOrEmpty(serverMetadata?.Edition);
-            if (editionKnown
-                && serverMetadata!.Edition!.Contains("Standard", StringComparison.OrdinalIgnoreCase))
+            // Suppress when the user explicitly set MAXDOP 2 as a query hint — the DOP
+            // cap is intentional, not the Standard Edition batch-mode limitation.
+            var hasMaxdop2Hint = !string.IsNullOrEmpty(stmt.StatementText)
+                && Regex.IsMatch(stmt.StatementText, @"MAXDOP\s+2\b", RegexOptions.IgnoreCase);
+
+            if (!hasMaxdop2Hint)
             {
-                // Server context confirms Standard Edition — check MAXDOP
-                if (serverMetadata.MaxDop > 2)
+                var editionKnown = !string.IsNullOrEmpty(serverMetadata?.Edition);
+                if (editionKnown
+                    && serverMetadata!.Edition!.Contains("Standard", StringComparison.OrdinalIgnoreCase))
                 {
+                    // Server context confirms Standard Edition — check MAXDOP
+                    if (serverMetadata.MaxDop > 2)
+                    {
+                        stmt.PlanWarnings.Add(new PlanWarning
+                        {
+                            WarningType = "Standard Edition DOP Limitation",
+                            Message = $"DOP is limited to 2 because SQL Server Standard Edition caps parallelism at 2 when batch mode operators are present, even though MAXDOP is set to {serverMetadata.MaxDop}. Developer or Enterprise Edition would allow higher DOP in the same conditions.",
+                            Severity = PlanWarningSeverity.Warning
+                        });
+                    }
+                }
+                else if (!editionKnown)
+                {
+                    // No server context, or edition unknown (e.g. collection failure) — suspect the limitation
                     stmt.PlanWarnings.Add(new PlanWarning
                     {
                         WarningType = "Standard Edition DOP Limitation",
-                        Message = $"DOP is limited to 2 because SQL Server Standard Edition caps parallelism at 2 when batch mode operators are present, even though MAXDOP is set to {serverMetadata.MaxDop}. Developer or Enterprise Edition would allow higher DOP in the same conditions.",
-                        Severity = PlanWarningSeverity.Warning
+                        Message = "DOP is limited to 2 and the plan uses batch mode operators. This may be caused by the SQL Server Standard Edition limitation, which caps parallelism at 2 when batch mode is in use. If this server runs Standard Edition, Developer or Enterprise Edition would allow higher DOP.",
+                        Severity = PlanWarningSeverity.Info
                     });
                 }
-            }
-            else if (!editionKnown)
-            {
-                // No server context, or edition unknown (e.g. collection failure) — suspect the limitation
-                stmt.PlanWarnings.Add(new PlanWarning
-                {
-                    WarningType = "Standard Edition DOP Limitation",
-                    Message = "DOP is limited to 2 and the plan uses batch mode operators. This may be caused by the SQL Server Standard Edition limitation, which caps parallelism at 2 when batch mode is in use. If this server runs Standard Edition, Developer or Enterprise Edition would allow higher DOP.",
-                    Severity = PlanWarningSeverity.Info
-                });
             }
         }
 

--- a/tests/PlanViewer.Core.Tests/PlanAnalyzerTests.cs
+++ b/tests/PlanViewer.Core.Tests/PlanAnalyzerTests.cs
@@ -989,5 +989,38 @@ public class PlanAnalyzerTests
         Assert.Equal(PlanWarningSeverity.Info, warnings[0].Severity);
     }
 
+    [Fact]
+    public void Rule38_StandardEdition_Dop2_BatchMode_MaxDop2QueryHint_NoWarning()
+    {
+        // User explicitly set OPTION (MAXDOP 2) — DOP cap is intentional, not the SE limit
+        var stmt = BuildBatchModeDop2Statement();
+        stmt.StatementText = "SELECT * FROM dbo.Fact OPTION (MAXDOP 2)";
+        var plan = BuildSyntheticPlan(stmt);
+        var metadata = new ServerMetadata
+        {
+            Edition = "Standard Edition (64-bit)",
+            MaxDop = 8
+        };
+        PlanAnalyzer.Analyze(plan, serverMetadata: metadata);
+
+        var warnings = stmt.PlanWarnings
+            .Where(w => w.WarningType == "Standard Edition DOP Limitation").ToList();
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void Rule38_NoServerMetadata_Dop2_BatchMode_MaxDop2QueryHint_NoWarning()
+    {
+        // Same suppression applies when we don't know the edition either
+        var stmt = BuildBatchModeDop2Statement();
+        stmt.StatementText = "SELECT * FROM dbo.Fact OPTION (MAXDOP 2)";
+        var plan = BuildSyntheticPlan(stmt);
+        PlanAnalyzer.Analyze(plan);
+
+        var warnings = stmt.PlanWarnings
+            .Where(w => w.WarningType == "Standard Edition DOP Limitation").ToList();
+        Assert.Empty(warnings);
+    }
+
     #endregion
 }


### PR DESCRIPTION
Follow-up to #275 (Standard Edition DOP 2 limitation rule).

When the user explicitly sets `OPTION (MAXDOP 2)` in a query, observing DOP=2 + batch mode operators is just the user's hint doing what was asked — not the Standard Edition batch-mode cap. The warning would be misleading in that case, so suppress it.

Mirrors the same handling Rule 3 (Serial Plan) uses for explicit `MAXDOP 1` hints.

## Behavior

- Query has `OPTION (MAXDOP 2)` (or any case-insensitive \`MAXDOP 2\` token) in `StatementText`: **no warning**, regardless of edition.
- Query has no MAXDOP hint, edition is Standard, MAXDOP > 2: **Warning** (unchanged).
- Query has no MAXDOP hint, edition unknown: **Info** (unchanged).
- Query has no MAXDOP hint, edition is Standard with MAXDOP=2: **no warning** (unchanged — limit isn't biting).

## Test plan

- [x] `dotnet test` — 77/77 pass (5 pre-existing Rule 38 tests + 2 new)
  - `Rule38_StandardEdition_Dop2_BatchMode_MaxDop2QueryHint_NoWarning`
  - `Rule38_NoServerMetadata_Dop2_BatchMode_MaxDop2QueryHint_NoWarning`
- [x] `dotnet build` Core + Web — clean