### PR TITLE
Silence AVLN3001 warnings via NoWarn

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -21,4 +21,15 @@
     <Product>Performance Studio</Product>
     <Copyright>Copyright (c) 2026 Erik Darling, Darling Data LLC</Copyright>
   </PropertyGroup>
+
+  <!--
+    Silence AVLN3001 ("XAML resource won't be reachable via runtime loader,
+    no public constructor was found"). All flagged controls take typed
+    constructor dependencies (ServerConnection, ICredentialService, ...) and
+    are instantiated directly in code-behind — they're never loaded via
+    AvaloniaXamlLoader.Load() and the IDE previewer isn't used.
+  -->
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);AVLN3001</NoWarn>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
The 5 `AVLN3001` ("XAML resource won't be reachable via runtime loader, no public constructor was found") warnings on every build flag scenarios that aren't used in this project:
- Affected controls: `QuerySessionControl`, `QueryStoreGridControl`, `QueryStoreOverviewControl`, `ConnectionDialog`, `QueryStoreHistoryWindow`
- All take typed constructor dependencies (`ServerConnection`, `ICredentialService`, etc.)
- All are instantiated directly in code-behind — never via `AvaloniaXamlLoader.Load()`
- The Avalonia IDE previewer isn't used in this project (no `Design.DataContext` anywhere)

Adds `<NoWarn>$(NoWarn);AVLN3001</NoWarn>` in `src/Directory.Build.props` so it applies to every SDK-style project under `src/`. Includes a comment block explaining why so a future reader doesn't reflexively re-enable it.

If the previewer ever becomes load-bearing, the right move is to remove this suppression and add parameterless constructors to the flagged controls.

## Test plan
- [ ] `dotnet build` from a clean state — confirm 0 warnings, 0 errors
- [ ] No behavior change at runtime expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)