### PR TITLE
Bump version to 1.10.0

### DIFF
--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -6,7 +6,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>EDD.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>1.9.0</Version>
+    <Version>1.10.0</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>


### PR DESCRIPTION
## Summary
- Bumps `<Version>` in `src/PlanViewer.App/PlanViewer.App.csproj` from `1.9.0` → `1.10.0`.

Prep for the v1.10.0 release. Once this and #307 (line-ending normalization) are on `dev`, the release goes out by opening `dev` → `main` and merging — `release.yml` auto-tags `v1.10.0` and publishes builds.

## Why 1.10.0 (minor) and not 1.9.1
Headline changes since v1.9.0:
- **#302** ApplicationIntent=ReadOnly support in connection dialog (new feature)
- **#215 parts 1+2** Wait stats config seeded and wired as the single source of truth
- **#305** Default grid GroupBy → Query Hash; first row no longer auto-expands (UX shift)
- **#304** Rule 38 suppressed when query has explicit MAXDOP 2 hint
- **#298** MFA auth error message readability (external contributor)
- **#299/#303/#306** Connection dialog polish + dead-code removal

A new connection feature plus a noticeable UX default change is more than a patch.

## Test plan
- [ ] CI green
- [ ] After both this and #307 land on `dev`, `dev` → `main` PR passes `check-version-bump` (1.9.0 → 1.10.0)
- [ ] On merge to `main`, `release.yml` creates tag `v1.10.0` and uploads platform artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)