### PR TITLE
feature - Improve navigation

### DIFF
--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
@@ -133,6 +133,7 @@
                   Background="{DynamicResource BackgroundDarkBrush}"
                   BorderThickness="0"
                   Sorting="ResultsGrid_Sorting"
+                  DoubleTapped="ResultsGrid_DoubleTapped"
                   ScrollViewer.HorizontalScrollBarVisibility="Auto">
             <DataGrid.ContextMenu>
                 <ContextMenu Opening="ContextMenu_Opening">

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using PlanViewer.Core.Interfaces;
@@ -758,6 +759,18 @@ public partial class QueryStoreGridControl : UserControl
     {
         if (sender is not Button btn) return;
         if (btn.DataContext is not QueryStoreRow row) return;
+        ToggleRowExpansion(row);
+    }
+
+    private void ResultsGrid_DoubleTapped(object? sender, TappedEventArgs e)
+    {
+        if (ResultsGrid.SelectedItem is not QueryStoreRow row) return;
+        if (!row.HasChildren) return;
+        ToggleRowExpansion(row);
+    }
+
+    private void ToggleRowExpansion(QueryStoreRow row)
+    {
         if (!row.HasChildren) return;
 
         row.IsExpanded = !row.IsExpanded;

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
@@ -5,10 +5,12 @@ using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.VisualTree;
 using Avalonia.Media;
 using PlanViewer.Core.Interfaces;
 using PlanViewer.Core.Models;
@@ -764,6 +766,9 @@ public partial class QueryStoreGridControl : UserControl
 
     private void ResultsGrid_DoubleTapped(object? sender, TappedEventArgs e)
     {
+        if (e.Source is not Visual v) return;
+        if (v.FindAncestorOfType<Button>() != null) return;
+        if (v.FindAncestorOfType<DataGridRow>() == null) return;
         if (ResultsGrid.SelectedItem is not QueryStoreRow row) return;
         if (!row.HasChildren) return;
         ToggleRowExpansion(row);

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -92,6 +92,23 @@ public partial class MainWindow : Window
                             e.Handled = true;
                         }
                         break;
+                    case Key.Tab:
+                        var tabCount = MainTabControl.Items.Count;
+                        if (tabCount > 1)
+                        {
+                            MainTabControl.SelectedIndex = (MainTabControl.SelectedIndex + 1) % tabCount;
+                            e.Handled = true;
+                        }
+                        break;
+                }
+            }
+            else if (e.KeyModifiers == (KeyModifiers.Control | KeyModifiers.Shift) && e.Key == Key.Tab)
+            {
+                var tabCount = MainTabControl.Items.Count;
+                if (tabCount > 1)
+                {
+                    MainTabControl.SelectedIndex = (MainTabControl.SelectedIndex - 1 + tabCount) % tabCount;
+                    e.Handled = true;
                 }
             }
         }, RoutingStrategies.Tunnel);

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -848,6 +848,16 @@ public partial class MainWindow : Window
         closeBtn.Tag = tab;
         closeBtn.Click += CloseTab_Click;
 
+        header.PointerPressed += (_, e) =>
+        {
+            if (e.GetCurrentPoint(null).Properties.PointerUpdateKind == PointerUpdateKind.MiddleButtonPressed)
+            {
+                MainTabControl.Items.Remove(tab);
+                UpdateEmptyOverlay();
+                e.Handled = true;
+            }
+        };
+
         // Right-click context menu
         var copyPathItem = new MenuItem { Header = "Copy Path", Tag = tab };
         // Only visible when tab content has a file path

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -841,6 +841,7 @@ public partial class MainWindow : Window
         var header = new StackPanel
         {
             Orientation = Orientation.Horizontal,
+            Background = Brushes.Transparent,
             Children = { headerText, closeBtn }
         };
 


### PR DESCRIPTION
## What does this PR do?

Implements #322 

## Which component(s) does this affect?

- [x] Desktop App (PlanViewer.App)
- [ ] Core Library (PlanViewer.Core)
- [ ] CLI Tool (PlanViewer.Cli)
- [ ] SSMS Extension (PlanViewer.Ssms)
- [ ] Tests
- [ ] Documentation

## How was this tested?

### Tab navigation
1. Open multiple tabs with "CTRL + N"
2. Use "CTRL + TAB" and "CTRL + SHIFT + TAB" to navigate through the tabs.

### Close tabs with mouse wheel click
1. Open multiple tabs with "CTRL + N"
2. Use the mouse wheel to click on the tab text and see them closing.

### Expand/collapse grouped rows on Query Store grid
1. Open query store 
2. Double-click on a row to expand.
3. Double-click again to collapse.

## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceStudio/blob/main/CONTRIBUTING.md)
- [x] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] All tests pass (`dotnet test`)
- [x] I have not introduced any hardcoded credentials or server names
