### PR TITLE
Persist initial database name on saved connection updates (#358)

### DIFF
--- a/src/PlanViewer.App/Services/ConnectionStore.cs
+++ b/src/PlanViewer.App/Services/ConnectionStore.cs
@@ -55,6 +55,7 @@ public class ConnectionStore
             existing.TrustServerCertificate = connection.TrustServerCertificate;
             existing.ApplicationIntentReadOnly = connection.ApplicationIntentReadOnly;
             existing.DisplayName = connection.DisplayName;
+            existing.DatabaseName = connection.DatabaseName;
             existing.LastConnected = DateTime.Now;
         }
         else


### PR DESCRIPTION
## Summary

Fixes the reopened follow-up on #358: when reconnecting to a previously used server, the new **Initial database** field came back empty even though server name and credentials were remembered.

## Root cause

#359 added the field and *was meant to* persist it on `ServerConnection` — `BuildServerConnection` sets it and `ApplySavedConnection` restores it. But `ConnectionStore.AddOrUpdate` silently dropped it: the **update** branch copies fields onto the existing record one at a time and never assigned `DatabaseName`. So the field was only saved on the **first** connect to a brand-new server (the *add* branch persists the whole object) and discarded on every reconnect to a known server.

Benjamin's Azure/JIT server already existed in his `connections.json` from before #359, so his connect always took the update path — which is why the field never stuck for him. The same bug also meant a saved server could never have its initial database changed.

## Fix

One line in the update branch of `AddOrUpdate`:

```csharp
existing.DatabaseName = connection.DatabaseName;
```

The restore side (`ApplySavedConnection`) already pre-fills the field, so this closes the loop.

## Test plan

- [x] `dotnet build src/PlanViewer.App` succeeds
- [ ] Connect to an already-saved server with an Initial database typed in → reopen the dialog → field is pre-filled
- [ ] Change the Initial database on a saved server, reconnect, reopen → new value is retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)