### PR TITLE
Fix two post-split UX issues (schema lookup on Run Repro, toolbar overflow)

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml
@@ -8,7 +8,19 @@
         <Border Grid.Row="0" Background="{DynamicResource BackgroundDarkBrush}" Padding="8,6"
                 BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,0,1">
             <DockPanel>
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" Spacing="4">
+                <TextBlock x:Name="StatusText" DockPanel.Dock="Right"
+                           HorizontalAlignment="Right" VerticalAlignment="Center"
+                           FontSize="11" Foreground="{DynamicResource ForegroundBrush}"
+                           TextTrimming="CharacterEllipsis" Margin="8,0,0,0"/>
+                <WrapPanel Orientation="Horizontal">
+                    <WrapPanel.Styles>
+                        <Style Selector="Button">
+                            <Setter Property="Margin" Value="0,2,4,2"/>
+                        </Style>
+                        <Style Selector="ComboBox">
+                            <Setter Property="Margin" Value="0,2,4,2"/>
+                        </Style>
+                    </WrapPanel.Styles>
                     <Button x:Name="ConnectButton" Content="Connect" Click="Connect_Click"
                             Height="28" Padding="8,0" FontSize="12"
                             Theme="{StaticResource AppButton}"
@@ -84,11 +96,7 @@
                             Height="28" Padding="10,0" FontSize="12"
                             Theme="{StaticResource AppButton}"
                             ToolTip.Tip="Configure SQL formatting options"/>
-                </StackPanel>
-                <TextBlock x:Name="StatusText" DockPanel.Dock="Right"
-                           HorizontalAlignment="Right" VerticalAlignment="Center"
-                           FontSize="11" Foreground="{DynamicResource ForegroundBrush}"
-                           TextTrimming="CharacterEllipsis"/>
+                </WrapPanel>
             </DockPanel>
         </Border>
 

--- a/src/PlanViewer.App/MainWindow.PlanViewer.cs
+++ b/src/PlanViewer.App/MainWindow.PlanViewer.cs
@@ -489,6 +489,12 @@ public partial class MainWindow : Window
             // Replace loading content with the actual plan
             var actualViewer = new PlanViewerControl();
             actualViewer.Metadata = metadata;
+            // Inherit the connection used to run the repro so schema lookups
+            // (Show Indexes, Show Table Definition) remain available on the
+            // new plan tab.
+            actualViewer.ConnectionString = connectionString;
+            actualViewer.SetConnectionServices(_credentialService, _connectionStore);
+            actualViewer.SetConnectionStatus(dialog.ResultConnection.ServerName, database);
             actualViewer.LoadPlan(actualPlanXml, "Actual Plan", queryText);
 
             tab.Content = CreatePlanTabContent(actualViewer);


### PR DESCRIPTION
## Summary
Two pre-existing UX bugs surfaced during smoke-testing of the god-file split PRs (#327–#334). Neither was caused by the move-only refactor — they were latent in the original code.

1. **Schema lookups greyed out after Run Repro from a file-loaded plan.** When you File → Open an estimated plan and click **Run Repro**, the resulting actual-plan tab had **Show Indexes / Show Table Definition** disabled on the node context menu. The freshly-created `PlanViewerControl` wasn't given the connection used to run the repro. Now it inherits `ConnectionString` + `SetConnectionServices` + `SetConnectionStatus`, matching the query-editor Run Repro path (which already did this).

2. **QuerySessionControl toolbar overflowed off-screen on narrow windows.** The Format / Format Options buttons (and more, on a sufficiently narrow window) were cut off and unreachable. Switched the toolbar from a single-row `StackPanel` to a `WrapPanel` so buttons wrap to a second row instead of being clipped.

## Test plan
- [x] `dotnet build PlanViewer.sln` — 0 errors
- [x] File → Open estimated plan → Run Repro → right-click a scan node → Show Indexes / Show Table Definition are **enabled**
- [x] Narrow the window — toolbar buttons wrap to a second row, all remain clickable
- [ ] Query-editor Run Repro path still works (unchanged, but worth a sanity check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)