### PR TITLE
Bump workflow actions to Node 24 versions

### DIFF
--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get PR version
         id: pr
@@ -21,7 +21,7 @@ jobs:
           Write-Host "PR version: $version"
 
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           path: main-branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
 

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -27,10 +27,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       has_changes: ${{ steps.check.outputs.has_changes }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: dev
           fetch-depth: 0
@@ -38,12 +38,12 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: dev
 
       - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Get version
         id: version
@@ -46,7 +46,7 @@ jobs:
           gh release create "v${{ steps.version.outputs.VERSION }}" --title "v${{ steps.version.outputs.VERSION }}" --generate-notes --target main
 
       - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
 
@@ -78,14 +78,14 @@ jobs:
       - name: Upload Windows build for signing
         if: steps.signing.outputs.ENABLED == 'true'
         id: upload-unsigned
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: App-unsigned
           path: publish/win-x64/
 
       - name: Sign Windows build
         if: steps.signing.outputs.ENABLED == 'true'
-        uses: signpath/github-action-submit-signing-request@v1
+        uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '7969f8b6-d946-4a74-9bac-a55856d8b8e0'


### PR DESCRIPTION
## Summary
Bumps the four GitHub Actions flagged as Node-20-deprecated by the v1.10.0 release run. After June 2, 2026, GitHub will force these to run on Node 24, so getting ahead of it.

| Action | Old | New | Why |
| --- | --- | --- | --- |
| `actions/checkout` | v4 | v5 | First major to default to Node 24 |
| `actions/setup-dotnet` | v4 | v5 | Same |
| `actions/upload-artifact` | v4 | v6 | v5 still defaults to Node 20; **v6** is the first Node-24 default |
| `signpath/github-action-submit-signing-request` | v1 | v2 | v2 declares `runs.using: node24` |

Sticking to the **smallest** major-version jump that fixes the deprecation:
- Skipping `checkout@v6` (one major beyond what's needed)
- Skipping `upload-artifact@v7` (adds opt-in ESM / direct-upload features that aren't relevant here)

## Why now
The `release.yml` run for v1.10.0 ended with this warning:
> Node.js 20 actions are deprecated... Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

## Risk
- **Minimum runner version 2.327.1** required for the `actions/*@v5/v6` versions. GitHub-hosted runners are well past that; only matters if self-hosted runners are introduced later.
- SignPath v2 input names verified unchanged from v1 against the action manifest — no workflow input adjustments needed.

## Test plan
- [ ] CI green on this PR
- [ ] On merge to `dev`, nightly build succeeds with the new action versions
- [ ] Next `dev` -> `main` release run no longer emits the Node 20 deprecation warning
- [ ] SignPath signing still works on the next release (signed binary present in `releases/PerformanceStudio-win-x64.zip`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)