### PR TITLE
Add proxy support for "Check for Updates" (#314)

### DIFF
--- a/src/PlanViewer.App/AboutWindow.axaml
+++ b/src/PlanViewer.App/AboutWindow.axaml
@@ -2,7 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="PlanViewer.App.AboutWindow"
         Title="About Performance Studio"
-        Width="450" Height="500"
+        Width="480" Height="640"
         CanResize="False"
         WindowStartupLocation="CenterOwner"
         Icon="avares://PlanViewer.App/EDD.ico"
@@ -47,14 +47,22 @@
             <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,6,0,0">
                 <Button x:Name="CheckUpdateButton" Content="Check for Updates"
                         Click="CheckUpdate_Click" Padding="10,4" FontSize="12"/>
-                <TextBlock x:Name="UpdateStatusText" FontSize="12" VerticalAlignment="Center"
-                           Foreground="{DynamicResource ForegroundBrush}"/>
                 <TextBlock x:Name="UpdateLink" FontSize="12" VerticalAlignment="Center"
                            Foreground="{DynamicResource AccentBrush}"
                            Cursor="Hand" IsVisible="False"
                            TextDecorations="Underline"
                            PointerPressed="UpdateLink_Click"/>
             </StackPanel>
+            <TextBlock x:Name="UpdateStatusText" FontSize="12"
+                       Foreground="{DynamicResource ForegroundBrush}"
+                       TextWrapping="Wrap" Margin="0,4,0,0"/>
+            <TextBlock x:Name="ReleasesPageLink" FontSize="12"
+                       Foreground="{DynamicResource AccentBrush}"
+                       Cursor="Hand" IsVisible="False"
+                       Text="Open the releases page in your browser"
+                       TextDecorations="Underline"
+                       PointerPressed="ReleasesPageLink_Click"
+                       Margin="0,4,0,0"/>
         </StackPanel>
 
         <!-- MCP Settings -->
@@ -80,6 +88,42 @@
                 <TextBlock x:Name="McpCopyStatus" FontSize="11" VerticalAlignment="Center"
                            Foreground="{DynamicResource ForegroundBrush}"/>
             </StackPanel>
+
+            <!-- Proxy Settings -->
+            <TextBlock Text="Proxy" FontWeight="SemiBold" FontSize="12"
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,16,0,4"/>
+            <StackPanel Orientation="Horizontal" Spacing="12">
+                <RadioButton x:Name="ProxySystemRadio" GroupName="ProxyMode"
+                             Content="Use system proxy (Windows credentials)"
+                             FontSize="12" IsChecked="True"
+                             Foreground="{DynamicResource ForegroundBrush}"/>
+                <RadioButton x:Name="ProxyManualRadio" GroupName="ProxyMode"
+                             Content="Manual"
+                             FontSize="12"
+                             Foreground="{DynamicResource ForegroundBrush}"/>
+            </StackPanel>
+            <Grid x:Name="ProxyManualPanel" IsVisible="False"
+                  ColumnDefinitions="90,*" RowDefinitions="Auto,Auto,Auto"
+                  Margin="0,8,0,0" RowSpacing="6" ColumnSpacing="8">
+                <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" FontSize="12"
+                           VerticalAlignment="Center"
+                           Foreground="{DynamicResource ForegroundBrush}"/>
+                <TextBox Grid.Row="0" Grid.Column="1" x:Name="ProxyAddressInput"
+                         Watermark="http://proxy.example.com:8080" FontSize="12"
+                         Padding="6,2" Height="28"/>
+                <TextBlock Grid.Row="1" Grid.Column="0" Text="Username:" FontSize="12"
+                           VerticalAlignment="Center"
+                           Foreground="{DynamicResource ForegroundBrush}"/>
+                <TextBox Grid.Row="1" Grid.Column="1" x:Name="ProxyUsernameInput"
+                         Watermark="DOMAIN\user" FontSize="12"
+                         Padding="6,2" Height="28"/>
+                <TextBlock Grid.Row="2" Grid.Column="0" Text="Password:" FontSize="12"
+                           VerticalAlignment="Center"
+                           Foreground="{DynamicResource ForegroundBrush}"/>
+                <TextBox Grid.Row="2" Grid.Column="1" x:Name="ProxyPasswordInput"
+                         PasswordChar="•" FontSize="12"
+                         Padding="6,2" Height="28"/>
+            </Grid>
         </StackPanel>
 
         <!-- Close -->

--- a/src/PlanViewer.App/AboutWindow.axaml.cs
+++ b/src/PlanViewer.App/AboutWindow.axaml.cs
@@ -6,10 +6,8 @@
 
 using System;
 using System.Diagnostics;
-using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text.Json;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
@@ -25,6 +23,7 @@ public partial class AboutWindow : Window
     private const string GitHubUrl = "https://github.com/erikdarlingdata/PerformanceStudio";
     private const string IssuesUrl = "https://github.com/erikdarlingdata/PerformanceStudio/issues";
     private const string DarlingDataUrl = "https://www.erikdarling.com";
+    private const string ReleasesUrl = "https://github.com/erikdarlingdata/PerformanceStudio/releases/latest";
 
     public AboutWindow()
     {
@@ -34,29 +33,75 @@ public partial class AboutWindow : Window
             VersionText.Text = $"Version {version.Major}.{version.Minor}.{version.Build}";
 
         // Load current MCP settings
-        var settings = McpSettings.Load();
-        McpEnabledCheckBox.IsChecked = settings.Enabled;
-        McpPortInput.Text = settings.Port.ToString();
+        var mcp = McpSettings.Load();
+        McpEnabledCheckBox.IsChecked = mcp.Enabled;
+        McpPortInput.Text = mcp.Port.ToString();
 
         // Save on change
         McpEnabledCheckBox.IsCheckedChanged += (_, _) => SaveMcpSettings();
         McpPortInput.LostFocus += (_, _) => SaveMcpSettings();
+
+        // Load proxy settings. The password is intentionally NOT round-tripped
+        // through the UI — TextBox.PasswordChar only masks the glyph, the cleartext
+        // still lives in the visual/accessibility tree. We surface "(saved — leave
+        // blank to keep)" via the watermark instead, and only update the credential
+        // when the user types a new value.
+        var proxy = ProxySettings.Load();
+        _hasStoredProxyPassword = !string.IsNullOrEmpty(proxy.Password);
+        ProxySystemRadio.IsChecked = proxy.Mode == ProxyMode.System;
+        ProxyManualRadio.IsChecked = proxy.Mode == ProxyMode.Manual;
+        ProxyAddressInput.Text = proxy.Address;
+        ProxyUsernameInput.Text = proxy.Username;
+        ProxyPasswordInput.Watermark = _hasStoredProxyPassword
+            ? "(saved — leave blank to keep)"
+            : "";
+        ProxyManualPanel.IsVisible = proxy.Mode == ProxyMode.Manual;
+
+        // Both radios fire IsCheckedChanged on every selection (one going false,
+        // one going true). Only the now-checked one should drive the save —
+        // otherwise the credential write races itself.
+        void OnProxyRadioChanged(object? sender, RoutedEventArgs _)
+        {
+            if (sender is RadioButton rb && rb.IsChecked == true)
+            {
+                ProxyManualPanel.IsVisible = ProxyManualRadio.IsChecked == true;
+                SaveProxySettings();
+            }
+        }
+        ProxySystemRadio.IsCheckedChanged += OnProxyRadioChanged;
+        ProxyManualRadio.IsCheckedChanged += OnProxyRadioChanged;
+        ProxyAddressInput.LostFocus += (_, _) => SaveProxySettings();
+        ProxyUsernameInput.LostFocus += (_, _) => SaveProxySettings();
+        ProxyPasswordInput.LostFocus += (_, _) => SaveProxySettings();
     }
+
+    private bool _hasStoredProxyPassword;
 
     private void SaveMcpSettings()
     {
-        var settingsDir = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".planview");
-        var settingsFile = Path.Combine(settingsDir, "settings.json");
-
-        var json = JsonSerializer.Serialize(new
+        Services.SettingsFile.Update(o =>
         {
-            mcp_enabled = McpEnabledCheckBox.IsChecked == true,
-            mcp_port = int.TryParse(McpPortInput.Text, out var p) && p >= 1024 && p <= 65535 ? p : 5152
-        }, new JsonSerializerOptions { WriteIndented = true });
+            o["mcp_enabled"] = McpEnabledCheckBox.IsChecked == true;
+            o["mcp_port"] = int.TryParse(McpPortInput.Text, out var p) && p >= 1024 && p <= 65535 ? p : 5152;
+        });
+    }
 
-        Directory.CreateDirectory(settingsDir);
-        Services.AtomicFile.WriteAllText(settingsFile, json);
+    private void SaveProxySettings()
+    {
+        var typedPassword = ProxyPasswordInput.Text ?? "";
+        var settings = new ProxySettings
+        {
+            Mode = ProxyManualRadio.IsChecked == true ? ProxyMode.Manual : ProxyMode.System,
+            Address = ProxyAddressInput.Text ?? "",
+            Username = ProxyUsernameInput.Text ?? "",
+            Password = typedPassword
+        };
+        // Empty textbox + an existing stored password means "keep what's there".
+        // Save() signals "leave the credential alone" with TouchCredential=false.
+        settings.TouchCredential = !(typedPassword.Length == 0 && _hasStoredProxyPassword);
+        settings.Save();
+        if (settings.TouchCredential)
+            _hasStoredProxyPassword = !string.IsNullOrEmpty(typedPassword);
     }
 
     private void GitHubLink_Click(object? sender, PointerPressedEventArgs e) => OpenUrl(GitHubUrl);
@@ -83,15 +128,20 @@ public partial class AboutWindow : Window
         CheckUpdateButton.IsEnabled = false;
         UpdateStatusText.Text = "Checking...";
         UpdateLink.IsVisible = false;
+        ReleasesPageLink.IsVisible = false;
 
-        // Try Velopack first (Windows only, supports download + apply)
+        // Try Velopack first (Windows only, supports download + apply). The custom
+        // downloader routes through the user's proxy + Windows credentials so this
+        // works on corporate networks (issue #314).
+        string? velopackError = null;
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             try
             {
                 _velopackMgr = new UpdateManager(
                     new Velopack.Sources.GithubSource(
-                        "https://github.com/erikdarlingdata/PerformanceStudio", null, false));
+                        "https://github.com/erikdarlingdata/PerformanceStudio",
+                        null, false, new ProxyAwareDownloader()));
 
                 _velopackUpdate = await _velopackMgr.CheckForUpdatesAsync();
                 if (_velopackUpdate != null)
@@ -103,9 +153,12 @@ public partial class AboutWindow : Window
                     return;
                 }
             }
-            catch
+            catch (Exception ex)
             {
-                // Velopack packages may not exist yet — fall through
+                // Velopack packages may not exist yet — fall through to API check.
+                // Hold onto the message in case the API check also fails (issue #314
+                // is exactly the case where the auth error here is the useful one).
+                velopackError = ex.Message;
             }
         }
 
@@ -115,7 +168,10 @@ public partial class AboutWindow : Window
 
         if (result.Error != null)
         {
-            UpdateStatusText.Text = $"Error: {result.Error}";
+            UpdateStatusText.Text = velopackError != null && velopackError != result.Error
+                ? $"Error: {result.Error} (installer check also failed: {velopackError})"
+                : $"Error: {result.Error}";
+            ReleasesPageLink.IsVisible = true;
         }
         else if (result.UpdateAvailable)
         {
@@ -131,6 +187,8 @@ public partial class AboutWindow : Window
 
         CheckUpdateButton.IsEnabled = true;
     }
+
+    private void ReleasesPageLink_Click(object? sender, PointerPressedEventArgs e) => OpenUrl(ReleasesUrl);
 
     private bool _updateDownloaded;
 
@@ -201,6 +259,7 @@ public partial class AboutWindow : Window
             {
                 UpdateStatusText.Text = $"Update failed: {ex.Message}";
                 UpdateLink.IsVisible = false;
+                ReleasesPageLink.IsVisible = true;
             }
             return;
         }

--- a/src/PlanViewer.App/Services/ProxyAwareDownloader.cs
+++ b/src/PlanViewer.App/Services/ProxyAwareDownloader.cs
@@ -1,0 +1,22 @@
+using System.Net.Http;
+using Velopack.Sources;
+
+namespace PlanViewer.App.Services;
+
+/// <summary>
+/// Velopack downloader that routes through the user-configured proxy. The default
+/// <see cref="HttpClientFileDownloader"/> creates a vanilla <see cref="HttpClientHandler"/>
+/// whose proxy never sees Windows credentials, which breaks "Check for Updates" on
+/// most corporate networks (GitHub issue #314).
+/// </summary>
+internal sealed class ProxyAwareDownloader : HttpClientFileDownloader
+{
+    // Snapshot at construction so a long-running Velopack flow (retries, redirects,
+    // delta + full downloads) doesn't keep re-reading the credential manager.
+    private readonly ProxySettings _settings = ProxySettings.Load();
+
+    protected override HttpClientHandler CreateHttpClientHandler()
+    {
+        return ProxyHttpHandlerFactory.Create(_settings);
+    }
+}

--- a/src/PlanViewer.App/Services/ProxyHttpHandlerFactory.cs
+++ b/src/PlanViewer.App/Services/ProxyHttpHandlerFactory.cs
@@ -1,0 +1,53 @@
+using System.Net;
+using System.Net.Http;
+
+namespace PlanViewer.App.Services;
+
+/// <summary>
+/// Builds an <see cref="HttpClientHandler"/> configured from <see cref="ProxySettings"/>.
+/// Centralised so the update check and the Velopack downloader share one source of truth.
+/// </summary>
+internal static class ProxyHttpHandlerFactory
+{
+    public static HttpClientHandler Create(ProxySettings settings)
+    {
+        var handler = new HttpClientHandler
+        {
+            AllowAutoRedirect = true,
+            MaxAutomaticRedirections = 10,
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+        };
+
+        if (settings.Mode == ProxyMode.Manual && !string.IsNullOrWhiteSpace(settings.Address))
+        {
+            var proxy = new WebProxy(settings.Address);
+            proxy.Credentials = string.IsNullOrEmpty(settings.Username)
+                ? CredentialCache.DefaultNetworkCredentials
+                : new NetworkCredential(settings.Username, settings.Password);
+
+            handler.UseProxy = true;
+            handler.Proxy = proxy;
+            handler.PreAuthenticate = true;
+        }
+        else
+        {
+            // System / auto-discovered proxy — most corporate setups need default
+            // Windows credentials sent for NTLM/Negotiate. This is the cheap fix
+            // that solves auto-detected proxies without any UI.
+            handler.UseProxy = true;
+            try
+            {
+                handler.Proxy = WebRequest.GetSystemWebProxy();
+            }
+            catch
+            {
+                // GetSystemWebProxy can throw on some Linux configs — fall back to
+                // HttpClient's default proxy resolution.
+            }
+            handler.DefaultProxyCredentials = CredentialCache.DefaultNetworkCredentials;
+            handler.PreAuthenticate = true;
+        }
+
+        return handler;
+    }
+}

--- a/src/PlanViewer.App/Services/ProxySettings.cs
+++ b/src/PlanViewer.App/Services/ProxySettings.cs
@@ -1,0 +1,81 @@
+using System;
+using PlanViewer.Core.Services;
+
+namespace PlanViewer.App.Services;
+
+internal enum ProxyMode
+{
+    System,
+    Manual
+}
+
+internal sealed class ProxySettings
+{
+    private const string CredentialServerId = "__proxy__";
+
+    public ProxyMode Mode { get; set; } = ProxyMode.System;
+    public string Address { get; set; } = "";
+    public string Username { get; set; } = "";
+    public string Password { get; set; } = "";
+
+    /// <summary>
+    /// When false, <see cref="Save"/> writes the JSON fields but leaves the stored
+    /// credential untouched. Used by the UI to support "leave blank to keep" — the
+    /// user shouldn't have to retype the password every time they change a non-secret
+    /// field like the proxy address.
+    /// </summary>
+    public bool TouchCredential { get; set; } = true;
+
+    public static ProxySettings Load()
+    {
+        var obj = SettingsFile.Read();
+        var s = new ProxySettings();
+
+        if (obj["proxy_mode"]?.GetValue<string>() is { } modeStr &&
+            Enum.TryParse<ProxyMode>(modeStr, ignoreCase: true, out var mode))
+        {
+            s.Mode = mode;
+        }
+        s.Address = obj["proxy_address"]?.GetValue<string>() ?? "";
+        s.Username = obj["proxy_username"]?.GetValue<string>() ?? "";
+
+        try
+        {
+            var cred = CredentialServiceFactory.Create().GetCredential(CredentialServerId);
+            if (cred.HasValue)
+                s.Password = cred.Value.Password;
+        }
+        catch
+        {
+            // Credential store unavailable — leave password empty.
+        }
+
+        return s;
+    }
+
+    public void Save()
+    {
+        SettingsFile.Update(o =>
+        {
+            o["proxy_mode"] = Mode.ToString().ToLowerInvariant();
+            o["proxy_address"] = Address;
+            o["proxy_username"] = Username;
+        });
+
+        if (!TouchCredential)
+            return;
+
+        try
+        {
+            var svc = CredentialServiceFactory.Create();
+            if (string.IsNullOrEmpty(Password))
+                svc.DeleteCredential(CredentialServerId);
+            else
+                svc.SaveCredential(CredentialServerId, Username, Password);
+        }
+        catch
+        {
+            // Credential store unavailable — password not persisted.
+        }
+    }
+}

--- a/src/PlanViewer.App/Services/SettingsFile.cs
+++ b/src/PlanViewer.App/Services/SettingsFile.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace PlanViewer.App.Services;
+
+internal static class SettingsFile
+{
+    public static string Path { get; } = System.IO.Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        ".planview", "settings.json");
+
+    public static JsonObject Read()
+    {
+        if (!File.Exists(Path))
+            return new JsonObject();
+
+        try
+        {
+            var json = File.ReadAllText(Path);
+            return JsonNode.Parse(json) as JsonObject ?? new JsonObject();
+        }
+        catch
+        {
+            return new JsonObject();
+        }
+    }
+
+    public static void Update(Action<JsonObject> mutate)
+    {
+        var obj = Read();
+        mutate(obj);
+        Directory.CreateDirectory(System.IO.Path.GetDirectoryName(Path)!);
+        var json = obj.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+        AtomicFile.WriteAllText(Path, json);
+    }
+}

--- a/src/PlanViewer.App/Services/UpdateChecker.cs
+++ b/src/PlanViewer.App/Services/UpdateChecker.cs
@@ -12,21 +12,21 @@ public static class UpdateChecker
     private const string ReleasesApiUrl =
         "https://api.github.com/repos/erikdarlingdata/PerformanceStudio/releases/latest";
 
-    private static readonly HttpClient Http = new()
-    {
-        DefaultRequestHeaders =
-        {
-            { "User-Agent", "PerformanceStudio-UpdateCheck" },
-            { "Accept", "application/vnd.github+json" }
-        },
-        Timeout = TimeSpan.FromSeconds(10)
-    };
-
     public static async Task<UpdateCheckResult> CheckAsync(Version currentVersion)
     {
+        // Build a fresh client per call so proxy-setting changes take effect without
+        // requiring an app restart. The check is rare and the handler is cheap.
+        using var handler = ProxyHttpHandlerFactory.Create(ProxySettings.Load());
+        using var http = new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromSeconds(10)
+        };
+        http.DefaultRequestHeaders.Add("User-Agent", "PerformanceStudio-UpdateCheck");
+        http.DefaultRequestHeaders.Add("Accept", "application/vnd.github+json");
+
         try
         {
-            var json = await Http.GetStringAsync(ReleasesApiUrl);
+            var json = await http.GetStringAsync(ReleasesApiUrl);
             using var doc = JsonDocument.Parse(json);
             var root = doc.RootElement;
 


### PR DESCRIPTION
## Summary

Fixes #314. James reported that "Check for Updates" fails behind a corporate proxy because neither Velopack nor the HttpClient fallback was sending Windows credentials to the proxy.

In his follow-up he confirmed his proxy is auto-discovered for most apps but SSMS 25 needed manual address + on-prem AD user/pass, so both modes are wired:

- **System (default)** — system-discovered proxy + Windows default credentials. Solves the auto-detect / NTLM / Negotiate case with no UI.
- **Manual** — proxy address + optional username/password (stored via the existing `ICredentialService`, i.e. Windows Credential Manager / macOS Keychain).

Both update paths go through the same `ProxyHttpHandlerFactory`:
- `UpdateChecker` (GitHub API fallback) builds its `HttpClient` from it.
- `ProxyAwareDownloader` overrides `HttpClientFileDownloader.CreateHttpClientHandler` and is passed as the 4th arg to `Velopack.Sources.GithubSource`.

Also addresses the UX items James asked for:
- The error text is wrapped (was being truncated)
- "Open the releases page in your browser" link appears when the check fails, so the user can update manually

A few rough edges fixed along the way:
- `SettingsFile.Update` is merge-safe — MCP and proxy saves no longer stomp each other
- Password is never round-tripped through the UI (TextBox.PasswordChar only masks the glyph; the cleartext would still live in the visual/accessibility tree). Watermark shows "(saved — leave blank to keep)".
- Velopack errors used to be silently swallowed before the fallback API check — which hid the actual #314 error. Now surfaced if both checks fail.

## Test plan

- [ ] Default install on a non-proxy machine: Check for Updates works (System mode, no proxy in play)
- [ ] @jamesrudolph behind his corporate proxy: System mode works without entering any credentials
- [ ] Manual mode with proxy address + AD username/password works (the SSMS 25 case)
- [ ] After typing a password and saving, re-opening About shows watermark and does not re-prompt
- [ ] If both Velopack and the GitHub API check fail, error text wraps and "Open releases page" link appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)