### PR TITLE
Upgrade to .NET 10 and refresh NuGet packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Setup .NET 8.0
+      - name: Setup .NET 10.0
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
           cache: true
           cache-dependency-path: '**/*.csproj'
 

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -29,10 +29,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Setup .NET 8.0
+      - name: Setup .NET 10.0
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Install WASM workload
         run: dotnet workload install wasm-tools

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,10 +42,10 @@ jobs:
         with:
           ref: dev
 
-      - name: Setup .NET 8.0
+      - name: Setup .NET 10.0
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Set nightly version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,10 @@ jobs:
         run: |
           gh release create "v${{ steps.version.outputs.VERSION }}" --title "v${{ steps.version.outputs.VERSION }}" --generate-notes --target main
 
-      - name: Setup .NET 8.0
+      - name: Setup .NET 10.0
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Build and test
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thank you for your interest in contributing to Performance Studio! This guide wi
 
 ### Prerequisites
 
-- [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
 - Git
 
 ### Build and Test

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Each warning includes severity (Info, Warning, or Critical), the operator node I
 
 ## Prerequisites
 
-- [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) (required to build and run)
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) (required to build and run)
 - SQL Server instance (optional — only needed for live plan capture; file analysis works without one)
 - Docker (optional — macOS/Linux users can run SQL Server locally via Docker)
 

--- a/server/PlanShare/PlanShare.csproj
+++ b/server/PlanShare/PlanShare.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>EDD.ico</ApplicationIcon>
@@ -24,8 +24,8 @@
     <PackageReference Include="AvaloniaEdit.TextMate" Version="11.4.1" />
     <PackageReference Include="AvaloniaEdit.TextMate.Grammars" Version="0.10.12" />
     <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="1.7.18" />
-    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
     <PackageReference Include="TextMateSharp.Grammars" Version="2.0.3" />
     <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="180.6.0" />
     <PackageReference Include="Velopack" Version="0.0.1298" />

--- a/src/PlanViewer.Cli/Commands/CredentialCommand.cs
+++ b/src/PlanViewer.Cli/Commands/CredentialCommand.cs
@@ -91,7 +91,7 @@ public static class CredentialCommand
         {
             IReadOnlyList<(string ServerName, string Username)>? creds = null;
             // CA1416: WindowsCredentialService is gated on OperatingSystem.IsWindows().
-            // .NET 8 won't run below Windows 10, so the underlying "windows5.1.2600" requirement is always met.
+            // .NET 10 won't run below Windows 10, so the underlying "windows5.1.2600" requirement is always met.
 #pragma warning disable CA1416
             if (OperatingSystem.IsWindows() && credentialService is WindowsCredentialService win)
                 creds = win.ListAll();

--- a/src/PlanViewer.Cli/PlanViewer.Cli.csproj
+++ b/src/PlanViewer.Cli/PlanViewer.Cli.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>PlanViewer.Cli</RootNamespace>

--- a/src/PlanViewer.Core/PlanViewer.Core.csproj
+++ b/src/PlanViewer.Core/PlanViewer.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>PlanViewer.Core</RootNamespace>

--- a/src/PlanViewer.Core/Services/CredentialServiceFactory.cs
+++ b/src/PlanViewer.Core/Services/CredentialServiceFactory.cs
@@ -7,7 +7,7 @@ public static class CredentialServiceFactory
     public static ICredentialService Create()
     {
         // CA1416: the underlying CredentialManager API declares "windows5.1.2600" (XP+);
-        // .NET 8 won't run on anything below Windows 10, so OperatingSystem.IsWindows() is sufficient.
+        // .NET 10 won't run on anything below Windows 10, so OperatingSystem.IsWindows() is sufficient.
 #pragma warning disable CA1416
         if (OperatingSystem.IsWindows())
             return new WindowsCredentialService();

--- a/src/PlanViewer.Web/PlanViewer.Web.csproj
+++ b/src/PlanViewer.Web/PlanViewer.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>PlanViewer.Web</RootNamespace>
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.12" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.12" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- Linked files from PlanViewer.Core — analysis pipeline only, no SqlClient/WASM-incompatible deps -->

--- a/tests/PlanViewer.Core.Tests/PlanTestHelper.cs
+++ b/tests/PlanViewer.Core.Tests/PlanTestHelper.cs
@@ -96,7 +96,7 @@ public static class PlanTestHelper
     /// </summary>
     public static ParsedPlan? LoadFromInternal(string planFileName)
     {
-        // Walk up from bin/Debug/net8.0 to find the repo root
+        // Walk up from bin/Debug/net10.0 to find the repo root
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
         while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, ".internal")))
             dir = dir.Parent;

--- a/tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj
+++ b/tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Bumps `TargetFramework` from `net8.0` to `net10.0` across all SDK-style projects (App, Core, Cli, Web, PlanShare, Tests). The SSMS extension and its installer stay on `net472` — VS extensions still require .NET Framework.
- NuGet refresh: `ModelContextProtocol` 1.2.0 → 1.3.0, `Microsoft.NET.Test.Sdk` 18.4.0 → 18.5.1, `Microsoft.AspNetCore.Components.WebAssembly` (+ DevServer) 8.0.12 → 10.0.0.
- CI workflows (`ci`, `nightly`, `release`, `deploy-web`) bumped to `dotnet-version: 10.0.x`.
- README, CONTRIBUTING, and three `.NET 8` source comments updated to `.NET 10`.

Mirrors the same .NET 10 upgrade exercise just completed on PerformanceMonitor. .NET 8 reaches end of support soon.

## Test plan
- [x] `dotnet build PlanViewer.sln -c Release` — succeeds (6 pre-existing Avalonia 11.4 obsolescence warnings about `DragEventArgs.Data` / `DataFormats.Files`, unrelated to the framework bump)
- [x] `dotnet build server/PlanShare/PlanShare.csproj -c Release` — clean
- [x] `dotnet test tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj -c Release` — 77/77 passing on `net10.0`
- [x] Smoke-launched `PlanViewer.App.exe` from `bin/Debug/net10.0/` locally — opened cleanly
- [ ] CI green on GitHub Actions