### PR TITLE
Bump all dependencies (except Avalonia 12 / VSSDK 18, which are blocked)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
-          dotnet tool install -g vpk
+          # Pin vpk to match the Velopack PackageReference (Velopack recommends the
+          # CLI and library versions match for compatible packages + reproducible releases).
+          dotnet tool install -g vpk --version 1.2.0
           New-Item -ItemType Directory -Force -Path releases/velopack
 
           # Download previous release for delta generation

--- a/server/PlanShare/PlanShare.csproj
+++ b/server/PlanShare/PlanShare.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -9,33 +9,33 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.14" />
+    <PackageReference Include="Avalonia" Version="11.3.17" />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.4.1" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.13" />
     <PackageReference Include="ScottPlot.Avalonia" Version="5.1.58" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.14" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.14" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.14" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.17" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.17" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.17" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.14">
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.17">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="AvaloniaEdit.TextMate" Version="11.4.1" />
-    <PackageReference Include="AvaloniaEdit.TextMate.Grammars" Version="0.10.12" />
-    <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="1.7.18" />
-    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
-    <PackageReference Include="TextMateSharp.Grammars" Version="2.0.3" />
-    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="180.6.0" />
-    <PackageReference Include="Velopack" Version="0.0.1298" />
+    <PackageReference Include="AvaloniaEdit.TextMate.Grammars" Version="0.10.12.1" />
+    <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="2.0.1" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
+    <PackageReference Include="TextMateSharp.Grammars" Version="2.0.4" />
+    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="180.37.3" />
+    <PackageReference Include="Velopack" Version="1.2.0" />
 
     <!-- Pin SkiaSharp native assets to match SkiaSharp 3.119.0.
          Avalonia.Skia 11.3.12 transitively pulls in 2.88.9 for Linux and WebAssembly,
          but the managed SkiaSharp 3.x requires native libs in the [119.0, 120.0) range.
          Without these pins, the old 2.88.x .so overwrites the correct one at publish time,
          causing a TypeInitializationException on Linux (GitHub issue #139). -->
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PlanViewer.Cli/PlanViewer.Cli.csproj
+++ b/src/PlanViewer.Cli/PlanViewer.Cli.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.7" />
+    <PackageReference Include="System.CommandLine" Version="2.0.9" />
   </ItemGroup>
 
 </Project>

--- a/src/PlanViewer.Core/PlanViewer.Core.csproj
+++ b/src/PlanViewer.Core/PlanViewer.Core.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
-    <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="1.7.18" />
+    <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="2.0.1" />
     <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0" />
-    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="180.6.0" />
+    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="180.37.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PlanViewer.Ssms/PlanViewer.Ssms.csproj
+++ b/src/PlanViewer.Ssms/PlanViewer.Ssms.csproj
@@ -75,8 +75,8 @@
     <None Include="source.extension.vsixmanifest" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.32112.339" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.11.435" IncludeAssets="build;buildTransitive" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.14.40265" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.14.2142" IncludeAssets="build;buildTransitive" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PlanViewer.Web/PlanViewer.Web.csproj
+++ b/src/PlanViewer.Web/PlanViewer.Web.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- Linked files from PlanViewer.Core — analysis pipeline only, no SqlClient/WASM-incompatible deps -->

--- a/tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj
+++ b/tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>


### PR DESCRIPTION
Sweeps every outdated package across all 8 projects to current stable, holding back only the two that are genuinely blocked. **Supersedes #368** (Avalonia 11.3.17 only) and the `upgrade/velopack-1.x` / `upgrade/meziantou-credentialmanager-2.x` branches — they're all folded in here.

## Bumps

**App** — Avalonia (+Desktop/Themes.Fluent/Fonts.Inter/Diagnostics) `11.3.14→11.3.17`, Meziantou.CredentialManager `1.7.18→2.0.1`, ModelContextProtocol (+AspNetCore) `1.3.0→1.4.0`, ScriptDom `180.6.0→180.37.3`, Velopack `0.0.1298→1.2.0` (+ vpk CLI pinned to 1.2.0 in `release.yml`), TextMateSharp.Grammars `2.0.3→2.0.4`, AvaloniaEdit.TextMate.Grammars `0.10.12→0.10.12.1`, SkiaSharp.NativeAssets.Linux `3.119.2→3.119.4`
**Core** — Meziantou `1.7.18→2.0.1`, ScriptDom `180.6.0→180.37.3`
**Cli** — System.CommandLine `2.0.7→2.0.9`
**Web** — AspNetCore.Components.WebAssembly (+DevServer) `10.0.0→10.0.9`
**PlanShare** — Microsoft.Data.Sqlite `10.0.5→10.0.9`
**Tests** — NET.Test.Sdk `18.5.1→18.6.0`, coverlet.collector `10.0.0→10.0.1`
**SSMS VSIX** — VisualStudio.SDK `→17.14.40265`, VSSDK.BuildTools `17.11.435→17.14.2142` (latest **17.x** — 18.x is un-restorable from nuget.org and targets VS 18, not VS 2022)

## Held back (blocked, not skipped)
- **Avalonia 12.x** — ScottPlot.Avalonia has no v12 build yet ([ScottPlot #5228](https://github.com/ScottPlot/ScottPlot/issues/5228)/[#5230](https://github.com/ScottPlot/ScottPlot/issues/5230)); charts render blank. Migration is done and parked on `upgrade/avalonia-12`.
- **VSSDK.BuildTools 18.x** — un-restorable from nuget.org (missing transitive `SDK.Analyzers 17.7.122`).

## Test plan
- [x] `dotnet build PlanViewer.sln -c Release` — clean, 0 errors, no NuGet downgrade/conflict
- [x] PlanShare builds; SSMS VSIX **restores** clean on 17.x (full VSIX build needs VS — runs in CI)
- [x] `dotnet test` — 77/77 pass
- [x] App launches and renders (Avalonia 11.3.17 + Velopack 1.2.0 + Meziantou 2.0.1 + MCP 1.4.0)
- [ ] **Release-time:** confirm an existing install updates across the Velopack 0.0.1298 → 1.2.0 boundary when the next release is cut (inherent to any updater bump; not testable headless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)