### PR TITLE
Clarify .NET SDK is only needed to build from source (#361)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Each warning includes severity (Info, Warning, or Critical), the operator node I
 
 ## Prerequisites
 
-- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) (required to build and run)
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) (only needed to build from source — the pre-built binaries below are self-contained and require no SDK)
 - SQL Server instance (optional — only needed for live plan capture; file analysis works without one)
 - Docker (optional — macOS/Linux users can run SQL Server locally via Docker)
 


### PR DESCRIPTION
Fixes #361.

The *Prerequisites* section listed the .NET 10 SDK as "required to build and run," which contradicted the *Download* section's note that the pre-built binaries are self-contained and require no SDK.

The SDK is only needed when building from source — running the released zips does not need it. Updated the Prerequisites bullet to say so.

## Test plan
- [x] Rendered README, confirmed Prerequisites and Download sections are now consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)