### PR TITLE
Fix check-version bootstrap for v1.11.0 release

### DIFF
--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -16,9 +16,14 @@ jobs:
         id: pr
         shell: pwsh
         run: |
-          $version = ([xml](Get-Content src/Directory.Build.props)).Project.PropertyGroup.Version | Where-Object { $_ }
+          # Prefer Directory.Build.props; fall back to App.csproj for branches that
+          # predate the version-unification refactor (PR #315).
+          $ddb = 'src/Directory.Build.props'
+          $app = 'src/PlanViewer.App/PlanViewer.App.csproj'
+          $path = if (Test-Path $ddb) { $ddb } else { $app }
+          $version = ([xml](Get-Content $path)).Project.PropertyGroup.Version | Where-Object { $_ }
           echo "VERSION=$version" >> $env:GITHUB_OUTPUT
-          Write-Host "PR version: $version"
+          Write-Host "PR version: $version (from $path)"
 
       - name: Checkout main
         uses: actions/checkout@v5
@@ -30,9 +35,12 @@ jobs:
         id: main
         shell: pwsh
         run: |
-          $version = ([xml](Get-Content main-branch/src/Directory.Build.props)).Project.PropertyGroup.Version | Where-Object { $_ }
+          $ddb = 'main-branch/src/Directory.Build.props'
+          $app = 'main-branch/src/PlanViewer.App/PlanViewer.App.csproj'
+          $path = if (Test-Path $ddb) { $ddb } else { $app }
+          $version = ([xml](Get-Content $path)).Project.PropertyGroup.Version | Where-Object { $_ }
           echo "VERSION=$version" >> $env:GITHUB_OUTPUT
-          Write-Host "Main version: $version"
+          Write-Host "Main version: $version (from $path)"
 
       - name: Compare versions
         env:
@@ -42,7 +50,7 @@ jobs:
           echo "Main version: $MAIN_VERSION"
           echo "PR version:   $PR_VERSION"
           if [ "$PR_VERSION" == "$MAIN_VERSION" ]; then
-            echo "::error::Version in PlanViewer.App.csproj ($PR_VERSION) has not changed from main. Bump the version before merging to main."
+            echo "::error::Version ($PR_VERSION) has not changed from main. Bump the version before merging to main."
             exit 1
           fi
           echo "✅ Version bumped: $MAIN_VERSION → $PR_VERSION"


### PR DESCRIPTION
## Summary

The v1.11.0 release PR (#341) fails the `check-version` workflow because main doesn't have `src/Directory.Build.props` yet — PR #315 (which introduced it) landed on dev *after* v1.10.0 was tagged.

Adds a `Test-Path` fallback so the workflow reads `Directory.Build.props` if present, else `App.csproj`. Becomes dead code once #341 lands on main, but kept defensively.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, #341's `check-version` re-runs against dev's updated workflow and passes (`Main version: 1.10.0` from App.csproj fallback vs `PR version: 1.11.0` from Directory.Build.props)

🤖 Generated with [Claude Code](https://claude.com/claude-code)