### PR TITLE
Bump Avalonia 11.3.14 -> 11.3.17 (in-line patch)

### DIFF
--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -9,15 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.14" />
+    <PackageReference Include="Avalonia" Version="11.3.17" />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.4.1" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.13" />
     <PackageReference Include="ScottPlot.Avalonia" Version="5.1.58" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.14" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.14" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.14" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.17" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.17" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.17" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.14">
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.17">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## What

Patch bump of the core Avalonia packages within the 11.3.x line:

| Package | Before | After |
|---|---|---|
| Avalonia | 11.3.14 | 11.3.17 |
| Avalonia.Desktop | 11.3.14 | 11.3.17 |
| Avalonia.Themes.Fluent | 11.3.14 | 11.3.17 |
| Avalonia.Fonts.Inter | 11.3.14 | 11.3.17 |
| Avalonia.Diagnostics | 11.3.14 | 11.3.17 |

`Avalonia.Controls.DataGrid` (11.3.13) and `Avalonia.AvaloniaEdit` / `AvaloniaEdit.TextMate` (11.4.1) are already at the latest 11.x and left unchanged.

## Why

Stays on the 11.3.x line, so there are no breaking changes, and it keeps us compatible with `ScottPlot.Avalonia` 5.1.58 (`Avalonia >= 11.3.4`) — so the Query Store charts keep rendering. The Avalonia **12** jump is a separate, larger migration that is currently blocked on ScottPlot shipping v12 support (upstream ScottPlot #5228 / #5230); that work is parked on `upgrade/avalonia-12` and is **not** part of this PR.

## Test plan

- [x] `dotnet build` clean — 0 errors, no NuGet downgrade/conflict warnings
- [x] App launches and main window renders on 11.3.17
- [ ] Reviewer sanity-check of Query Store charts (ScottPlot) once running

🤖 Generated with [Claude Code](https://claude.com/claude-code)