### PR TITLE
switch the default grid GroupBy from "None" to "Query Hash" and don't…

### DIFF
--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
@@ -70,7 +70,7 @@
                 <StackPanel Spacing="4">
                     <TextBlock Text="Group by" Foreground="{DynamicResource ForegroundBrush}" FontSize="11"/>
                     <ComboBox x:Name="GroupByBox" Width="130" Height="36" FontSize="13"
-                              SelectedIndex="0" SelectionChanged="GroupBy_SelectionChanged">
+                              SelectedIndex="1" SelectionChanged="GroupBy_SelectionChanged">
                         <ComboBoxItem Content="None" Tag="none"/>
                         <ComboBoxItem Content="Query Hash" Tag="query-hash"/>
                         <ComboBoxItem Content="Module" Tag="module"/>
@@ -150,7 +150,7 @@
                 </ContextMenu>
             </DataGrid.ContextMenu>
             <DataGrid.Columns>
-                <DataGridTemplateColumn Header="" Width="220" IsVisible="False">
+                <DataGridTemplateColumn Header="" Width="220" IsVisible="True">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate x:DataType="local:QueryStoreRow">
                             <StackPanel Orientation="Horizontal" Margin="{Binding IndentMargin}"

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
@@ -44,7 +44,7 @@ public partial class QueryStoreGridControl : UserControl
     private bool _waitStatsSupported;  // false until version + capture mode confirmed
     private bool _waitStatsEnabled = true;
     private bool _waitPercentMode;
-    private QueryStoreGroupBy _groupByMode = QueryStoreGroupBy.None;
+    private QueryStoreGroupBy _groupByMode = QueryStoreGroupBy.QueryHash;
     private List<QueryStoreRow> _groupedRootRows = new(); // top-level rows for grouped mode
 
     public event EventHandler<List<QueryStorePlan>>? PlansSelected;
@@ -89,6 +89,7 @@ public partial class QueryStoreGridControl : UserControl
         // Auto-fetch with default settings on connect
         Avalonia.Threading.Dispatcher.UIThread.Post(() =>
         {
+            ReorderColumnsForGroupBy();
             Fetch_Click(null, new RoutedEventArgs());
             _initialOrderByLoaded = true;
         }, Avalonia.Threading.DispatcherPriority.Loaded);
@@ -311,12 +312,7 @@ public partial class QueryStoreGridControl : UserControl
         LoadButton.IsEnabled = true;
         SelectToggleButton.Content = "Select All";
 
-        // Auto-expand the first root row to the deepest level
-        if (rootRows.Count > 0)
-        {
-            var first = rootRows[0];
-            ExpandRowRecursive(first);
-        }
+
 
         UpdateStatusText();
         UpdateBarRatios();


### PR DESCRIPTION


## What does this PR do?

QueryStoreGridControl.axaml:
•	Changed GroupByBox default SelectedIndex from 0 (None) to 1 (Query Hash)
•	Changed expand column IsVisible from False to True (since grouped mode is now the default)

QueryStoreGridControl.axaml.cs:
•	Changed _groupByMode default from QueryStoreGroupBy.None to QueryHash
•	Added ReorderColumnsForGroupBy() call before the initial fetch so columns are properly ordered on startup
•	Removed the auto-expand of the first root row after grouped fetch (lines that called ExpandRowRecursive(first))

## Which component(s) does this affect?

- [x] Desktop App (PlanViewer.App)
- [ ] Core Library (PlanViewer.Core)
- [ ] CLI Tool (PlanViewer.Cli)
- [ ] SSMS Extension (PlanViewer.Ssms)
- [ ] Tests
- [ ] Documentation

## Motivation
I find more usefull to have a group by "query hash" by default, i always switch to that groupby so why not opening it by default directly ?

## How was this tested?

<img width="1280" height="832" alt="2026-05-03_10h42_09" src="https://github.com/user-attachments/assets/d1f29dcf-e8d7-47c3-8b56-730d1845ec68" />


Describe the testing you've done. Include:
- Plan files tested : queryStore
- Platforms tested : windows only

## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceStudio/blob/main/CONTRIBUTING.md)
- [x] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] All tests pass (`dotnet test`)
- [x] I have not introduced any hardcoded credentials or server names
