### PR TITLE
Add optional initial database to Connect dialog (#358)

### DIFF
--- a/src/PlanViewer.App/Dialogs/ConnectionDialog.axaml
+++ b/src/PlanViewer.App/Dialogs/ConnectionDialog.axaml
@@ -2,8 +2,8 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="PlanViewer.App.Dialogs.ConnectionDialog"
         Title="Connect to Server"
-        Width="480" Height="520"
-        MinWidth="400" MinHeight="480"
+        Width="480" Height="588"
+        MinWidth="400" MinHeight="548"
         WindowStartupLocation="CenterOwner"
         CanResize="False"
         Icon="avares://PlanViewer.App/EDD.ico"
@@ -85,6 +85,15 @@
                       Foreground="{DynamicResource ForegroundBrush}"
                       ToolTip.Tip="Sets ApplicationIntent=ReadOnly. Required when connecting via an AG listener or Azure failover group endpoint to route to a readable secondary (including Query Store on secondary replicas)."
                       FontSize="12"/>
+
+            <!-- Optional initial database (required for Azure SQL DB / JIT access where master isn't reachable) -->
+            <StackPanel Spacing="4">
+                <TextBlock Text="Initial database (optional)"
+                           Foreground="{DynamicResource ForegroundBrush}" FontSize="12"/>
+                <TextBox x:Name="DatabaseInputBox" FontSize="13" Height="32"
+                         Watermark="Leave empty to connect to master"
+                         ToolTip.Tip="Connects directly to this database instead of master. Useful for Azure SQL Database or Just-In-Time access where the login can't open master. Test Connection will pre-select it below."/>
+            </StackPanel>
         </StackPanel>
 
         <!-- Test Connection + Status -->

--- a/src/PlanViewer.App/Dialogs/ConnectionDialog.axaml.cs
+++ b/src/PlanViewer.App/Dialogs/ConnectionDialog.axaml.cs
@@ -78,6 +78,7 @@ public partial class ConnectionDialog : Window
 
         TrustCertBox.IsChecked = saved.TrustServerCertificate;
         ReadOnlyIntentCheckBox.IsChecked = saved.ApplicationIntentReadOnly;
+        DatabaseInputBox.Text = saved.DatabaseName ?? "";
 
         // Load stored credentials
         var cred = _credentialService.GetCredential(saved.Id);
@@ -125,6 +126,11 @@ public partial class ConnectionDialog : Window
             return;
         }
 
+        // For Azure SQL DB / JIT access the login often can't open master, so connect
+        // through the database the user named (if any) instead of the hardcoded master.
+        var typedDatabase = DatabaseInputBox.Text?.Trim();
+        var connectDatabase = string.IsNullOrEmpty(typedDatabase) ? "master" : typedDatabase;
+
         StatusText.Text = "Connecting...";
         StatusText.Foreground = new Avalonia.Media.SolidColorBrush(Avalonia.Media.Color.FromRgb(0xE4, 0xE6, 0xEB));
         TestButton.IsEnabled = false;
@@ -135,12 +141,13 @@ public partial class ConnectionDialog : Window
             var connectionString = connection.GetConnectionString(
                 LoginBox.Text?.Trim(),
                 PasswordBox.Text,
-                "master");
+                connectDatabase);
 
             await using var conn = new SqlConnection(connectionString);
             await conn.OpenAsync();
 
-            // Fetch databases
+            // Fetch databases the login can see. On Azure SQL DB connected to a single user
+            // database this returns master + that database, which is expected.
             var databases = new List<string>();
             using var cmd = new SqlCommand(
                 "SELECT name FROM sys.databases WHERE state_desc = 'ONLINE' ORDER BY name", conn);
@@ -148,13 +155,21 @@ public partial class ConnectionDialog : Window
             while (await reader.ReadAsync())
                 databases.Add(reader.GetString(0));
 
+            // The named database is reachable (OpenAsync succeeded), so make sure it's
+            // selectable even if enumeration didn't surface it (restricted JIT permissions).
+            if (!string.IsNullOrEmpty(typedDatabase) &&
+                !databases.Contains(typedDatabase, StringComparer.OrdinalIgnoreCase))
+                databases.Insert(0, typedDatabase);
+
             DatabaseBox.ItemsSource = databases;
             DatabaseBox.IsEnabled = true;
             ConnectButton.IsEnabled = true;
 
-            // Default to master if available
-            var masterIdx = databases.IndexOf("master");
-            if (masterIdx >= 0) DatabaseBox.SelectedIndex = masterIdx;
+            // Pre-select the named database when given, otherwise default to master.
+            var preferred = string.IsNullOrEmpty(typedDatabase) ? "master" : typedDatabase;
+            var preferredIdx = databases.FindIndex(d => d.Equals(preferred, StringComparison.OrdinalIgnoreCase));
+            if (preferredIdx >= 0) DatabaseBox.SelectedIndex = preferredIdx;
+            else if (databases.Count > 0) DatabaseBox.SelectedIndex = 0;
 
             StatusText.Text = $"Connected ({databases.Count} databases)";
             StatusText.Foreground = Avalonia.Media.Brushes.LimeGreen;
@@ -213,11 +228,13 @@ public partial class ConnectionDialog : Window
     private ServerConnection BuildServerConnection()
     {
         var serverName = ServerNameBox.Text?.Trim() ?? "";
+        var databaseName = DatabaseInputBox.Text?.Trim();
         return new ServerConnection
         {
             Id = serverName,
             ServerName = serverName,
             DisplayName = serverName,
+            DatabaseName = string.IsNullOrEmpty(databaseName) ? null : databaseName,
             AuthenticationType = GetSelectedAuthType(),
             TrustServerCertificate = TrustCertBox.IsChecked == true,
             EncryptMode = GetSelectedEncryptMode(),

--- a/src/PlanViewer.Core/Models/ServerConnection.cs
+++ b/src/PlanViewer.Core/Models/ServerConnection.cs
@@ -18,6 +18,13 @@ public class ServerConnection
     public bool TrustServerCertificate { get; set; } = false;
     public bool ApplicationIntentReadOnly { get; set; } = false;
 
+    /// <summary>
+    /// Optional database name for the initial connection. Use for Azure SQL Database or
+    /// Just-In-Time access where the login can't open master.
+    /// Leave empty for on-premises SQL Server (defaults to master).
+    /// </summary>
+    public string? DatabaseName { get; set; }
+
     [JsonIgnore]
     public string AuthenticationDisplay => AuthenticationType switch
     {


### PR DESCRIPTION
## Summary

Resolves #358. For Azure SQL DB / Just-In-Time access, the consultant's login often can't open `master` — but the Connect dialog always tested against `master` and enumerated `sys.databases` to populate the database dropdown, so the test failed and the dropdown never populated, leaving no path to **Connect**.

This adds an optional **"Initial database"** field to the Connect dialog (ported from the `DatabaseName` field already used in PerformanceMonitor's Add/Edit Server dialog).

## Behavior

- **Field empty** → unchanged: Test Connection connects to `master`, enumerates databases, you pick from the dropdown.
- **Field set** → Test Connection connects **directly to that database** instead of `master`; the named DB is guaranteed selectable even under restricted JIT permissions, and it's **pre-selected** in the dropdown. The name is persisted on `ServerConnection` and restored for saved connections.

## Changes

- `PlanViewer.Core/Models/ServerConnection.cs` — added optional `DatabaseName` property.
- `PlanViewer.App/Dialogs/ConnectionDialog.axaml` — added the "Initial database (optional)" text box above Test Connection; bumped fixed window height to fit.
- `PlanViewer.App/Dialogs/ConnectionDialog.axaml.cs` — wired the typed database into `TestConnection_Click` (connect target + pre-select), `BuildServerConnection` (persist), and `ApplySavedConnection` (restore).

## Testing

- Builds clean; app launches and the dialog renders the new field correctly.
- Avalonia review: no layout clipping (flexible spacer row absorbs the added height), valid Avalonia property usages.
- ⚠️ The Azure SQL DB / JIT path itself is **not yet verified against a live Azure SQL DB** — asking the issue author (@benjamin-szczur) to test that flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)