### PR TITLE
QS Overview review followups, brand sweep, version unification

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Report a problem with SQL Performance Studio
+description: Report a problem with Performance Studio
 title: "[BUG] "
 labels: ["bug"]
 
@@ -8,7 +8,7 @@ body:
     id: component
     attributes:
       label: Component
-      description: Which part of SQL Performance Studio is affected?
+      description: Which part of Performance Studio is affected?
       options:
         - Desktop App (Windows)
         - Desktop App (macOS)
@@ -21,7 +21,7 @@ body:
   - type: input
     id: version
     attributes:
-      label: SQL Performance Studio Version
+      label: Performance Studio Version
       description: Check the About dialog or the release you downloaded.
       placeholder: "e.g., 0.7.0"
     validations:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: Questions & Discussion
     url: https://github.com/erikdarlingdata/PerformanceStudio/discussions
-    about: Ask questions and discuss SQL Performance Studio with the community
+    about: Ask questions and discuss Performance Studio with the community

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,24 @@
+<Project>
+  <!--
+    Single source of truth for product version + identity across src/ projects.
+
+    Picked up automatically by SDK-style projects in this folder and below:
+      PlanViewer.App, PlanViewer.Core, PlanViewer.Cli, PlanViewer.Web,
+      PlanViewer.Ssms.Installer.
+
+    NOT picked up by PlanViewer.Ssms — it's a legacy non-SDK project.
+    Its version lives in:
+      Properties/AssemblyInfo.cs   (AssemblyVersion + AssemblyFileVersion)
+      source.extension.vsixmanifest (Identity Version="...")
+    Bump those manually when bumping the version here.
+
+    Tests and server/ projects are outside src/ and are unaffected.
+  -->
+  <PropertyGroup>
+    <Version>1.10.0</Version>
+    <Authors>Erik Darling</Authors>
+    <Company>Darling Data LLC</Company>
+    <Product>Performance Studio</Product>
+    <Copyright>Copyright (c) 2026 Erik Darling, Darling Data LLC</Copyright>
+  </PropertyGroup>
+</Project>

--- a/src/PlanViewer.App/Controls/QueryStoreOverviewControl.axaml
+++ b/src/PlanViewer.App/Controls/QueryStoreOverviewControl.axaml
@@ -10,10 +10,18 @@
             <RowDefinition Height="2*"/>
         </Grid.RowDefinitions>
 
-        <!-- Row 0: Progress bar (always visible to reserve space, toggle IsIndeterminate) -->
-        <ProgressBar x:Name="LoadingBar" Grid.Row="0" IsIndeterminate="False"
-                     Height="3" Margin="0"
-                     Foreground="{DynamicResource AccentBrush}"/>
+        <!-- Row 0: Progress bar + refresh-error badge -->
+        <Grid Grid.Row="0">
+            <ProgressBar x:Name="LoadingBar" IsIndeterminate="False"
+                         Height="3" Margin="0"
+                         VerticalAlignment="Top"
+                         Foreground="{DynamicResource AccentBrush}"/>
+            <TextBlock x:Name="RefreshErrorBadge" Text="⚠ refresh failed"
+                       FontSize="10" FontWeight="SemiBold"
+                       Foreground="#F2C94C"
+                       HorizontalAlignment="Right" VerticalAlignment="Top"
+                       Margin="0,2,10,0" IsVisible="False" Cursor="Hand"/>
+        </Grid>
 
         <!-- Row 1: Donut + TimeSlicer + WaitStats -->
         <Grid Grid.Row="1" Margin="10">
@@ -43,9 +51,15 @@
             <Border Grid.Column="2" Background="{DynamicResource BackgroundLightBrush}"
                     CornerRadius="4" Margin="5,0,0,0" ClipToBounds="True">
                 <Grid RowDefinitions="Auto,*">
-                    <TextBlock Grid.Row="0" Text="Wait Stats by Database" FontSize="11" FontWeight="SemiBold"
-                               Foreground="{DynamicResource ForegroundBrush}"
-                               HorizontalAlignment="Center" Margin="0,4,0,0"/>
+                    <Grid Grid.Row="0">
+                        <TextBlock Text="Wait Stats by Database" FontSize="11" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource ForegroundBrush}"
+                                   HorizontalAlignment="Center" Margin="0,4,0,0"/>
+                        <TextBlock x:Name="WaitStatsWarning" Text="⚠" FontSize="12"
+                                   Foreground="#F2C94C"
+                                   HorizontalAlignment="Right" VerticalAlignment="Center"
+                                   Margin="0,4,8,0" IsVisible="False" Cursor="Hand"/>
+                    </Grid>
                     <Border x:Name="WaitStatsBorder" Grid.Row="1" ClipToBounds="True">
                         <Canvas x:Name="WaitStatsCanvas" Background="Transparent"/>
                     </Border>

--- a/src/PlanViewer.App/Controls/QueryStoreOverviewControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreOverviewControl.axaml.cs
@@ -170,15 +170,13 @@ public partial class QueryStoreOverviewControl : UserControl
                     _masterConnectionString, _activeDbs, _slicerStartUtc, _slicerEndUtc, _maxDop, ct);
                 _waitSlices = slices;
 
-                if (errors.Count > 0)
-                {
-                    await Dispatcher.UIThread.InvokeAsync(() =>
-                        ShowWaitStatsErrors(errors));
-                }
+                await Dispatcher.UIThread.InvokeAsync(() => UpdateWaitStatsWarning(errors));
             }
             else
             {
                 _waitSlices.Clear();
+                await Dispatcher.UIThread.InvokeAsync(() =>
+                    UpdateWaitStatsWarning(new List<(string Database, string Error)>()));
             }
 
             await Dispatcher.UIThread.InvokeAsync(() =>
@@ -193,31 +191,23 @@ public partial class QueryStoreOverviewControl : UserControl
         }
     }
 
-    private void ShowWaitStatsErrors(List<(string Database, string Error)> errors)
+    private void UpdateWaitStatsWarning(List<(string Database, string Error)> errors)
     {
-        var msg = string.Join("\n", errors.Select(e => $"[{e.Database}] {e.Error}"));
-        var window = new Avalonia.Controls.Window
+        if (errors.Count == 0)
         {
-            Title = "Wait Stats Errors",
-            Width = 600,
-            Height = 300,
-            Content = new ScrollViewer
-            {
-                Content = new TextBlock
-                {
-                    Text = msg,
-                    TextWrapping = Avalonia.Media.TextWrapping.Wrap,
-                    Margin = new Thickness(10),
-                    Foreground = new SolidColorBrush(Color.Parse("#E4E6EB")),
-                    FontSize = 12,
-                }
-            }
-        };
-        var topLevel = TopLevel.GetTopLevel(this);
-        if (topLevel is Avalonia.Controls.Window owner)
-            window.ShowDialog(owner);
-        else
-            window.Show();
+            WaitStatsWarning.IsVisible = false;
+            ToolTip.SetTip(WaitStatsWarning, null);
+            return;
+        }
+
+        var header = errors.Count == 1
+            ? "Wait stats incomplete (1 error):"
+            : $"Wait stats incomplete ({errors.Count} errors):";
+        var msg = string.Join("\n", errors.Select(e => $"[{e.Database}] {e.Error}"));
+
+        ToolTip.SetTip(WaitStatsWarning, $"{header}\n{msg}");
+        ToolTip.SetShowDelay(WaitStatsWarning, 200);
+        WaitStatsWarning.IsVisible = true;
     }
 
     // ── Donut Chart ──────────────────────────────────────────────────────────
@@ -438,15 +428,35 @@ public partial class QueryStoreOverviewControl : UserControl
         _slicerStartUtc = e.StartUtc;
         _slicerEndUtc = e.EndUtc;
 
+        // Don't dispose the previous CTS — the in-flight refresh still holds its token.
+        // Cancel signals the previous run; GC reclaims the source after both runs unwind.
         _cts?.Cancel();
-        _cts?.Dispose();
-        _cts = new CancellationTokenSource();
+        var newCts = new CancellationTokenSource();
+        _cts = newCts;
+
+        ClearRefreshError();
         try
         {
-            await RefreshMetricsAndWaitStatsAsync(_cts.Token);
+            await RefreshMetricsAndWaitStatsAsync(newCts.Token);
         }
         catch (OperationCanceledException) { }
-        catch { /* swallow errors from refresh */ }
+        catch (Exception ex)
+        {
+            ShowRefreshError(ex);
+        }
+    }
+
+    private void ShowRefreshError(Exception ex)
+    {
+        ToolTip.SetTip(RefreshErrorBadge, $"Last refresh failed:\n{ex.Message}");
+        ToolTip.SetShowDelay(RefreshErrorBadge, 200);
+        RefreshErrorBadge.IsVisible = true;
+    }
+
+    private void ClearRefreshError()
+    {
+        RefreshErrorBadge.IsVisible = false;
+        ToolTip.SetTip(RefreshErrorBadge, null);
     }
 
     // ── Wait Stats Chart (stacked by database) ──────────────────────────────
@@ -460,7 +470,7 @@ public partial class QueryStoreOverviewControl : UserControl
             {
                 Text = _supportsWaitStats ? "No wait stats data" : "Wait stats not supported (SQL 2017+ required)",
                 FontSize = 10,
-                Foreground = new SolidColorBrush(Color.Parse("#888888")),
+                Foreground = this.FindResource("ForegroundMutedBrush") as IBrush ?? new SolidColorBrush(Color.Parse("#B0B6C0")),
                 TextWrapping = Avalonia.Media.TextWrapping.Wrap,
             };
             Canvas.SetLeft(msg, 10);

--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -6,11 +6,6 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>EDD.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>1.10.0</Version>
-    <Authors>Erik Darling</Authors>
-    <Company>Darling Data LLC</Company>
-    <Product>Performance Studio</Product>
-    <Copyright>Copyright (c) 2026 Erik Darling, Darling Data LLC</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PlanViewer.Cli/PlanViewer.Cli.csproj
+++ b/src/PlanViewer.Cli/PlanViewer.Cli.csproj
@@ -11,11 +11,6 @@
     <Nullable>enable</Nullable>
     <RootNamespace>PlanViewer.Cli</RootNamespace>
     <AssemblyName>planview</AssemblyName>
-    <Version>1.3.0</Version>
-    <Authors>Erik Darling</Authors>
-    <Company>Darling Data LLC</Company>
-    <Product>Performance Studio</Product>
-    <Copyright>Copyright (c) 2026 Erik Darling, Darling Data LLC</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PlanViewer.Core/PlanViewer.Core.csproj
+++ b/src/PlanViewer.Core/PlanViewer.Core.csproj
@@ -5,11 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>PlanViewer.Core</RootNamespace>
-    <Version>1.4.0</Version>
-    <Authors>Erik Darling</Authors>
-    <Company>Darling Data LLC</Company>
-    <Product>SQL Performance Studio</Product>
-    <Copyright>Copyright (c) 2026 Erik Darling, Darling Data LLC</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PlanViewer.Ssms.Installer/PlanViewer.Ssms.Installer.csproj
+++ b/src/PlanViewer.Ssms.Installer/PlanViewer.Ssms.Installer.csproj
@@ -6,11 +6,6 @@
     <AssemblyName>InstallSsmsExtension</AssemblyName>
     <RootNamespace>PlanViewer.Ssms.Installer</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <Version>1.3.0</Version>
-    <Authors>Erik Darling</Authors>
-    <Company>Darling Data LLC</Company>
-    <Product>SQL Performance Studio</Product>
-    <Copyright>Copyright (c) 2026 Erik Darling, Darling Data LLC</Copyright>
   </PropertyGroup>
 
 </Project>

--- a/src/PlanViewer.Ssms.Installer/Program.cs
+++ b/src/PlanViewer.Ssms.Installer/Program.cs
@@ -16,7 +16,7 @@ namespace PlanViewer.Ssms.Installer
         static int Main(string[] args)
         {
             Console.WriteLine("===========================================");
-            Console.WriteLine(" SQL Performance Studio — SSMS Extension");
+            Console.WriteLine(" Performance Studio — SSMS Extension");
             Console.WriteLine("===========================================");
             Console.WriteLine();
 

--- a/src/PlanViewer.Ssms/AnalyzePlanCommand.cs
+++ b/src/PlanViewer.Ssms/AnalyzePlanCommand.cs
@@ -54,9 +54,9 @@ namespace PlanViewer.Ssms
                 {
                     // App not found — ask user to locate it once
                     var result = System.Windows.Forms.MessageBox.Show(
-                        "SQL Performance Studio was not found.\n\n" +
+                        "Performance Studio was not found.\n\n" +
                         "Would you like to locate it? The path will be saved for next time.",
-                        "SQL Performance Studio",
+                        "Performance Studio",
                         System.Windows.Forms.MessageBoxButtons.YesNo,
                         System.Windows.Forms.MessageBoxIcon.Question);
 
@@ -68,7 +68,7 @@ namespace PlanViewer.Ssms
                             // Try again now that the path is saved to registry
                             if (!AppLauncher.LaunchApp(tempFile))
                             {
-                                ShowError("Could not launch SQL Performance Studio from:\n" + appPath);
+                                ShowError("Could not launch Performance Studio from:\n" + appPath);
                             }
                         }
                     }
@@ -76,7 +76,7 @@ namespace PlanViewer.Ssms
             }
             catch (Exception ex)
             {
-                ShowError("Error opening plan in SQL Performance Studio:\n\n" + ex.Message);
+                ShowError("Error opening plan in Performance Studio:\n\n" + ex.Message);
             }
         }
 
@@ -84,7 +84,7 @@ namespace PlanViewer.Ssms
         {
             System.Windows.Forms.MessageBox.Show(
                 message,
-                "SQL Performance Studio",
+                "Performance Studio",
                 System.Windows.Forms.MessageBoxButtons.OK,
                 System.Windows.Forms.MessageBoxIcon.Warning);
         }

--- a/src/PlanViewer.Ssms/AnalyzePlanPackage.vsct
+++ b/src/PlanViewer.Ssms/AnalyzePlanPackage.vsct
@@ -18,7 +18,7 @@
         <Parent guid="guidCmdSet" id="AnalyzePlanGroupId"/>
         <Icon guid="guidImages" id="bmpAnalyze"/>
         <Strings>
-          <ButtonText>Open in SQL Performance Studio</ButtonText>
+          <ButtonText>Open in Performance Studio</ButtonText>
         </Strings>
       </Button>
     </Buttons>

--- a/src/PlanViewer.Ssms/AppLauncher.cs
+++ b/src/PlanViewer.Ssms/AppLauncher.cs
@@ -7,7 +7,7 @@ using Microsoft.Win32;
 namespace PlanViewer.Ssms
 {
     /// <summary>
-    /// Finds and launches SQL Performance Studio with a plan file.
+    /// Finds and launches Performance Studio with a plan file.
     /// If the app is already running, sends the file via named pipe
     /// so it opens as a new tab instead of a new window.
     /// </summary>
@@ -39,7 +39,7 @@ namespace PlanViewer.Ssms
         }
 
         /// <summary>
-        /// Opens the file in SQL Performance Studio. If the app is already running,
+        /// Opens the file in Performance Studio. If the app is already running,
         /// sends the file path via named pipe (opens as a new tab). Otherwise
         /// launches a new instance.
         /// Returns true if the file was sent or launched successfully.
@@ -172,6 +172,9 @@ namespace PlanViewer.Ssms
                 Path.Combine(localAppData, "Programs", "plan-b", ExeName),
                 Path.Combine(programFiles, "DarlingData", "SQLPerformanceStudio", ExeName),
                 Path.Combine(programFilesX86, "DarlingData", "SQLPerformanceStudio", ExeName),
+                Path.Combine(programFiles, "Performance Studio", ExeName),
+                Path.Combine(programFilesX86, "Performance Studio", ExeName),
+                // Legacy install paths — kept so existing installs still launch:
                 Path.Combine(programFiles, "SQL Performance Studio", ExeName),
                 Path.Combine(programFilesX86, "SQL Performance Studio", ExeName),
             };
@@ -194,8 +197,8 @@ namespace PlanViewer.Ssms
         {
             using (var dialog = new System.Windows.Forms.OpenFileDialog())
             {
-                dialog.Title = "Locate SQL Performance Studio";
-                dialog.Filter = "SQL Performance Studio|PlanViewer.App.exe|All executables|*.exe";
+                dialog.Title = "Locate Performance Studio";
+                dialog.Filter = "Performance Studio|PlanViewer.App.exe|All executables|*.exe";
                 dialog.FileName = ExeName;
 
                 if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK

--- a/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
+++ b/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
@@ -2,10 +2,10 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("PlanViewer.Ssms")]
-[assembly: AssemblyDescription("SSMS extension to open execution plans in SQL Performance Studio")]
+[assembly: AssemblyDescription("SSMS extension to open execution plans in Performance Studio")]
 [assembly: AssemblyCompany("Darling Data")]
-[assembly: AssemblyProduct("SQL Performance Studio for SSMS")]
+[assembly: AssemblyProduct("Performance Studio for SSMS")]
 [assembly: AssemblyCopyright("Copyright Darling Data 2026")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.10.0.0")]
+[assembly: AssemblyFileVersion("1.10.0.0")]

--- a/src/PlanViewer.Ssms/VSPackage.resx
+++ b/src/PlanViewer.Ssms/VSPackage.resx
@@ -58,6 +58,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="110" xml:space="preserve">
-    <value>SQL Performance Studio for SSMS</value>
+    <value>Performance Studio for SSMS</value>
   </data>
 </root>

--- a/src/PlanViewer.Ssms/install.cmd
+++ b/src/PlanViewer.Ssms/install.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM Installs the SQL Performance Studio SSMS extension.
+REM Installs the Performance Studio SSMS extension.
 REM For SSMS 22, this must be run from an elevated (admin) command prompt.
 
 setlocal
@@ -14,7 +14,7 @@ if not exist "%VSIX%" (
     exit /b 1
 )
 
-echo Installing SQL Performance Studio SSMS extension...
+echo Installing Performance Studio SSMS extension...
 echo VSIX: %VSIX%
 echo.
 

--- a/src/PlanViewer.Ssms/source.extension.vsixmanifest
+++ b/src/PlanViewer.Ssms/source.extension.vsixmanifest
@@ -3,11 +3,11 @@
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="PlanViewer.Ssms.64F79022-9D9A-4463-A1AE-4B19426A0CB1"
-              Version="1.0.0"
+              Version="1.10.0"
               Language="en-US"
               Publisher="Darling Data" />
-    <DisplayName>SQL Performance Studio for SSMS</DisplayName>
-    <Description xml:space="preserve">Adds "Open in SQL Performance Studio" to the execution plan right-click menu in SSMS. Extracts the plan XML and opens it in SQL Performance Studio for advanced analysis.</Description>
+    <DisplayName>Performance Studio for SSMS</DisplayName>
+    <Description xml:space="preserve">Adds "Open in Performance Studio" to the execution plan right-click menu in SSMS. Extracts the plan XML and opens it in Performance Studio for advanced analysis.</Description>
     <MoreInfo>https://github.com/erikdarlingdata/PerformanceStudio</MoreInfo>
     <License>LICENSE</License>
     <Tags>SQL Server, Execution Plan, Performance, SSMS</Tags>

--- a/src/PlanViewer.Web/PlanViewer.Web.csproj
+++ b/src/PlanViewer.Web/PlanViewer.Web.csproj
@@ -5,11 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>PlanViewer.Web</RootNamespace>
-    <Version>1.7.3</Version>
-    <Authors>Erik Darling</Authors>
-    <Company>Darling Data LLC</Company>
-    <Product>SQL Performance Studio</Product>
-    <Copyright>Copyright (c) 2026 Erik Darling, Darling Data LLC</Copyright>
     <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

Three logical chunks bundled into one PR — followups from a multi-agent review of `c90bff7` (multi-DB Query Store overview).

### QueryStoreOverviewControl fixes
- **Dim-text rule violation**: `#888888` → theme `ForegroundMutedBrush` at line 463.
- **Modal-on-every-slicer-drag**: `ShowWaitStatsErrors` modal replaced with an inline `⚠` badge in the wait-stats panel header. Tooltip lists each `[database] message`. Clears automatically on a successful refresh.
- **CTS race in `OnSlicerRangeChanged`**: stop disposing the previous CTS while the in-flight refresh still holds its token. Capture the new CTS in a local before assigning to `_cts`. The `DetachedFromVisualTree` handler still disposes on teardown — safe because nothing else is racing at that point.
- **Swallowed `catch { }`**: replaced with a `RefreshErrorBadge` in Row 0 next to the LoadingBar. Tooltip surfaces `ex.Message` so a failed refresh no longer silently shows a blank chart. Cleared at the start of each new refresh attempt.

### Brand sweep ("SQL Performance Studio" → "Performance Studio")
User-visible surfaces only:
- Issue templates (`bug_report.yml`, `config.yml`)
- `.csproj` `<Product>` tags (Core, Web, Cli, Installer; App via inherited)
- VSIX `DisplayName` + `Description`, `.vsct` ButtonText, `VSPackage.resx`
- `AssemblyInfo` Description + Product
- All `MessageBox` titles and error strings in `AnalyzePlanCommand.cs`
- Locate-app dialog title and file filter in `AppLauncher.cs`
- `install.cmd` user-visible messages, installer console banner

**Compatibility surfaces left unchanged**: pipe name `SQLPerformanceStudio_OpenFile`, registry key `SOFTWARE\DarlingData\SQLPerformanceStudio`, internal-ID Program-Files paths, legacy `plan-b` candidate. Spaced "SQL Performance Studio" Program-Files paths preserved as additional fallbacks so existing installs still launch.

### Version unification
- New `src/Directory.Build.props` sets `Version`, `Authors`, `Company`, `Product`, `Copyright` once. Picked up by every SDK-style project under `src/`.
- Removed duplicated metadata from `PlanViewer.App`, `Core`, `Cli`, `Web`, `Ssms.Installer` csprojs (all inherit now).
- `PlanViewer.Ssms` is legacy non-SDK; bumped manually:
  - `Properties/AssemblyInfo.cs` 1.0.0.0 → 1.10.0.0 (×2)
  - `source.extension.vsixmanifest` 1.0.0 → 1.10.0
- Inheritance verified locally: clean Release build of `PlanViewer.Cli` and `PlanViewer.App` both report `ProductVersion=1.10.0+<sha>`, `FileVersion=1.10.0.0`, `ProductName=Performance Studio`.
- Tests (`tests/`) and server (`server/`) projects are outside `src/` and unaffected.

## Test plan
- [ ] Build the full solution from scratch — confirm 0 errors
- [ ] Drag the QS Overview slicer rapidly — confirm no modal pops; if a wait-stats error occurs, ⚠ badge appears with tooltip on hover
- [ ] Disconnect SQL briefly and drag the slicer — confirm "⚠ refresh failed" badge appears next to the loading bar; restore connection and drag — badge clears
- [ ] Right-click an execution plan in SSMS — context menu reads "Open in Performance Studio"
- [ ] Open About dialog or check assembly properties — `Performance Studio` and `1.10.0`
- [ ] Build the SSMS VSIX — confirm `1.10.0` in the extension metadata
- [ ] If you have a legacy install at `C:\Program Files\SQL Performance Studio\` available — confirm it still launches via the SSMS context menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)