### PR TITLE
Surface Query Store plan-load failures instead of silent 'No Plan Loaded'

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml
@@ -328,12 +328,15 @@
             </Grid>
 
             <!-- Empty State -->
-            <StackPanel x:Name="EmptyState" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Center">
-                <TextBlock Text="No Plan Loaded" FontSize="20" FontWeight="Light"
+            <StackPanel x:Name="EmptyState" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Center" MaxWidth="520">
+                <TextBlock x:Name="EmptyStateTitle" Text="No Plan Loaded" FontSize="20" FontWeight="Light"
                            Foreground="{DynamicResource ForegroundBrush}" HorizontalAlignment="Center"/>
-                <TextBlock Text="Open a .sqlplan file or drag one onto this window"
+                <TextBlock x:Name="EmptyStateHint" Text="Open a .sqlplan file or drag one onto this window"
                            FontSize="13" Foreground="{DynamicResource ForegroundBrush}"
                            HorizontalAlignment="Center" Margin="0,8,0,0"/>
+                <TextBlock x:Name="EmptyStateError" Text="" IsVisible="False"
+                           FontSize="13" Foreground="#E06C75" TextWrapping="Wrap"
+                           TextAlignment="Center" HorizontalAlignment="Center" Margin="0,8,0,0"/>
             </StackPanel>
 
             <!-- Properties Splitter -->

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -187,6 +187,13 @@ public partial class PlanViewerControl : UserControl
     public ParsedPlan? CurrentPlan => _currentPlan;
 
     /// <summary>
+    /// Reason the most recent <see cref="LoadPlan"/> failed (blank XML, parse error,
+    /// or no renderable statements), or null when it succeeded. Lets callers surface
+    /// why a plan didn't load instead of silently showing the empty state.
+    /// </summary>
+    public string? LastLoadError { get; private set; }
+
+    /// <summary>
     /// Exposes the query text associated with this plan (if any).
     /// </summary>
     public string? QueryText => _queryText;
@@ -298,15 +305,40 @@ public partial class PlanViewerControl : UserControl
         });
     }
 
-    public void LoadPlan(string planXml, string label, string? queryText = null)
+    /// <summary>
+    /// Parses and renders a plan. Returns true when a plan was rendered; false when the
+    /// XML was blank, failed to parse, or contained no renderable statements (in which case
+    /// the empty state explains why and <see cref="LastLoadError"/> holds the reason).
+    /// </summary>
+    public bool LoadPlan(string planXml, string label, string? queryText = null)
     {
         _label = label;
         _queryText = queryText;
+        LastLoadError = null;
 
         // Query text stored for copy/repro but no longer shown in a
         // separate expander — it's already visible in the Statements grid.
 
+        // A Query Store row can have a NULL/empty query_plan; don't treat that
+        // (or a parse failure) as a silent "No Plan Loaded".
+        if (string.IsNullOrWhiteSpace(planXml))
+        {
+            LastLoadError = "The plan is empty — this source has no stored query plan XML.";
+            ShowEmptyState("Couldn't Load Plan", LastLoadError);
+            return false;
+        }
+
         _currentPlan = ShowPlanParser.Parse(planXml);
+
+        // ShowPlanParser never throws; it records failures in ParseError and returns an
+        // empty plan. Surface that instead of rendering a blank "No Plan Loaded" panel.
+        if (!string.IsNullOrEmpty(_currentPlan.ParseError))
+        {
+            LastLoadError = _currentPlan.ParseError;
+            ShowEmptyState("Couldn't Load Plan", $"Parse error: {_currentPlan.ParseError}");
+            return false;
+        }
+
         PlanAnalyzer.Analyze(_currentPlan, ConfigLoader.Load(), _serverMetadata);
         BenefitScorer.Score(_currentPlan);
 
@@ -317,9 +349,9 @@ public partial class PlanViewerControl : UserControl
 
         if (allStatements.Count == 0)
         {
-            EmptyState.IsVisible = true;
-            PlanScrollViewer.IsVisible = false;
-            return;
+            LastLoadError = "The plan parsed but contains no statements to display.";
+            ShowEmptyState("No Plan Loaded", null);
+            return false;
         }
 
         EmptyState.IsVisible = false;
@@ -355,6 +387,30 @@ public partial class PlanViewerControl : UserControl
             CriticalWarningCount = criticalCount,
             MissingIndexCount = _currentPlan.AllMissingIndexes.Count
         });
+
+        return true;
+    }
+
+    /// <summary>
+    /// Shows the empty-state panel with a title and, optionally, an error detail line.
+    /// When <paramref name="error"/> is null the normal "open a file" hint is shown instead.
+    /// </summary>
+    private void ShowEmptyState(string title, string? error)
+    {
+        EmptyStateTitle.Text = title;
+        if (string.IsNullOrEmpty(error))
+        {
+            EmptyStateError.IsVisible = false;
+            EmptyStateHint.IsVisible = true;
+        }
+        else
+        {
+            EmptyStateError.Text = error;
+            EmptyStateError.IsVisible = true;
+            EmptyStateHint.IsVisible = false;
+        }
+        EmptyState.IsVisible = true;
+        PlanScrollViewer.IsVisible = false;
     }
 
     public void Clear()
@@ -367,8 +423,8 @@ public partial class PlanViewerControl : UserControl
         _queryText = null;
         _selectedNodeBorder = null;
         _selectedNode = null;
-        EmptyState.IsVisible = true;
-        PlanScrollViewer.IsVisible = false;
+        LastLoadError = null;
+        ShowEmptyState("No Plan Loaded", null);
         InsightsPanel.IsVisible = false;
         CostText.Text = "";
         CloseStatementsPanel();

--- a/src/PlanViewer.App/Controls/QuerySessionControl.Plans.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.Plans.cs
@@ -30,7 +30,7 @@ namespace PlanViewer.App.Controls;
 
 public partial class QuerySessionControl : UserControl
 {
-    private void AddPlanTab(string planXml, string queryText, bool estimated, string? labelOverride = null)
+    private bool AddPlanTab(string planXml, string queryText, bool estimated, string? labelOverride = null)
     {
         _planCounter++;
         var label = labelOverride ?? (estimated ? $"Est Plan {_planCounter}" : $"Plan {_planCounter}");
@@ -42,7 +42,15 @@ public partial class QuerySessionControl : UserControl
         if (_serverConnection != null)
             viewer.SetConnectionStatus(_serverConnection.ServerName, _selectedDatabase);
         viewer.OpenInEditorRequested += OnOpenInEditorRequested;
-        viewer.LoadPlan(planXml, label, queryText);
+
+        if (!viewer.LoadPlan(planXml, label, queryText))
+        {
+            // Blank XML or a parse failure. Don't navigate away from the current view
+            // (e.g. the Query Store grid) to a blank tab — surface why and stay put.
+            viewer.OpenInEditorRequested -= OnOpenInEditorRequested;
+            SetStatus($"Couldn't load {label}: {viewer.LastLoadError}", autoClear: false);
+            return false;
+        }
 
         // Build tab header with close button and right-click rename
         var headerText = new TextBlock
@@ -101,6 +109,7 @@ public partial class QuerySessionControl : UserControl
         SubTabControl.Items.Add(tab);
         SubTabControl.SelectedItem = tab;
         UpdateCompareButtonState();
+        return true;
     }
 
     private void StartRename(StackPanel header, TextBlock headerText)

--- a/src/PlanViewer.App/Controls/QuerySessionControl.QueryStore.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.QueryStore.cs
@@ -254,13 +254,19 @@ public partial class QuerySessionControl : UserControl
 
     private void OnQueryStorePlansSelected(object? sender, List<QueryStorePlan> plans)
     {
+        int loaded = 0;
         foreach (var qsPlan in plans)
         {
             var tabLabel = $"QS {qsPlan.QueryId} / {qsPlan.PlanId}";
-            AddPlanTab(qsPlan.PlanXml, qsPlan.QueryText, estimated: true, labelOverride: tabLabel);
+            if (AddPlanTab(qsPlan.PlanXml, qsPlan.QueryText, estimated: true, labelOverride: tabLabel))
+                loaded++;
         }
 
-        SetStatus($"{plans.Count} Query Store plans loaded");
+        // Only show the success summary when every plan loaded; otherwise AddPlanTab has
+        // already left a persistent status explaining the failure — don't clobber it.
+        if (loaded == plans.Count)
+            SetStatus($"{plans.Count} Query Store plans loaded");
+
         HumanAdviceButton.IsEnabled = true;
         RobotAdviceButton.IsEnabled = true;
     }


### PR DESCRIPTION
## Problem
Loading a plan from the Query Store grid could blank to "No Plan Loaded" while the QS grid itself vanished, with no explanation.

## Root cause
- `PlanViewerControl.LoadPlan` treated a *failed parse* identically to an *empty plan*: `ShowPlanParser.Parse` never throws — it records failures in `ParsedPlan.ParseError` and returns a zero-statement plan — but the desktop app never read `ParseError`, so any parse failure rendered as a bare "No Plan Loaded".
- `AddPlanTab` unconditionally added **and selected** the new plan tab even when the load failed, navigating away from the grid to that blank tab.

Commit `e8e5a21` (parser hardening) was the regression vector: it wrapped the parser tree-walk in a catch-all, converting what used to be a visible crash on a bad plan into a silent zero-statement `ParseError` — i.e. exactly this symptom.

## Fix
- `LoadPlan` returns `bool` and exposes `LastLoadError`, distinguishing **blank/NULL plan XML**, a **parse error** (surfaced verbatim in the empty-state panel), and **parsed-but-no-statements**.
- `AddPlanTab` no longer switches away on failure — it keeps the Query Store grid active and leaves a persistent status line explaining why.
- `Clear()` resets the empty state so a reused viewer can't show a stale error (caught by the Avalonia gotcha review).

The four direct `LoadPlan` callers (File→Open, paste, estimated/actual execution) ignore the new return value and keep their prior behavior; they additionally benefit from real error text in the empty state.

## Note
This makes failures *visible and non-destructive*; it does not alter the parser. If a specific plan still fails, the on-screen "Parse error: …" now names the cause so the underlying parser issue can be fixed separately.

## Testing
- `dotnet build` PlanViewer.App: 0 errors.
- App launches clean; empty state renders with no Avalonia binding errors.
- Avalonia gotcha review: clean (no null-element risk, no event-handler leak, no orphaned MCP session — failed loads never register one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
