### PR TITLE
Restore dropped XML docs in AppSettingsService

### DIFF
--- a/src/PlanViewer.App/Services/AppSettingsService.cs
+++ b/src/PlanViewer.App/Services/AppSettingsService.cs
@@ -48,6 +48,11 @@ internal sealed class AppSettingsService
     /// Loads settings from disk. Returns default settings if the file is missing or corrupt.
     /// Migrates legacy format settings from the old standalone file if present.
     /// </summary>
+    /// <remarks>
+    /// Returns the in-process cached instance — callers must not mutate it. Use
+    /// <see cref="AppSettings.Clone"/> if you need an editable copy, or <see cref="Save"/>
+    /// to persist new state (which also refreshes the cache).
+    /// </remarks>
     public static AppSettings Load()
     {
         if (_cached != null)
@@ -192,6 +197,10 @@ internal sealed class AppSettings
     [JsonPropertyName("open_plans")]
     public List<string> OpenPlans { get; set; } = new();
 
+    /// <summary>
+    /// Divergence limit for accuracy ratio coloring on plan links. Default 10.
+    /// Links with accuracy ratio between 1/limit and limit keep the default edge color.
+    /// </summary>
     [JsonPropertyName("accuracy_ratio_divergence_limit")]
     public double AccuracyRatioDivergenceLimit { get; set; } = 10;
 

--- a/src/PlanViewer.App/Services/AppSettingsService.cs
+++ b/src/PlanViewer.App/Services/AppSettingsService.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 


### PR DESCRIPTION
## Summary
- Re-add the XML summary for `AccuracyRatioDivergenceLimit` that was lost in #351 when the property was moved into the App State block.
- Document that `Load()` returns the shared cached instance so callers don't accidentally mutate it and corrupt the cache for everyone else.

## Test plan
- [x] Docs-only change, no behavior impact.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)