### PR TITLE
Skip CI on non-build changes via paths-ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,19 @@ on:
     branches: [main]
   pull_request:
     branches: [main, dev]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'CITATION.cff'
+      - 'llms.txt'
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'docs/**'
+      - 'screenshots/**'
+      - 'server/**'
+      - 'src/PlanViewer.Ssms/**'
+      - 'src/PlanViewer.Ssms.Installer/**'
 
 jobs:
   build-and-test:


### PR DESCRIPTION
## Summary
PR-trigger `paths-ignore` on `.github/workflows/ci.yml`. The workflow runs as before whenever any changed file falls outside the ignore list; if every changed file matches the list, CI doesn't run.

Push to `main` is unaffected — that path keeps building unconditionally.

### Ignored paths
| Pattern | Why |
|---|---|
| `**.md` | Documentation |
| `LICENSE`, `CITATION.cff`, `llms.txt` | Project metadata |
| `.gitignore`, `.gitattributes` | Repo config |
| `.github/ISSUE_TEMPLATE/**` | GitHub UI templates only |
| `docs/**`, `screenshots/**` | Non-build assets |
| `server/**` | PlanShare server, not in `PlanViewer.sln` |
| `src/PlanViewer.Ssms/**`, `src/PlanViewer.Ssms.Installer/**` | Intentionally excluded from `PlanViewer.sln` (built by their own VS workflow, not CI) |

Mirrors the path-filter pattern already used in `deploy-web.yml`. If branch protection requires `build-and-test` and a future PR touches *only* ignored paths, the merge UI may flag the absent check — if that bites, swap to the per-step `dorny/paths-filter` pattern from `build.yml`.

## Test plan
- [ ] This PR touches `.github/workflows/ci.yml` (not in ignore list) → CI should run
- [ ] After merge, a PR touching only `README.md` should not trigger CI
- [ ] After merge, a PR touching `src/PlanViewer.Ssms/AppLauncher.cs` (SSMS code) should not trigger CI
- [ ] Verify branch protection still allows merging when CI is filtered out (vs. blocking on absent check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)