### PR TITLE
Clean up two warnings from PR #336

### DIFF
--- a/src/PlanViewer.App/Controls/QueryStoreHistoryControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreHistoryControl.axaml.cs
@@ -47,7 +47,6 @@ public partial class QueryStoreHistoryControl : UserControl
 
 	// Legend state
 	private bool _legendExpanded;
-	private bool _suppressGridSelectionEvent;
 	private bool _isLoadingPlan;
 	private string _dataSummaryText = "";
 
@@ -793,7 +792,7 @@ public partial class QueryStoreHistoryControl : UserControl
 		// (which would wipe sort state and scroll position)
 		foreach (var row in HistoryDataGrid.GetVisualDescendants().OfType<DataGridRow>())
 		{
-			var idx = row.GetIndex();
+			var idx = row.Index;
 			row.Background = _selectedRowIndices.Contains(idx)
 				? new SolidColorBrush(Avalonia.Media.Color.FromArgb(60, 79, 195, 247))
 				: Brushes.Transparent;
@@ -829,8 +828,6 @@ public partial class QueryStoreHistoryControl : UserControl
 
 	private void HistoryDataGrid_SelectionChanged(object? sender, SelectionChangedEventArgs e)
 	{
-		if (_suppressGridSelectionEvent) return;
-
 		_selectedRowIndices.Clear();
 		if (HistoryDataGrid.SelectedItems != null)
 		{


### PR DESCRIPTION
## Summary
- Replace deprecated `DataGridRow.GetIndex()` with the `Index` property in `QueryStoreHistoryControl.HighlightGridRows`
- Remove dead `_suppressGridSelectionEvent` field — the suppression was only needed for the old `ItemsSource`-reset highlight path that was refactored away during PR #336 review

Pure cleanup; no behavior change.

## Test plan
- [x] `dotnet build -c Debug` produces 0 warnings for `QueryStoreHistoryControl.axaml.cs`
- [x] Query Store history viewer still highlights grid rows on chart click / box-select
- [x] Grid row click still highlights chart dots (path through `HistoryDataGrid_SelectionChanged`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)