### PR TITLE
Fix SSMS VSIX release step + bump to 1.11.2 (#343)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,11 +63,12 @@ jobs:
           dotnet publish src/PlanViewer.App/PlanViewer.App.csproj -c Release -r osx-x64 --self-contained -o publish/osx-x64
           dotnet publish src/PlanViewer.App/PlanViewer.App.csproj -c Release -r osx-arm64 --self-contained -o publish/osx-arm64
 
-      # ── SSMS extension VSIX (issue #343 — get it into automated builds) ──
+      # ── SSMS extension VSIX (issue 343 — get it into automated builds) ──
       # PlanViewer.Ssms is a legacy non-SDK project and is not in PlanViewer.sln,
       # so the `dotnet build` above never touches it. It needs full MSBuild plus
-      # the VSSDK build targets. continue-on-error keeps a VSIX build failure
-      # from blocking the (critical-path) cross-platform app release.
+      # the VSSDK build targets from the Microsoft.VSSDK.BuildTools package.
+      # The build step never fails the job (it only sets an output on success),
+      # so a VSIX build failure can never block the cross-platform app release.
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v2
         continue-on-error: true
@@ -82,32 +83,36 @@ jobs:
           $manifest = 'src/PlanViewer.Ssms/source.extension.vsixmanifest'
           $manifestVersion = ([xml](Get-Content $manifest)).PackageManifest.Metadata.Identity.Version
           if ($manifestVersion -ne $env:VERSION) {
-            Write-Host "::warning::VSIX manifest version ($manifestVersion) != release version ($env:VERSION) — bump source.extension.vsixmanifest and Properties/AssemblyInfo.cs"
+            Write-Host "::warning::VSIX manifest version ($manifestVersion) does not match release version ($env:VERSION) - bump source.extension.vsixmanifest and Properties/AssemblyInfo.cs"
           }
 
-          msbuild src/PlanViewer.Ssms/PlanViewer.Ssms.csproj -t:Restore,Build -p:Configuration=Release -p:DeployExtension=false
+          # Use -restore (not the -t:Restore,Build target list) so the
+          # package-generated props land in a fresh evaluation before Build.
+          # Those props redirect VSToolsPath into the Microsoft.VSSDK.BuildTools
+          # package, which is how the VSSDK targets resolve on a runner that
+          # lacks the Visual Studio extension-development workload.
+          msbuild src/PlanViewer.Ssms/PlanViewer.Ssms.csproj -restore -t:Build -p:Configuration=Release -p:DeployExtension=false
           dotnet build src/PlanViewer.Ssms.Installer/PlanViewer.Ssms.Installer.csproj -c Release
 
           $vsix = 'src/PlanViewer.Ssms/bin/Release/PlanViewer.Ssms.vsix'
           $exe  = 'src/PlanViewer.Ssms.Installer/bin/Release/net472/InstallSsmsExtension.exe'
-          if (-not (Test-Path $vsix)) { throw "VSIX not produced at $vsix" }
-          if (-not (Test-Path $exe))  { throw "Installer not produced at $exe" }
-
-          New-Item -ItemType Directory -Force -Path releases | Out-Null
-          Copy-Item $vsix 'releases/PlanViewer.Ssms.vsix'
-          Copy-Item $exe  'releases/InstallSsmsExtension.exe'
+          if ((Test-Path $vsix) -and (Test-Path $exe)) {
+            New-Item -ItemType Directory -Force -Path releases | Out-Null
+            Copy-Item $vsix 'releases/PlanViewer.Ssms.vsix'
+            Copy-Item $exe  'releases/InstallSsmsExtension.exe'
+            "BUILT=true" >> $env:GITHUB_OUTPUT
+            Write-Host "SSMS extension built: $vsix"
+          } else {
+            Write-Host "::warning::SSMS extension did not produce the expected artifacts - release published without the VSIX (issue 343)"
+          }
 
       - name: Upload SSMS extension to release
-        if: steps.ssms.outcome == 'success'
+        if: steps.ssms.outputs.BUILT == 'true'
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.VERSION }}
         run: gh release upload "v$env:VERSION" releases/PlanViewer.Ssms.vsix releases/InstallSsmsExtension.exe --clobber
-
-      - name: Warn if SSMS extension build failed
-        if: steps.ssms.outcome != 'success'
-        run: echo "::warning::SSMS extension VSIX build failed — release published without it (issue #343)"
 
       # ── SignPath code signing (Windows only, skipped if secret not configured) ──
       - name: Check if signing is configured

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
     Tests and server/ projects are outside src/ and are unaffected.
   -->
   <PropertyGroup>
-    <Version>1.11.1</Version>
+    <Version>1.11.2</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
+++ b/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
@@ -7,5 +7,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Performance Studio for SSMS")]
 [assembly: AssemblyCopyright("Copyright Darling Data 2026")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("1.11.1.0")]
-[assembly: AssemblyFileVersion("1.11.1.0")]
+[assembly: AssemblyVersion("1.11.2.0")]
+[assembly: AssemblyFileVersion("1.11.2.0")]

--- a/src/PlanViewer.Ssms/source.extension.vsixmanifest
+++ b/src/PlanViewer.Ssms/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="PlanViewer.Ssms.64F79022-9D9A-4463-A1AE-4B19426A0CB1"
-              Version="1.11.1"
+              Version="1.11.2"
               Language="en-US"
               Publisher="Darling Data" />
     <DisplayName>Performance Studio for SSMS</DisplayName>


### PR DESCRIPTION
Fixes the SSMS VSIX release step from #344. The v1.11.1 release attempt was the test that exposed both bugs.

## What went wrong with v1.11.1

1. **YAML comment ate part of a command.** The `Warn if SSMS extension build failed` step had `(issue #343)` in a single-line `run:` value. YAML treats ` #` as the start of a comment, so the command became an unterminated pwsh string and the step failed. That step was *not* `continue-on-error`, so it failed the whole `release` job — skipping signing, Velopack, and **every artifact upload**. v1.11.1 was created empty and has since been deleted (release + tag).

2. **The VSIX build genuinely failed** with `MSB4226: ...Microsoft.VsSDK.targets was not found`. `msbuild -t:Restore,Build` evaluates the project once *before* Restore writes the package-generated props, so `VSToolsPath` was never redirected into the `Microsoft.VSSDK.BuildTools` package — the runner has no VS extension-development workload, so the VSSDK targets were unreachable.

## Fixes

- Build with `msbuild -restore -t:Build` — Restore runs in its own evaluation, so the `Microsoft.VSSDK.BuildTools` package props are in place before Build and the VSSDK targets resolve without the VS workload.
- **Removed the separate warn step.** The build step now only sets a `BUILT` output on success; the upload is gated on it. Nothing in the SSMS path can fail the `release` job anymore — worst case is a release without the VSIX plus a CI warning.
- Dropped non-ASCII characters from the `run:`-block strings.
- Bump to **1.11.2** (1.11.1 is burned).

## Test plan

- [x] CI build/test green.
- [ ] After this merges to `main`, the v1.11.2 release run should attach `PlanViewer.Ssms.vsix` + `InstallSsmsExtension.exe` **and** complete signing/Velopack/zip uploads. The `-restore` fix for the VSIX is a strong diagnosis but is verified only by that run; if it still fails, the release now completes cleanly without the VSIX instead of breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
