### PR TITLE
Bump version to 1.13.0 for release

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
     Tests and server/ projects are outside src/ and are unaffected.
   -->
   <PropertyGroup>
-    <Version>1.12.0</Version>
+    <Version>1.13.0</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
+++ b/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
@@ -7,5 +7,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Performance Studio for SSMS")]
 [assembly: AssemblyCopyright("Copyright Darling Data 2026")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("1.12.0.0")]
-[assembly: AssemblyFileVersion("1.12.0.0")]
+[assembly: AssemblyVersion("1.13.0.0")]
+[assembly: AssemblyFileVersion("1.13.0.0")]

--- a/src/PlanViewer.Ssms/source.extension.vsixmanifest
+++ b/src/PlanViewer.Ssms/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="PlanViewer.Ssms.64F79022-9D9A-4463-A1AE-4B19426A0CB1"
-              Version="1.12.0"
+              Version="1.13.0"
               Language="en-US"
               Publisher="Darling Data" />
     <DisplayName>Performance Studio for SSMS</DisplayName>


### PR DESCRIPTION
Minor version bump (1.12.0 → 1.13.0) for the dev→main release. This batch includes new features (connect-dialog initial database, SSMS ARM64 target), so a minor bump per the project convention.

Updates all three tracked version locations:
- `src/Directory.Build.props` (`<Version>`)
- `src/PlanViewer.Ssms/Properties/AssemblyInfo.cs` (AssemblyVersion + AssemblyFileVersion)
- `src/PlanViewer.Ssms/source.extension.vsixmanifest` (Identity Version)

Satisfies the `check-version` gate on the dev→main release PR (#365).

🤖 Generated with [Claude Code](https://claude.com/claude-code)