### PR TITLE
Release v1.11.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,7 +23,7 @@ body:
     attributes:
       label: Performance Studio Version
       description: Check the About dialog or the release you downloaded.
-      placeholder: "e.g., 0.7.0"
+      placeholder: "e.g., 1.11.0"
     validations:
       required: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,52 @@ jobs:
           dotnet publish src/PlanViewer.App/PlanViewer.App.csproj -c Release -r osx-x64 --self-contained -o publish/osx-x64
           dotnet publish src/PlanViewer.App/PlanViewer.App.csproj -c Release -r osx-arm64 --self-contained -o publish/osx-arm64
 
+      # ── SSMS extension VSIX (issue #343 — get it into automated builds) ──
+      # PlanViewer.Ssms is a legacy non-SDK project and is not in PlanViewer.sln,
+      # so the `dotnet build` above never touches it. It needs full MSBuild plus
+      # the VSSDK build targets. continue-on-error keeps a VSIX build failure
+      # from blocking the (critical-path) cross-platform app release.
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v2
+        continue-on-error: true
+
+      - name: Build SSMS extension
+        id: ssms
+        continue-on-error: true
+        shell: pwsh
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          $manifest = 'src/PlanViewer.Ssms/source.extension.vsixmanifest'
+          $manifestVersion = ([xml](Get-Content $manifest)).PackageManifest.Metadata.Identity.Version
+          if ($manifestVersion -ne $env:VERSION) {
+            Write-Host "::warning::VSIX manifest version ($manifestVersion) != release version ($env:VERSION) — bump source.extension.vsixmanifest and Properties/AssemblyInfo.cs"
+          }
+
+          msbuild src/PlanViewer.Ssms/PlanViewer.Ssms.csproj -t:Restore,Build -p:Configuration=Release -p:DeployExtension=false
+          dotnet build src/PlanViewer.Ssms.Installer/PlanViewer.Ssms.Installer.csproj -c Release
+
+          $vsix = 'src/PlanViewer.Ssms/bin/Release/PlanViewer.Ssms.vsix'
+          $exe  = 'src/PlanViewer.Ssms.Installer/bin/Release/net472/InstallSsmsExtension.exe'
+          if (-not (Test-Path $vsix)) { throw "VSIX not produced at $vsix" }
+          if (-not (Test-Path $exe))  { throw "Installer not produced at $exe" }
+
+          New-Item -ItemType Directory -Force -Path releases | Out-Null
+          Copy-Item $vsix 'releases/PlanViewer.Ssms.vsix'
+          Copy-Item $exe  'releases/InstallSsmsExtension.exe'
+
+      - name: Upload SSMS extension to release
+        if: steps.ssms.outcome == 'success'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: gh release upload "v$env:VERSION" releases/PlanViewer.Ssms.vsix releases/InstallSsmsExtension.exe --clobber
+
+      - name: Warn if SSMS extension build failed
+        if: steps.ssms.outcome != 'success'
+        run: echo "::warning::SSMS extension VSIX build failed — release published without it (issue #343)"
+
       # ── SignPath code signing (Windows only, skipped if secret not configured) ──
       - name: Check if signing is configured
         id: signing

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ A VSIX extension that adds **"Open in Performance Studio"** to the execution pla
 
 ### Installation
 
-1. Download `PlanViewer.Ssms.vsix` and `InstallSsmsExtension.exe` from the [v0.7.0 release](https://github.com/erikdarlingdata/PerformanceStudio/releases/tag/v0.7.0) (SSMS extension is not yet included in automated builds)
+1. Download `PlanViewer.Ssms.vsix` and `InstallSsmsExtension.exe` from the [latest release](https://github.com/erikdarlingdata/PerformanceStudio/releases/latest)
 2. Place them in the same folder
 3. Double-click `InstallSsmsExtension.exe` and approve the UAC prompt
 4. The installer auto-detects SSMS 21 and/or SSMS 22 and installs into both

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
     Tests and server/ projects are outside src/ and are unaffected.
   -->
   <PropertyGroup>
-    <Version>1.11.0</Version>
+    <Version>1.11.1</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.App/Mcp/McpHostService.cs
+++ b/src/PlanViewer.App/Mcp/McpHostService.cs
@@ -63,7 +63,9 @@ public sealed class McpHostService : BackgroundService
                     options.ServerInfo = new()
                     {
                         Name = "PerformanceStudio",
-                        Version = "0.7.0"
+                        /* Derived from the product version in Directory.Build.props
+                           so it never drifts from the actual release. */
+                        Version = typeof(McpHostService).Assembly.GetName().Version?.ToString(3) ?? "1.11.0"
                     };
                     options.ServerInstructions = McpInstructions.Text;
                 })

--- a/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
+++ b/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
@@ -7,5 +7,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Performance Studio for SSMS")]
 [assembly: AssemblyCopyright("Copyright Darling Data 2026")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("1.11.0.0")]
-[assembly: AssemblyFileVersion("1.11.0.0")]
+[assembly: AssemblyVersion("1.11.1.0")]
+[assembly: AssemblyFileVersion("1.11.1.0")]

--- a/src/PlanViewer.Ssms/source.extension.vsixmanifest
+++ b/src/PlanViewer.Ssms/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="PlanViewer.Ssms.64F79022-9D9A-4463-A1AE-4B19426A0CB1"
-              Version="1.11.0"
+              Version="1.11.1"
               Language="en-US"
               Publisher="Darling Data" />
     <DisplayName>Performance Studio for SSMS</DisplayName>


### PR DESCRIPTION
Release **v1.11.1** — a small release to validate the new SSMS extension VSIX build in the release workflow (#343).

## What's in it

- **SSMS extension is now built and released automatically** — `release.yml` builds `PlanViewer.Ssms.vsix` + `InstallSsmsExtension.exe` and attaches them to the release. This is the first release that exercises that path.
- MCP server version is no longer hardcoded — derived from the assembly version.
- README points the SSMS install at the latest release; bug-report template placeholder refreshed.

## Validation

This release is primarily a test of the VSIX CI build. After it completes, confirm `PlanViewer.Ssms.vsix` is attached to the v1.11.1 release. The VSIX build is `continue-on-error`, so if the runner lacks VSSDK targets the app release still succeeds and CI emits a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
