### PR TITLE
Fix SSMS extension version targeting so the gallery shows SSMS 21/22 (#370)

### DIFF
--- a/src/PlanViewer.Ssms/source.extension.vsixmanifest
+++ b/src/PlanViewer.Ssms/source.extension.vsixmanifest
@@ -7,18 +7,18 @@
               Language="en-US"
               Publisher="Darling Data" />
     <DisplayName>Performance Studio for SSMS</DisplayName>
-    <Description xml:space="preserve">Adds "Open in Performance Studio" to the execution plan right-click menu in SSMS. Extracts the plan XML and opens it in Performance Studio for advanced analysis.</Description>
+    <Description xml:space="preserve">Adds "Open in Performance Studio" to the execution plan right-click menu in SSMS. Extracts the plan XML and opens it in Performance Studio for advanced analysis. Compatible with SSMS 21 and SSMS 22.</Description>
     <MoreInfo>https://github.com/erikdarlingdata/PerformanceStudio</MoreInfo>
     <License>LICENSE</License>
     <Icon>Resources\PerformanceStudioIcon.png</Icon>
     <Tags>SQL Server, Execution Plan, Performance, SSMS</Tags>
   </Metadata>
   <Installation>
-    <!-- SSMS 21 = product line 21, SSMS 22.3+ = product line 22 (VS 18.0 shell) -->
-    <InstallationTarget Id="Microsoft.VisualStudio.Ssms" Version="[17.0,)">
+    <!-- Version is the SSMS product version, not the VS shell version: [21.0,23.0) = SSMS 21 and 22. -->
+    <InstallationTarget Id="Microsoft.VisualStudio.Ssms" Version="[21.0,23.0)">
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
-    <InstallationTarget Id="Microsoft.VisualStudio.Ssms" Version="[17.0,)">
+    <InstallationTarget Id="Microsoft.VisualStudio.Ssms" Version="[21.0,23.0)">
       <ProductArchitecture>arm64</ProductArchitecture>
     </InstallationTarget>
   </Installation>


### PR DESCRIPTION
Fixes #370.

The `InstallationTarget` version under `Microsoft.VisualStudio.Ssms` is the **SSMS product version**, not the VS shell version. The previous `[17.0,)` installed fine (SSMS 21/22 are both >= 17) but the SSMS Gallery rendered the lower bound literally as "Supports SSMS 17 SSMS 18". This switches to `[21.0,23.0)` — the form ErikEJ's SqlCeToolbox uses — so the gallery shows "SSMS 21 / SSMS 22", and clarifies the `<Description>`.

Confirmed with @ErikEJ (gallery maintainer) on the issue thread.

## Test plan
- Rebuilt the VSIX from the edited manifest; confirmed `[21.0,23.0)` is in the packaged `extension.vsixmanifest`.
- Uninstalled the existing extension from SSMS 22 (VSIXInstaller exit 0).
- Reinstalled the rebuilt VSIX into SSMS 22 — **VSIXInstaller exit 0**, confirming SSMS accepts `[21.0,23.0)`.
- Verified the deployed manifest shows `Version=[21.0,23.0)` for both amd64 and arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
