### PR TITLE
Publish SSMS extension to the SSMS Gallery on release (#343)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,19 @@ jobs:
           VERSION: ${{ steps.version.outputs.VERSION }}
         run: gh release upload "v$env:VERSION" releases/PlanViewer.Ssms.vsix releases/InstallSsmsExtension.exe --clobber
 
+      # Publish to the SSMS Gallery (https://ssmsgallery.azurewebsites.net, issue 343).
+      # The gallery extracts version/description from the vsixmanifest, so the
+      # upload filename is irrelevant. continue-on-error: a gallery outage must
+      # never fail the release. bash so `curl` is curl.exe, not the pwsh alias.
+      - name: Publish SSMS extension to SSMS Gallery
+        if: steps.ssms.outputs.BUILT == 'true'
+        continue-on-error: true
+        shell: bash
+        run: |
+          echo "Uploading PlanViewer.Ssms.vsix to the SSMS Gallery..."
+          curl -sS -f "https://ssmsgallery.azurewebsites.net/api/upload" \
+            -F "file=@releases/PlanViewer.Ssms.vsix"
+
       # ── SignPath code signing (Windows only, skipped if secret not configured) ──
       - name: Check if signing is configured
         id: signing


### PR DESCRIPTION
Completes the original ask in #343. With the VSIX now built and verified in releases (v1.11.2), this adds the gallery publish step.

## Change

`release.yml` gains a `Publish SSMS extension to SSMS Gallery` step that POSTs `PlanViewer.Ssms.vsix` to `https://ssmsgallery.azurewebsites.net/api/upload` after the GitHub release upload.

- Gated on `steps.ssms.outputs.BUILT == 'true'` — only runs if the VSIX actually built.
- `continue-on-error: true` — a gallery outage can never fail the release.
- `shell: bash` so `curl` is curl.exe, not the PowerShell `Invoke-WebRequest` alias.
- ErikEJ confirmed on #343 that the gallery extracts version + description from the vsixmanifest, so the upload filename is irrelevant.

## Activation

No version bump — this rides along on the next release. Nothing publishes until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)