### PR TITLE
Try ubuntu-latest for CI (experiment)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
Switch `runs-on: windows-latest` → `runs-on: ubuntu-latest` for the CI workflow as an experiment. Linux runners are ~2× faster than Windows runners on GitHub-hosted infrastructure.

Nothing in `PlanViewer.sln` is Windows-only:
- `PlanViewer.Core`, `.App`, `.Cli` — net8.0, cross-platform
- `PlanViewer.Web` — Blazor WASM, builds on Linux with `wasm-tools`
- `PlanViewer.Core.Tests` — xunit on net8.0
- `PlanViewer.App.csproj` already declares `SkiaSharp.NativeAssets.Linux` so SkiaSharp's native bits are present on Linux

`PlanViewer.Ssms` (legacy net472 + VSSDK) is intentionally excluded from `PlanViewer.sln` and is not built in CI, so it doesn't gate this change.

## Decision rule
- ✅ CI green on Linux → keep
- ⚠️ CI red but the failure is a clean small fix (e.g., a missing native package reference) → fix forward
- ❌ CI red and the fix is invasive → revert this PR. The cache + solution-build wins from #317 remain regardless.

## Test plan
- [ ] CI passes on this PR
- [ ] Compare runtime to recent windows-latest runs (#317 was 4:01 cold)
- [ ] If green, watch the next few PRs to confirm stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)