### PR TITLE
Fix crashes, DoS, and security issues from Fable code review

### DIFF
--- a/server/PlanShare/Program.cs
+++ b/server/PlanShare/Program.cs
@@ -347,8 +347,10 @@ app.Run();
 
 static string GenerateId()
 {
+    // The id is the only access control on a shared plan, so it must be
+    // unpredictable — use a cryptographic RNG, not Random.Shared (xoshiro).
     const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    return new string(Random.Shared.GetItems<char>(chars.AsSpan(), 8));
+    return new string(RandomNumberGenerator.GetItems<char>(chars.AsSpan(), 8));
 }
 
 static string GenerateDeleteToken()

--- a/src/PlanViewer.App/Controls/PlanViewerControl.Rendering.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.Rendering.cs
@@ -543,7 +543,7 @@ public partial class PlanViewerControl : UserControl
             "BackgroundLightBrush" => new SolidColorBrush(Color.FromRgb(0x23, 0x26, 0x2E)),
             "BorderBrush" => new SolidColorBrush(Color.FromRgb(0x3A, 0x3D, 0x45)),
             "ForegroundBrush" => new SolidColorBrush(Color.FromRgb(0xE4, 0xE6, 0xEB)),
-            "ForegroundMutedBrush" => new SolidColorBrush(Color.FromRgb(0xE4, 0xE6, 0xEB)),
+            "ForegroundMutedBrush" => new SolidColorBrush(Color.FromRgb(0xB0, 0xB6, 0xC0)),
             _ => Brushes.White
         };
     }

--- a/src/PlanViewer.App/Controls/QuerySessionControl.Format.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.Format.cs
@@ -143,6 +143,11 @@ public partial class QuerySessionControl : UserControl
             QueryEditor.CaretOffset = Math.Min(caretOffset, QueryEditor.Document.TextLength);
             SetStatus("Formatted");
         }
+        catch (Exception ex)
+        {
+            // async void handler: an unhandled throw here would crash the app.
+            SetStatus($"Format failed: {ex.Message}");
+        }
         finally
         {
             FormatButton.IsEnabled = true;

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -175,7 +175,11 @@ public partial class MainWindow : Window
                 }
                 catch
                 {
-                    // Pipe error — restart the listener
+                    // Pipe error (e.g. another instance already holds the single
+                    // server slot). Back off before retrying so we don't spin at
+                    // 100% CPU recreating the listener in a tight loop.
+                    try { await Task.Delay(1000, token); }
+                    catch (OperationCanceledException) { break; }
                 }
             }
         }, token);

--- a/src/PlanViewer.App/Program.cs
+++ b/src/PlanViewer.App/Program.cs
@@ -2,7 +2,6 @@ using Avalonia;
 using System;
 using System.IO;
 using System.IO.Pipes;
-using System.Threading;
 using Velopack;
 
 namespace PlanViewer.App;
@@ -10,7 +9,6 @@ namespace PlanViewer.App;
 class Program
 {
     private const string PipeName = "SQLPerformanceStudio_OpenFile";
-    private const string MutexName = "SQLPerformanceStudio_SingleInstance";
 
     [STAThread]
     public static void Main(string[] args)
@@ -33,26 +31,23 @@ class Program
             .LogToTrace();
 
     /// <summary>
-    /// Tries to connect to an already-running instance and send the file path.
-    /// Returns true if the message was delivered (caller should exit).
+    /// Tries to hand the file path to an already-running instance over its named pipe.
+    /// A failed/timed-out connect means no instance is listening, so the caller should
+    /// launch normally. Returns true only if the path was actually delivered.
     /// </summary>
+    /// <remarks>
+    /// Detection is via the pipe itself rather than a named mutex: the previous mutex
+    /// was disposed as soon as this method returned, so no instance ever held it and
+    /// the forwarding path was never taken.
+    /// </remarks>
     private static bool TrySendToRunningInstance(string filePath)
     {
-        bool createdNew;
-        using var mutex = new Mutex(true, MutexName, out createdNew);
-
-        if (createdNew)
-        {
-            // We're the first instance — release and let normal startup proceed
-            mutex.ReleaseMutex();
-            return false;
-        }
-
-        // Another instance owns the mutex — try sending the file path
         try
         {
             using var client = new NamedPipeClientStream(".", PipeName, PipeDirection.Out);
-            client.Connect(3000); // 3 second timeout
+            // Short timeout: a running instance's listener is idle and connects
+            // immediately; when none is running this is the only added launch delay.
+            client.Connect(500);
             using var writer = new StreamWriter(client);
             writer.WriteLine(filePath);
             writer.Flush();
@@ -60,7 +55,7 @@ class Program
         }
         catch
         {
-            // Pipe not available — fall through to launch normally
+            // No instance listening (or pipe busy) — fall through to launch normally.
             return false;
         }
     }

--- a/src/PlanViewer.App/Themes/DarkTheme.axaml
+++ b/src/PlanViewer.App/Themes/DarkTheme.axaml
@@ -5,6 +5,7 @@
     <SolidColorBrush x:Key="BackgroundDarkBrush" Color="#15171C"/>
     <SolidColorBrush x:Key="BackgroundLightBrush" Color="#22252D"/>
     <SolidColorBrush x:Key="ForegroundBrush" Color="#E4E6EB"/>
+    <SolidColorBrush x:Key="ForegroundMutedBrush" Color="#B0B6C0"/>
     <SolidColorBrush x:Key="BorderBrush" Color="#3A3D45"/>
     <SolidColorBrush x:Key="AccentBrush" Color="#2eaef1"/>
 

--- a/src/PlanViewer.Cli/ConnectionHelper.cs
+++ b/src/PlanViewer.Cli/ConnectionHelper.cs
@@ -17,7 +17,10 @@ public static class ConnectionHelper
             ApplicationName = "PlanViewer",
             ConnectTimeout = 15,
             TrustServerCertificate = trustCert,
-            Encrypt = trustCert ? SqlConnectionEncryptOption.Optional : SqlConnectionEncryptOption.Mandatory
+            // Keep encryption mandatory regardless of --trust-cert. --trust-cert only
+            // skips certificate *validation* (for self-signed certs); it must not also
+            // drop the connection to optional/plaintext, which would allow a MITM.
+            Encrypt = SqlConnectionEncryptOption.Mandatory
         };
 
         if (multipleActiveResultSets)

--- a/src/PlanViewer.Core/Output/HtmlExporter.cs
+++ b/src/PlanViewer.Core/Output/HtmlExporter.cs
@@ -373,7 +373,9 @@ pre.query-text, pre.text-output {
         if (node == null) return false;
         foreach (var w in node.Warnings)
         {
-            if (w.Type.EndsWith(" Spill", StringComparison.Ordinal))
+            // Covers "Sort Spill"/"Hash Spill"/"Exchange Spill" as well as the
+            // standalone "Spill to TempDb" and "Spill Occurred" warning types.
+            if (w.Type.Contains("Spill", StringComparison.Ordinal))
                 return true;
         }
         foreach (var child in node.Children)
@@ -507,7 +509,7 @@ pre.query-text, pre.text-output {
 
         foreach (var w in sorted)
         {
-            var sevLower = w.Severity.ToLower();
+            var sevLower = w.Severity.ToLowerInvariant();
             sb.AppendLine($"<div class=\"warning-item {sevLower}\">");
             sb.AppendLine($"<span class=\"sev sev-{sevLower}\">{Encode(w.Severity)}</span>");
             if (w.Operator != null)

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.Statement.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.Statement.cs
@@ -290,11 +290,15 @@ public static partial class PlanAnalyzer
         // https://erikdarling.com/cursor-declarations-that-use-openjson-can-bloat-your-plan-cache/).
         if (!cfg.IsRuleDisabled(37) && !string.IsNullOrEmpty(stmt.StatementText))
         {
-            // DECLARE <name> [qualifier(s)] CURSOR ... FOR
-            // Flags the declaration if LOCAL isn't among the qualifiers before CURSOR.
+            // DECLARE <name> [INSENSITIVE|SCROLL] CURSOR [qualifier(s)] FOR ...
+            // In the T-SQL extended syntax, LOCAL/GLOBAL appear AFTER the CURSOR
+            // keyword (only INSENSITIVE/SCROLL are legal before it), so the LOCAL
+            // qualifier must be looked for between CURSOR and the FOR that introduces
+            // the SELECT. Capturing tokens *before* CURSOR never sees LOCAL and would
+            // fire on every cursor, including ones already declared LOCAL.
             var cursorDeclMatch = Regex.Match(
                 stmt.StatementText,
-                @"\bDECLARE\s+\w+\s+((?:\w+\s+)*)CURSOR\b",
+                @"\bDECLARE\s+\w+\s+(?:INSENSITIVE\s+|SCROLL\s+)*CURSOR\b(.*?)\bFOR\b",
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
             if (cursorDeclMatch.Success)
             {

--- a/src/PlanViewer.Core/Services/ShowPlanParser.RelOp.cs
+++ b/src/PlanViewer.Core/Services/ShowPlanParser.RelOp.cs
@@ -9,8 +9,11 @@ namespace PlanViewer.Core.Services;
 
 public static partial class ShowPlanParser
 {
-    private static PlanNode ParseRelOp(XElement relOpEl)
+    private static PlanNode ParseRelOp(XElement relOpEl, int depth = 0)
     {
+        if (depth > MaxParseDepth)
+            throw new InvalidOperationException("Plan operator nesting exceeds the supported depth limit.");
+
         var node = new PlanNode
         {
             NodeId = (int)ParseDouble(relOpEl.Attribute("NodeId")?.Value),
@@ -762,7 +765,7 @@ public static partial class ShowPlanParser
         // Recurse into child RelOps
         foreach (var childRelOp in FindChildRelOps(relOpEl))
         {
-            var childNode = ParseRelOp(childRelOp);
+            var childNode = ParseRelOp(childRelOp, depth + 1);
             childNode.Parent = node;
             node.Children.Add(childNode);
         }

--- a/src/PlanViewer.Core/Services/ShowPlanParser.cs
+++ b/src/PlanViewer.Core/Services/ShowPlanParser.cs
@@ -11,6 +11,11 @@ public static partial class ShowPlanParser
 {
     private static readonly XNamespace Ns = "http://schemas.microsoft.com/sqlserver/2004/07/showplan";
 
+    // Plan XML is untrusted input (opened/pasted/downloaded). Cap recursion depth so a
+    // maliciously deep tree throws a catchable exception instead of an uncatchable
+    // StackOverflowException that takes the whole process down.
+    private const int MaxParseDepth = 1000;
+
     public static ParsedPlan Parse(string xml)
     {
         var plan = new ParsedPlan { RawXml = xml };
@@ -26,6 +31,11 @@ public static partial class ShowPlanParser
             return plan;
         }
 
+        // The tree walk below can throw on hostile/malformed plans (including the depth
+        // guards in ParseRelOp/ParseStatementAndChildren that stop unbounded recursion).
+        // Contain it so a bad plan becomes a ParseError, never a crash for the caller.
+        try
+        {
         var root = doc.Root;
         if (root == null) return plan;
 
@@ -67,6 +77,11 @@ public static partial class ShowPlanParser
         }
 
         ComputeOperatorCosts(plan);
+        }
+        catch (Exception ex)
+        {
+            plan.ParseError = ex.Message;
+        }
         return plan;
     }
 
@@ -74,9 +89,11 @@ public static partial class ShowPlanParser
     /// Handles StmtSimple, StmtCond (IF/ELSE), and StmtCursor recursively.
     /// Returns a flat list of all parseable statements found.
     /// </summary>
-    private static List<PlanStatement> ParseStatementAndChildren(XElement stmtEl)
+    private static List<PlanStatement> ParseStatementAndChildren(XElement stmtEl, int depth = 0)
     {
         var results = new List<PlanStatement>();
+        if (depth > MaxParseDepth)
+            throw new InvalidOperationException("Plan statement nesting exceeds the supported depth limit.");
         var localName = stmtEl.Name.LocalName;
 
         if (localName == "StmtCond")
@@ -86,21 +103,21 @@ public static partial class ShowPlanParser
             if (condEl != null)
             {
                 foreach (var child in condEl.Elements())
-                    results.AddRange(ParseStatementAndChildren(child));
+                    results.AddRange(ParseStatementAndChildren(child, depth + 1));
             }
 
             var thenStmts = stmtEl.Element(Ns + "Then")?.Element(Ns + "Statements");
             if (thenStmts != null)
             {
                 foreach (var child in thenStmts.Elements())
-                    results.AddRange(ParseStatementAndChildren(child));
+                    results.AddRange(ParseStatementAndChildren(child, depth + 1));
             }
 
             var elseStmts = stmtEl.Element(Ns + "Else")?.Element(Ns + "Statements");
             if (elseStmts != null)
             {
                 foreach (var child in elseStmts.Elements())
-                    results.AddRange(ParseStatementAndChildren(child));
+                    results.AddRange(ParseStatementAndChildren(child, depth + 1));
             }
         }
         else if (localName == "StmtCursor")


### PR DESCRIPTION
Hardening fixes surfaced by the Fable code review, spanning the share server, desktop app, CLI, and Core parser/exporter.

## Changes
- `server/PlanShare/Program.cs` — share-server hardening
- `src/PlanViewer.App` — rendering, paste/format handling, window and startup hardening
- `src/PlanViewer.Cli/ConnectionHelper.cs` — connection handling
- `src/PlanViewer.Core` — `ShowPlanParser`, `PlanAnalyzer.Statement`, and `HtmlExporter` hardening against malformed/oversized plan input

## Notes
This is the existing local `e8e5a21` commit, routed through a PR because `dev` is protected. Part of the current dev→main release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)