### PR TITLE
Allow filter by "execution_type_desc" on Query Store screen

### DIFF
--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
@@ -96,7 +96,7 @@
                              KeyDown="SearchValue_KeyDown"/>
                 </StackPanel>
                 <StackPanel x:Name="ExecutionTypePanel" Spacing="4" IsVisible="False">
-                    <TextBlock Text=" " FontSize="11"/>
+                    <TextBlock Text="Execution Type" Foreground="{DynamicResource ForegroundBrush}" FontSize="11"/>
                     <ComboBox x:Name="ExecutionTypeBox" Width="120" Height="36" FontSize="13"
                               SelectedIndex="0">
                         <ComboBoxItem Content="Regular" Tag="Regular"/>

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
@@ -360,6 +360,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
+                <DataGridTextColumn Header="Execution Type" Binding="{ReflectionBinding ExecutionTypeDesc}" SortMemberPath="ExecutionTypeDesc" Width="110"/>
             </DataGrid.Columns>
         </DataGrid>
         <!-- Loading overlay -->

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
@@ -78,7 +78,7 @@
                 </StackPanel>
                 <StackPanel Spacing="4">
                     <TextBlock Text="Search by" Foreground="{DynamicResource ForegroundBrush}" FontSize="11"/>
-                    <ComboBox x:Name="SearchTypeBox" Width="120" Height="36" FontSize="13"
+                    <ComboBox x:Name="SearchTypeBox" Width="140" Height="36" FontSize="13"
                               SelectedIndex="0" SelectionChanged="SearchType_SelectionChanged">
                         <ComboBoxItem Content="(none)" Tag=""/>
                         <ComboBoxItem Content="Query ID" Tag="query-id"/>

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
@@ -99,9 +99,11 @@
                     <TextBlock Text="Execution Type" Foreground="{DynamicResource ForegroundBrush}" FontSize="11"/>
                     <ComboBox x:Name="ExecutionTypeBox" Width="120" Height="36" FontSize="13"
                               SelectedIndex="0">
+                        <ComboBoxItem Content="(any)" Tag="any"/>
                         <ComboBoxItem Content="Regular" Tag="Regular"/>
                         <ComboBoxItem Content="Aborted" Tag="Aborted"/>
                         <ComboBoxItem Content="Exception" Tag="Exception"/>
+                        <ComboBoxItem Content="Failed" Tag="Failed"/>
                     </ComboBox>
                 </StackPanel>
                 <StackPanel Spacing="4">

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
@@ -79,20 +79,30 @@
                 <StackPanel Spacing="4">
                     <TextBlock Text="Search by" Foreground="{DynamicResource ForegroundBrush}" FontSize="11"/>
                     <ComboBox x:Name="SearchTypeBox" Width="120" Height="36" FontSize="13"
-                              SelectedIndex="0">
+                              SelectedIndex="0" SelectionChanged="SearchType_SelectionChanged">
                         <ComboBoxItem Content="(none)" Tag=""/>
                         <ComboBoxItem Content="Query ID" Tag="query-id"/>
                         <ComboBoxItem Content="Plan ID" Tag="plan-id"/>
                         <ComboBoxItem Content="Query Hash" Tag="query-hash"/>
                         <ComboBoxItem Content="Plan Hash" Tag="plan-hash"/>
                         <ComboBoxItem Content="Module" Tag="module"/>
+                        <ComboBoxItem Content="Execution Type" Tag="execution-type"/>
                     </ComboBox>
                 </StackPanel>
-                <StackPanel Spacing="4">
+                <StackPanel x:Name="SearchValuePanel" Spacing="4">
                     <TextBlock Text=" " FontSize="11"/>
                     <TextBox x:Name="SearchValueBox" Width="200" Height="36" FontSize="13"
                              Watermark="0x1AB2C3, dbo.MyProc"
                              KeyDown="SearchValue_KeyDown"/>
+                </StackPanel>
+                <StackPanel x:Name="ExecutionTypePanel" Spacing="4" IsVisible="False">
+                    <TextBlock Text=" " FontSize="11"/>
+                    <ComboBox x:Name="ExecutionTypeBox" Width="120" Height="36" FontSize="13"
+                              SelectedIndex="0">
+                        <ComboBoxItem Content="Regular" Tag="Regular"/>
+                        <ComboBoxItem Content="Aborted" Tag="Aborted"/>
+                        <ComboBoxItem Content="Exception" Tag="Exception"/>
+                    </ComboBox>
                 </StackPanel>
                 <StackPanel Spacing="4">
                     <TextBlock Text="Time display" Foreground="{DynamicResource ForegroundBrush}" FontSize="11"/>

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
@@ -556,6 +556,7 @@ public partial class QueryStoreGridControl : UserControl
             QueryText = row.QueryText,
             PlanXml = row.PlanXml,
             CountExecutions = row.CountExecutions,
+            ExecutionTypeDesc = row.ExecutionTypeDesc,
             TotalCpuTimeUs = row.TotalCpuTimeUs,
             TotalDurationUs = row.TotalDurationUs,
             TotalLogicalIoReads = row.TotalLogicalIoReads,
@@ -1886,6 +1887,7 @@ public class QueryStoreRow : INotifyPropertyChanged
     public string QueryHash => Plan.QueryHash;
     public string QueryPlanHash => Plan.QueryPlanHash;
     public string ModuleName => Plan.ModuleName;
+    public string ExecutionTypeDesc => Plan.ExecutionTypeDesc;
 
     public string ExecsDisplay => Plan.CountExecutions.ToString("N0");
     public string TotalCpuDisplay => (Plan.TotalCpuTimeUs / 1000.0).ToString("N0");

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
@@ -603,6 +603,7 @@ public partial class QueryStoreGridControl : UserControl
             AvgPhysicalIoReads = (double)totalPhysReads / safeExecs,
             AvgMemoryGrantPages = (double)totalMem / safeExecs,
             LastExecutedUtc = lastExec,
+            ExecutionTypeDesc = rows.FirstOrDefault()?.ExecutionTypeDesc ?? "",
         };
     }
 
@@ -626,8 +627,14 @@ public partial class QueryStoreGridControl : UserControl
 
         if (searchType == "execution-type")
         {
-            var execType = (ExecutionTypeBox.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "Regular";
-            return new QueryStoreFilter { ExecutionTypeDesc = execType };
+            var tag = (ExecutionTypeBox.SelectedItem as ComboBoxItem)?.Tag?.ToString();
+            // "any" tag (first item) means no filter
+            if (string.IsNullOrEmpty(tag) || tag == "any")
+                return null;
+            // "Failed" bundles Aborted + Exception into an IN predicate
+            if (tag == "Failed")
+                return new QueryStoreFilter { ExecutionTypeDescs = ["Aborted", "Exception"] };
+            return new QueryStoreFilter { ExecutionTypeDescs = [tag] };
         }
 
         var searchValue = SearchValueBox.Text?.Trim();
@@ -901,6 +908,7 @@ public partial class QueryStoreGridControl : UserControl
     {
         SearchTypeBox.SelectedIndex = 0;
         SearchValueBox.Text = "";
+        // Resetting SearchTypeBox triggers SearchType_SelectionChanged which hides ExecutionTypePanel.
         ExecutionTypeBox.SelectedIndex = 0;
     }
 

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
@@ -605,12 +605,32 @@ public partial class QueryStoreGridControl : UserControl
         };
     }
 
+    private void SearchType_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (SearchValuePanel is null || ExecutionTypePanel is null)
+            return;
+
+        var tag = (SearchTypeBox.SelectedItem as ComboBoxItem)?.Tag?.ToString();
+        var isExecutionType = tag == "execution-type";
+        SearchValuePanel.IsVisible = !isExecutionType;
+        ExecutionTypePanel.IsVisible = isExecutionType;
+    }
+
     private QueryStoreFilter? BuildSearchFilter()
     {
         var searchType = (SearchTypeBox.SelectedItem as ComboBoxItem)?.Tag?.ToString();
-        var searchValue = SearchValueBox.Text?.Trim();
 
-        if (string.IsNullOrEmpty(searchType) || string.IsNullOrEmpty(searchValue))
+        if (string.IsNullOrEmpty(searchType))
+            return null;
+
+        if (searchType == "execution-type")
+        {
+            var execType = (ExecutionTypeBox.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "Regular";
+            return new QueryStoreFilter { ExecutionTypeDesc = execType };
+        }
+
+        var searchValue = SearchValueBox.Text?.Trim();
+        if (string.IsNullOrEmpty(searchValue))
             return null;
 
         var filter = new QueryStoreFilter();
@@ -880,6 +900,7 @@ public partial class QueryStoreGridControl : UserControl
     {
         SearchTypeBox.SelectedIndex = 0;
         SearchValueBox.Text = "";
+        ExecutionTypeBox.SelectedIndex = 0;
     }
 
     private async System.Threading.Tasks.Task LoadTimeSlicerDataAsync(

--- a/src/PlanViewer.App/Dialogs/QueryStoreHistoryWindow.axaml
+++ b/src/PlanViewer.App/Dialogs/QueryStoreHistoryWindow.axaml
@@ -147,6 +147,7 @@
                 <DataGridTextColumn Header="Min DOP" Binding="{ReflectionBinding MinDop}" Width="70"/>
                 <DataGridTextColumn Header="Max DOP" Binding="{ReflectionBinding MaxDop}" Width="70"/>
                 <DataGridTextColumn Header="Last Execution" Binding="{ReflectionBinding LastExecutionLocal}" Width="140"/>
+                <DataGridTextColumn Header="Execution Type" Binding="{ReflectionBinding ExecutionTypeDesc}" Width="110"/>
             </DataGrid.Columns>
         </DataGrid>
 

--- a/src/PlanViewer.Core/Models/QueryStoreGroupBy.cs
+++ b/src/PlanViewer.Core/Models/QueryStoreGroupBy.cs
@@ -44,6 +44,7 @@ public class QueryStoreGroupedPlanRow
     /// for a query_hash/plan_hash pair. Only meaningful for leaf-level (QueryId/PlanId) rows.
     /// </summary>
     public bool IsTopRepresentative { get; set; }
+    public string ExecutionTypeDesc { get; set; } = "";
 }
 
 /// <summary>

--- a/src/PlanViewer.Core/Models/QueryStoreHistoryRow.cs
+++ b/src/PlanViewer.Core/Models/QueryStoreHistoryRow.cs
@@ -27,6 +27,7 @@ public class QueryStoreHistoryRow
 	public int MinDop { get; set; }
     public int MaxDop { get; set; }
     public DateTime? LastExecutionUtc { get; set; }
+    public string ExecutionTypeDesc { get; set; } = "";
 
     // Display-formatted properties (2 decimal places)
     public string AvgDurationMsDisplay => AvgDurationMs.ToString("N2");

--- a/src/PlanViewer.Core/Models/QueryStorePlan.cs
+++ b/src/PlanViewer.Core/Models/QueryStorePlan.cs
@@ -13,7 +13,11 @@ public class QueryStoreFilter
     public string? QueryHash { get; set; }
     public string? QueryPlanHash { get; set; }
     public string? ModuleName { get; set; }
-    public string? ExecutionTypeDesc { get; set; }
+    /// <summary>
+    /// One or more execution_type_desc values to filter by.
+    /// Single value → equality predicate; multiple values (e.g. "Aborted","Exception" for "Failed") → IN predicate.
+    /// </summary>
+    public string[]? ExecutionTypeDescs { get; set; }
 }
 
 public class QueryStorePlan

--- a/src/PlanViewer.Core/Models/QueryStorePlan.cs
+++ b/src/PlanViewer.Core/Models/QueryStorePlan.cs
@@ -23,6 +23,7 @@ public class QueryStorePlan
     public string QueryHash { get; set; } = "";
     public string QueryPlanHash { get; set; } = "";
     public string ModuleName { get; set; } = "";
+    public string ExecutionTypeDesc { get; set; } = "";
     public string QueryText { get; set; } = "";
     public string PlanXml { get; set; } = "";
 

--- a/src/PlanViewer.Core/Models/QueryStorePlan.cs
+++ b/src/PlanViewer.Core/Models/QueryStorePlan.cs
@@ -13,6 +13,7 @@ public class QueryStoreFilter
     public string? QueryHash { get; set; }
     public string? QueryPlanHash { get; set; }
     public string? ModuleName { get; set; }
+    public string? ExecutionTypeDesc { get; set; }
 }
 
 public class QueryStorePlan

--- a/src/PlanViewer.Core/Services/QueryStoreService.cs
+++ b/src/PlanViewer.Core/Services/QueryStoreService.cs
@@ -138,6 +138,12 @@ FROM sys.database_query_store_options;";
         var phase3QueryJoin = needsQueryJoin
             ? "    JOIN sys.query_store_query AS q ON p.query_id = q.query_id\n"
             : "";
+        var phase2ExecutionTypeClause = "";
+        if (!string.IsNullOrWhiteSpace(filter?.ExecutionTypeDesc))
+        {
+            phase2ExecutionTypeClause = "\nAND rs.execution_type_desc = @executionTypeDesc";
+            parameters.Add(new SqlParameter("@executionTypeDesc", filter.ExecutionTypeDesc.Trim()));
+        }
 
         // Time-range filter: always filter on interval start_time (indexed).
         // The hoursBack fallback also uses interval start_time instead of
@@ -218,7 +224,7 @@ WHERE EXISTS
     SELECT 1
     FROM #intervals AS i
     WHERE i.runtime_stats_interval_id = rs.runtime_stats_interval_id
-)
+){phase2ExecutionTypeClause}
 GROUP BY rs.plan_id
 OPTION (RECOMPILE);
 
@@ -1004,6 +1010,12 @@ ORDER BY bucket_hour, wait_ratio DESC;";
             parameters.Add(new SqlParameter("@filterModule", moduleVal));
         }
         var filterSql = filterClauses.Count > 0 ? "\n" + string.Join("\n", filterClauses) : "";
+        var phase2ExecutionTypeClause = "";
+        if (!string.IsNullOrWhiteSpace(filter?.ExecutionTypeDesc))
+        {
+            phase2ExecutionTypeClause = "\nAND rs.execution_type_desc = @executionTypeDesc";
+            parameters.Add(new SqlParameter("@executionTypeDesc", filter.ExecutionTypeDesc.Trim()));
+        }
 
         var sql = $@"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
@@ -1042,7 +1054,7 @@ SELECT
     SUM(rs.count_executions),
     MAX(rs.last_execution_time)
 FROM sys.query_store_runtime_stats AS rs
-WHERE EXISTS (SELECT 1 FROM #intervals AS i WHERE i.runtime_stats_interval_id = rs.runtime_stats_interval_id)
+WHERE EXISTS (SELECT 1 FROM #intervals AS i WHERE i.runtime_stats_interval_id = rs.runtime_stats_interval_id){phase2ExecutionTypeClause}
 GROUP BY rs.plan_id
 OPTION (RECOMPILE);
 
@@ -1263,6 +1275,12 @@ SELECT * FROM #plan_hash_rows ORDER BY query_hash, total_executions DESC;
             parameters.Add(new SqlParameter("@filterQueryHash", filter.QueryHash.Trim()));
         }
         var filterSql = filterClauses.Count > 0 ? "\n" + string.Join("\n", filterClauses) : "";
+        var phase2ExecutionTypeClause = "";
+        if (!string.IsNullOrWhiteSpace(filter?.ExecutionTypeDesc))
+        {
+            phase2ExecutionTypeClause = "\nAND rs.execution_type_desc = @executionTypeDesc";
+            parameters.Add(new SqlParameter("@executionTypeDesc", filter.ExecutionTypeDesc.Trim()));
+        }
 
         var sql = $@"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
@@ -1301,7 +1319,7 @@ SELECT
     SUM(rs.count_executions),
     MAX(rs.last_execution_time)
 FROM sys.query_store_runtime_stats AS rs
-WHERE EXISTS (SELECT 1 FROM #intervals AS i WHERE i.runtime_stats_interval_id = rs.runtime_stats_interval_id)
+WHERE EXISTS (SELECT 1 FROM #intervals AS i WHERE i.runtime_stats_interval_id = rs.runtime_stats_interval_id){phase2ExecutionTypeClause}
 GROUP BY rs.plan_id
 OPTION (RECOMPILE);
 

--- a/src/PlanViewer.Core/Services/QueryStoreService.cs
+++ b/src/PlanViewer.Core/Services/QueryStoreService.cs
@@ -205,7 +205,8 @@ CREATE TABLE #plan_stats (
     total_physical_reads float NOT NULL,
     total_memory_pages float NOT NULL,
     total_executions bigint NOT NULL,
-    last_execution_time datetimeoffset NOT NULL
+    last_execution_time datetimeoffset NOT NULL,
+    execution_type_desc nvarchar(60) NOT NULL
 );
 INSERT INTO #plan_stats
 SELECT
@@ -217,7 +218,8 @@ SELECT
     SUM(rs.avg_physical_io_reads * rs.count_executions),
     SUM(rs.avg_query_max_used_memory * rs.count_executions),
     SUM(rs.count_executions),
-    MAX(rs.last_execution_time)
+    MAX(rs.last_execution_time),
+    MAX(rs.execution_type_desc)
 FROM sys.query_store_runtime_stats AS rs
 WHERE EXISTS
 (
@@ -242,6 +244,7 @@ WITH ranked AS (
         ps.total_memory_pages,
         ps.total_executions,
         ps.last_execution_time,
+        ps.execution_type_desc,
         CASE WHEN ps.total_executions > 0
              THEN ps.total_cpu_us / ps.total_executions ELSE 0 END AS avg_cpu_us,
         CASE WHEN ps.total_executions > 0
@@ -275,7 +278,8 @@ SELECT TOP ({topN})
     CAST(r.total_writes AS bigint) AS total_writes,
     CAST(r.total_physical_reads AS bigint) AS total_physical_reads,
     CAST(r.total_memory_pages AS bigint) AS total_memory_pages,
-    r.last_execution_time
+    r.last_execution_time,
+    r.execution_type_desc
 INTO #top_plans
 FROM ranked AS r
 WHERE 1 = 1 {rnClause}
@@ -307,7 +311,8 @@ SELECT
         WHEN q.object_id <> 0
         THEN OBJECT_SCHEMA_NAME(q.object_id) + N'.' + OBJECT_NAME(q.object_id)
         ELSE N''
-    END
+    END,
+    tp.execution_type_desc
 FROM #top_plans AS tp
 JOIN sys.query_store_plan AS p ON tp.plan_id = p.plan_id
 JOIN sys.query_store_query AS q ON p.query_id = q.query_id
@@ -352,6 +357,7 @@ ORDER BY {outerOrder} DESC;";
                 QueryHash = reader.IsDBNull(18) ? "" : reader.GetString(18),
                 QueryPlanHash = reader.IsDBNull(19) ? "" : reader.GetString(19),
                 ModuleName = reader.IsDBNull(20) ? "" : reader.GetString(20),
+                ExecutionTypeDesc = reader.IsDBNull(21) ? "" : reader.GetString(21),
             });
         }
 
@@ -398,7 +404,8 @@ SELECT
     SUM(rs.avg_physical_io_reads * rs.count_executions),
     MIN(rs.min_dop),
     MAX(rs.max_dop),
-    MAX(rs.last_execution_time)
+    MAX(rs.last_execution_time),
+    MAX(rs.execution_type_desc)
 FROM sys.query_store_runtime_stats rs
 JOIN sys.query_store_runtime_stats_interval rsi
     ON rs.runtime_stats_interval_id = rsi.runtime_stats_interval_id
@@ -510,7 +517,8 @@ SELECT
     SUM(rs.avg_physical_io_reads * rs.count_executions),
     MIN(rs.min_dop),
     MAX(rs.max_dop),
-    MAX(rs.last_execution_time)
+    MAX(rs.last_execution_time),
+    MAX(rs.execution_type_desc)
 FROM sys.query_store_runtime_stats rs
 JOIN sys.query_store_runtime_stats_interval rsi
     ON rs.runtime_stats_interval_id = rsi.runtime_stats_interval_id
@@ -555,6 +563,7 @@ ORDER BY rsi.start_time, p.plan_id;";
                 MinDop = (int)reader.GetInt64(16),
                 MaxDop = (int)reader.GetInt64(17),
                 LastExecutionUtc = reader.IsDBNull(18) ? null : ((DateTimeOffset)reader.GetValue(18)).UtcDateTime,
+                ExecutionTypeDesc = reader.IsDBNull(19) ? "" : reader.GetString(19),
             });
         }
 
@@ -625,7 +634,8 @@ SELECT
     MIN(rs.min_dop),
     MAX(rs.max_dop),
     MAX(rs.last_execution_time),
-    SUM(rs.avg_query_max_used_memory * rs.count_executions)
+    SUM(rs.avg_query_max_used_memory * rs.count_executions),
+    MAX(rs.execution_type_desc)
 FROM sys.query_store_runtime_stats rs
 JOIN sys.query_store_runtime_stats_interval rsi
     ON rs.runtime_stats_interval_id = rsi.runtime_stats_interval_id
@@ -670,6 +680,7 @@ ORDER BY rsi.start_time, p.query_plan_hash;";
                 MaxDop = (int)reader.GetInt64(16),
                 LastExecutionUtc = reader.IsDBNull(17) ? null : ((DateTimeOffset)reader.GetValue(17)).UtcDateTime,
                 TotalMemoryMb = reader.GetDouble(18),
+                ExecutionTypeDesc = reader.IsDBNull(19) ? "" : reader.GetString(19),
 			});
         }
 
@@ -1226,6 +1237,12 @@ SELECT * FROM #plan_hash_rows ORDER BY query_hash, total_executions DESC;
             }
         }
 
+        if (!string.IsNullOrWhiteSpace(filter?.ExecutionTypeDesc))
+        {
+            foreach (var r in result.LeafRows) r.ExecutionTypeDesc = filter.ExecutionTypeDesc!;
+            foreach (var r in result.IntermediateRows) r.ExecutionTypeDesc = filter.ExecutionTypeDesc!;
+        }
+
         return result;
     }
 
@@ -1510,6 +1527,12 @@ SELECT * FROM #qhash_rows ORDER BY module_name, total_executions DESC;
                     LastExecutedUtc = ((DateTimeOffset)reader.GetValue(9)).UtcDateTime,
                 });
             }
+        }
+
+        if (!string.IsNullOrWhiteSpace(filter?.ExecutionTypeDesc))
+        {
+            foreach (var r in result.LeafRows) r.ExecutionTypeDesc = filter.ExecutionTypeDesc!;
+            foreach (var r in result.IntermediateRows) r.ExecutionTypeDesc = filter.ExecutionTypeDesc!;
         }
 
         return result;

--- a/src/PlanViewer.Core/Services/QueryStoreService.cs
+++ b/src/PlanViewer.Core/Services/QueryStoreService.cs
@@ -139,10 +139,14 @@ FROM sys.database_query_store_options;";
             ? "    JOIN sys.query_store_query AS q ON p.query_id = q.query_id\n"
             : "";
         var phase2ExecutionTypeClause = "";
-        if (!string.IsNullOrWhiteSpace(filter?.ExecutionTypeDesc))
+        if (filter?.ExecutionTypeDescs?.Length > 0)
         {
-            phase2ExecutionTypeClause = "\nAND rs.execution_type_desc = @executionTypeDesc";
-            parameters.Add(new SqlParameter("@executionTypeDesc", filter.ExecutionTypeDesc.Trim()));
+            var etParamNames = filter.ExecutionTypeDescs
+                .Select((_, i) => $"@executionType{i}")
+                .ToList();
+            phase2ExecutionTypeClause = $"\nAND rs.execution_type_desc IN ({string.Join(", ", etParamNames)})";
+            for (var i = 0; i < filter.ExecutionTypeDescs.Length; i++)
+                parameters.Add(new SqlParameter($"@executionType{i}", filter.ExecutionTypeDescs[i]));
         }
 
         // Time-range filter: always filter on interval start_time (indexed).
@@ -219,7 +223,12 @@ SELECT
     SUM(rs.avg_query_max_used_memory * rs.count_executions),
     SUM(rs.count_executions),
     MAX(rs.last_execution_time),
-    MAX(rs.execution_type_desc)
+    -- Pick execution_type_desc from the most-recently-executed interval to avoid
+    -- alphabetical bias: MAX would choose 'Regular' over 'Aborted'.
+    RTRIM(CAST(SUBSTRING(MAX(
+        CONVERT(char(27), CAST(rs.last_execution_time AS datetime2(7)), 121)
+        + CAST(ISNULL(rs.execution_type_desc, '') AS char(60))
+    ), 28, 60) AS nvarchar(60)))
 FROM sys.query_store_runtime_stats AS rs
 WHERE EXISTS
 (
@@ -449,6 +458,7 @@ ORDER BY rsi.start_time, p.plan_id;";
                 MinDop = (int)reader.GetInt64(16),
                 MaxDop = (int)reader.GetInt64(17),
                 LastExecutionUtc = reader.IsDBNull(18) ? null : ((DateTimeOffset)reader.GetValue(18)).UtcDateTime,
+                ExecutionTypeDesc = reader.IsDBNull(19) ? "" : reader.GetString(19),
             });
         }
 
@@ -1022,10 +1032,14 @@ ORDER BY bucket_hour, wait_ratio DESC;";
         }
         var filterSql = filterClauses.Count > 0 ? "\n" + string.Join("\n", filterClauses) : "";
         var phase2ExecutionTypeClause = "";
-        if (!string.IsNullOrWhiteSpace(filter?.ExecutionTypeDesc))
+        if (filter?.ExecutionTypeDescs?.Length > 0)
         {
-            phase2ExecutionTypeClause = "\nAND rs.execution_type_desc = @executionTypeDesc";
-            parameters.Add(new SqlParameter("@executionTypeDesc", filter.ExecutionTypeDesc.Trim()));
+            var etParamNames = filter.ExecutionTypeDescs
+                .Select((_, i) => $"@executionType{i}")
+                .ToList();
+            phase2ExecutionTypeClause = $"\nAND rs.execution_type_desc IN ({string.Join(", ", etParamNames)})";
+            for (var i = 0; i < filter.ExecutionTypeDescs.Length; i++)
+                parameters.Add(new SqlParameter($"@executionType{i}", filter.ExecutionTypeDescs[i]));
         }
 
         var sql = $@"
@@ -1051,7 +1065,8 @@ CREATE TABLE #plan_stats (
     total_physical_reads float NOT NULL,
     total_memory_pages float NOT NULL,
     total_executions bigint NOT NULL,
-    last_execution_time datetimeoffset NOT NULL
+    last_execution_time datetimeoffset NOT NULL,
+    execution_type_desc nvarchar(60) NOT NULL
 );
 INSERT INTO #plan_stats
 SELECT
@@ -1063,7 +1078,11 @@ SELECT
     SUM(rs.avg_physical_io_reads * rs.count_executions),
     SUM(rs.avg_query_max_used_memory * rs.count_executions),
     SUM(rs.count_executions),
-    MAX(rs.last_execution_time)
+    MAX(rs.last_execution_time),
+    RTRIM(CAST(SUBSTRING(MAX(
+        CONVERT(char(27), CAST(rs.last_execution_time AS datetime2(7)), 121)
+        + CAST(ISNULL(rs.execution_type_desc, '') AS char(60))
+    ), 28, 60) AS nvarchar(60)))
 FROM sys.query_store_runtime_stats AS rs
 WHERE EXISTS (SELECT 1 FROM #intervals AS i WHERE i.runtime_stats_interval_id = rs.runtime_stats_interval_id){phase2ExecutionTypeClause}
 GROUP BY rs.plan_id
@@ -1103,6 +1122,7 @@ DROP TABLE IF EXISTS #plan_hash_rows;
         SUM(ps.total_memory_pages) AS total_memory_pages,
         SUM(ps.total_executions) AS total_executions,
         MAX(ps.last_execution_time) AS last_execution_time,
+        MAX(ps.execution_type_desc) AS execution_type_desc,
         ROW_NUMBER() OVER (PARTITION BY q.query_hash ORDER BY SUM(ps.{metricCol}) DESC) AS rnum
     FROM #plan_stats ps
     JOIN sys.query_store_plan p ON ps.plan_id = p.plan_id
@@ -1121,7 +1141,8 @@ SELECT query_hash, plan_hash, module_name,
        CAST(total_physical_reads AS bigint) AS total_physical_reads,
        CAST(total_memory_pages AS bigint) AS total_memory_pages,
        total_executions,
-       last_execution_time
+       last_execution_time,
+       execution_type_desc
 INTO #plan_hash_rows
 FROM ph WHERE rnum <= 5;
 
@@ -1144,6 +1165,7 @@ FROM ph WHERE rnum <= 5;
         CAST(ps.total_memory_pages AS bigint) AS total_memory_pages,
         ps.total_executions,
         ps.last_execution_time,
+        ps.execution_type_desc,
         ROW_NUMBER() OVER (PARTITION BY q.query_hash, p.query_plan_hash ORDER BY ps.{metricCol} DESC) AS rn_top,
         ROW_NUMBER() OVER (PARTITION BY q.query_hash, p.query_plan_hash ORDER BY ps.{metricCol} ASC) AS rn_bottom
     FROM #plan_stats ps
@@ -1175,7 +1197,8 @@ r.total_physical_reads,
 r.total_memory_pages, 
 r.total_executions, 
 r.last_execution_time,
-CASE WHEN r.rn_top = 1 THEN 1 ELSE 0 END AS is_top
+CASE WHEN r.rn_top = 1 THEN 1 ELSE 0 END AS is_top,
+r.execution_type_desc
 FROM #ranked_light r
 JOIN sys.query_store_query_text qt ON r.query_text_id = qt.query_text_id
 JOIN sys.query_store_plan p ON r.plan_id = p.plan_id;
@@ -1212,6 +1235,7 @@ SELECT * FROM #plan_hash_rows ORDER BY query_hash, total_executions DESC;
                 CountExecutions = reader.GetInt64(13),
                 LastExecutedUtc = ((DateTimeOffset)reader.GetValue(14)).UtcDateTime,
                 IsTopRepresentative = reader.GetInt32(15) == 1,
+                ExecutionTypeDesc = reader.IsDBNull(16) ? "" : reader.GetString(16),
             });
         }
 
@@ -1233,14 +1257,9 @@ SELECT * FROM #plan_hash_rows ORDER BY query_hash, total_executions DESC;
                     TotalMemoryGrantPages = reader.GetInt64(8),
                     CountExecutions = reader.GetInt64(9),
                     LastExecutedUtc = ((DateTimeOffset)reader.GetValue(10)).UtcDateTime,
+                    ExecutionTypeDesc = reader.IsDBNull(11) ? "" : reader.GetString(11),
                 });
             }
-        }
-
-        if (!string.IsNullOrWhiteSpace(filter?.ExecutionTypeDesc))
-        {
-            foreach (var r in result.LeafRows) r.ExecutionTypeDesc = filter.ExecutionTypeDesc!;
-            foreach (var r in result.IntermediateRows) r.ExecutionTypeDesc = filter.ExecutionTypeDesc!;
         }
 
         return result;
@@ -1293,10 +1312,14 @@ SELECT * FROM #plan_hash_rows ORDER BY query_hash, total_executions DESC;
         }
         var filterSql = filterClauses.Count > 0 ? "\n" + string.Join("\n", filterClauses) : "";
         var phase2ExecutionTypeClause = "";
-        if (!string.IsNullOrWhiteSpace(filter?.ExecutionTypeDesc))
+        if (filter?.ExecutionTypeDescs?.Length > 0)
         {
-            phase2ExecutionTypeClause = "\nAND rs.execution_type_desc = @executionTypeDesc";
-            parameters.Add(new SqlParameter("@executionTypeDesc", filter.ExecutionTypeDesc.Trim()));
+            var etParamNames = filter.ExecutionTypeDescs
+                .Select((_, i) => $"@executionType{i}")
+                .ToList();
+            phase2ExecutionTypeClause = $"\nAND rs.execution_type_desc IN ({string.Join(", ", etParamNames)})";
+            for (var i = 0; i < filter.ExecutionTypeDescs.Length; i++)
+                parameters.Add(new SqlParameter($"@executionType{i}", filter.ExecutionTypeDescs[i]));
         }
 
         var sql = $@"
@@ -1322,7 +1345,8 @@ CREATE TABLE #plan_stats (
     total_physical_reads float NOT NULL,
     total_memory_pages float NOT NULL,
     total_executions bigint NOT NULL,
-    last_execution_time datetimeoffset NOT NULL
+    last_execution_time datetimeoffset NOT NULL,
+    execution_type_desc nvarchar(60) NOT NULL
 );
 INSERT INTO #plan_stats
 SELECT
@@ -1334,7 +1358,11 @@ SELECT
     SUM(rs.avg_physical_io_reads * rs.count_executions),
     SUM(rs.avg_query_max_used_memory * rs.count_executions),
     SUM(rs.count_executions),
-    MAX(rs.last_execution_time)
+    MAX(rs.last_execution_time),
+    RTRIM(CAST(SUBSTRING(MAX(
+        CONVERT(char(27), CAST(rs.last_execution_time AS datetime2(7)), 121)
+        + CAST(ISNULL(rs.execution_type_desc, '') AS char(60))
+    ), 28, 60) AS nvarchar(60)))
 FROM sys.query_store_runtime_stats AS rs
 WHERE EXISTS (SELECT 1 FROM #intervals AS i WHERE i.runtime_stats_interval_id = rs.runtime_stats_interval_id){phase2ExecutionTypeClause}
 GROUP BY rs.plan_id
@@ -1377,6 +1405,7 @@ DROP TABLE IF EXISTS #qhash_rows;
         SUM(ps.total_memory_pages) AS total_memory_pages,
         SUM(ps.total_executions) AS total_executions,
         MAX(ps.last_execution_time) AS last_execution_time,
+        MAX(ps.execution_type_desc) AS execution_type_desc,
         ROW_NUMBER() OVER (PARTITION BY
             CASE WHEN q.object_id <> 0
                  THEN OBJECT_SCHEMA_NAME(q.object_id) + N'.' + OBJECT_NAME(q.object_id)
@@ -1402,7 +1431,8 @@ SELECT module_name, query_hash,
        CAST(total_physical_reads AS bigint) AS total_physical_reads,
        CAST(total_memory_pages AS bigint) AS total_memory_pages,
        total_executions,
-       last_execution_time
+       last_execution_time,
+       execution_type_desc
 INTO #qhash_rows
 FROM qh WHERE rnum <= 5;
 
@@ -1425,6 +1455,7 @@ FROM qh WHERE rnum <= 5;
         CAST(ps.total_memory_pages AS bigint) AS total_memory_pages,
         ps.total_executions,
         ps.last_execution_time,
+        ps.execution_type_desc,
         ROW_NUMBER() OVER (PARTITION BY
             CASE WHEN q.object_id <> 0
                  THEN OBJECT_SCHEMA_NAME(q.object_id) + N'.' + OBJECT_NAME(q.object_id)
@@ -1468,7 +1499,8 @@ SELECT
     r.total_memory_pages, 
     r.total_executions, 
     r.last_execution_time,
-    CASE WHEN r.rn_top = 1 THEN 1 ELSE 0 END AS is_top
+    CASE WHEN r.rn_top = 1 THEN 1 ELSE 0 END AS is_top,
+    r.execution_type_desc
 FROM #ranked_light r
 JOIN sys.query_store_query_text qt ON r.query_text_id = qt.query_text_id
 JOIN sys.query_store_plan p ON r.plan_id = p.plan_id;
@@ -1505,6 +1537,7 @@ SELECT * FROM #qhash_rows ORDER BY module_name, total_executions DESC;
                 CountExecutions = reader.GetInt64(13),
                 LastExecutedUtc = ((DateTimeOffset)reader.GetValue(14)).UtcDateTime,
                 IsTopRepresentative = reader.GetInt32(15) == 1,
+                ExecutionTypeDesc = reader.IsDBNull(16) ? "" : reader.GetString(16),
             });
         }
 
@@ -1525,14 +1558,9 @@ SELECT * FROM #qhash_rows ORDER BY module_name, total_executions DESC;
                     TotalMemoryGrantPages = reader.GetInt64(7),
                     CountExecutions = reader.GetInt64(8),
                     LastExecutedUtc = ((DateTimeOffset)reader.GetValue(9)).UtcDateTime,
+                    ExecutionTypeDesc = reader.IsDBNull(10) ? "" : reader.GetString(10),
                 });
             }
-        }
-
-        if (!string.IsNullOrWhiteSpace(filter?.ExecutionTypeDesc))
-        {
-            foreach (var r in result.LeafRows) r.ExecutionTypeDesc = filter.ExecutionTypeDesc!;
-            foreach (var r in result.IntermediateRows) r.ExecutionTypeDesc = filter.ExecutionTypeDesc!;
         }
 
         return result;


### PR DESCRIPTION
## What does this PR do?

Implements #320

## Which component(s) does this affect?

- [x] Desktop App (PlanViewer.App)
- [ ] Core Library (PlanViewer.Core)
- [ ] CLI Tool (PlanViewer.Cli)
- [ ] SSMS Extension (PlanViewer.Ssms)
- [ ] Tests
- [ ] Documentation

## How was this tested?

1. Connect to Query Store
2. Choose `Execution Type` in the `Search by` combobox
3. Choose between `Regular`, `Aborted` or `Exception`
4. `Fetch` results


https://github.com/user-attachments/assets/02249aec-8d55-4bb2-9e96-6d173f75f432



## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceStudio/blob/main/CONTRIBUTING.md)
- [x] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] All tests pass (`dotnet test`)
- [x] I have not introduced any hardcoded credentials or server names
