### PR TITLE
Speed up CI with NuGet cache + solution-wide build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,25 +17,17 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
+          cache: true
+          cache-dependency-path: '**/*.csproj'
 
       - name: Install WASM workload
         run: dotnet workload install wasm-tools
 
-      - name: Restore dependencies
-        run: |
-          dotnet restore src/PlanViewer.Core/PlanViewer.Core.csproj
-          dotnet restore src/PlanViewer.App/PlanViewer.App.csproj
-          dotnet restore src/PlanViewer.Cli/PlanViewer.Cli.csproj
-          dotnet restore src/PlanViewer.Web/PlanViewer.Web.csproj
-          dotnet restore tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj
+      - name: Restore solution
+        run: dotnet restore PlanViewer.sln
 
-      - name: Build all projects
-        run: |
-          dotnet build src/PlanViewer.Core/PlanViewer.Core.csproj -c Release --no-restore
-          dotnet build src/PlanViewer.App/PlanViewer.App.csproj -c Release --no-restore
-          dotnet build src/PlanViewer.Cli/PlanViewer.Cli.csproj -c Release --no-restore
-          dotnet build src/PlanViewer.Web/PlanViewer.Web.csproj -c Release --no-restore
-          dotnet build tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj -c Release --no-restore
+      - name: Build solution
+        run: dotnet build PlanViewer.sln -c Release --no-restore
 
       - name: Run tests
         run: dotnet test tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj -c Release --no-build --verbosity normal


### PR DESCRIPTION
## Summary
Two changes to `.github/workflows/ci.yml`:

1. **NuGet cache via setup-dotnet**: `cache: true` with `cache-dependency-path: '**/*.csproj'` persists `~/.nuget/packages` across runs. Cold restore (~90s on `windows-latest`) becomes a tar extract on cache hit. Cache invalidates whenever any `.csproj` changes.

2. **Solution-wide build**: replaced five sequential `dotnet restore` + five sequential `dotnet build` invocations with one each against `PlanViewer.sln`. MSBuild builds the dependency graph in parallel internally, and we save four MSBuild startup cycles.

`PlanViewer.Ssms` and `PlanViewer.Ssms.Installer` are intentionally excluded from `PlanViewer.sln`, so they remain out of CI as before.

## Expected impact
PS CI was ~7 min cold. Estimate after merge:
- First run on this branch: similar time (~7 min — populates the cache).
- Subsequent runs: ~3-4 min (cache hit eliminates the restore step entirely; solution build saves ~30-60s of MSBuild startup overhead).

## Test plan
- [ ] First run after merge — confirm CI passes (cache populates here)
- [ ] Open a follow-up PR (or push a small commit) — confirm restore step shows cache hit and total runtime drops
- [ ] Confirm the build still produces correct artifacts (no projects silently skipped from sln)

## Followups
@erikdarlingdata previously called out path filters and `ubuntu-latest` migration as further wins. Both are out of scope here — this PR is the low-risk pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)