### PR TITLE
Preserve Unix execute bit in Linux/macOS release zips

### DIFF
--- a/.github/scripts/zip_with_exec.py
+++ b/.github/scripts/zip_with_exec.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Create a .zip whose entries carry Unix permission bits.
+
+Why this exists
+---------------
+The release/ nightly workflows run on windows-latest, where PowerShell's
+Compress-Archive cannot store Unix file modes. The .NET ZipArchive API can set
+external attributes but hardcodes the archive's "host system" byte to Windows
+(0), so unzip / macOS / Linux ignore the mode and the self-contained .NET
+apphost (PlanViewer.App) extracts WITHOUT its execute bit -- the app then fails
+to launch on Linux/macOS ("permission denied").
+
+Python's zipfile lets us set create_system = 3 (Unix) explicitly, so extractors
+honor the mode. Files default to 0644, directories to 0755, and any path passed
+via --exec / --exec-optional is marked 0755 (rwxr-xr-x).
+
+Usage
+-----
+  python zip_with_exec.py SOURCE_DIR DEST_ZIP
+      [--exec RELPATH ...] [--exec-optional RELPATH ...]
+
+  SOURCE_DIR        directory whose *contents* are zipped (the directory itself
+                    is not stored as a top-level entry -- matches the behavior of
+                    `Compress-Archive -Path SOURCE_DIR/*`)
+  DEST_ZIP          output .zip path (overwritten if present)
+  --exec            forward-slash relpath that MUST exist; marked executable.
+                    A missing --exec path is a hard error so a renamed/absent
+                    apphost fails the release loudly instead of shipping a zip
+                    that won't launch.
+  --exec-optional   relpath marked executable if present, skipped if absent
+                    (e.g. createdump, which only some runtime IDs include).
+"""
+import argparse
+import os
+import shutil
+import stat
+import sys
+import zipfile
+
+UNIX = 3  # ZIP "version made by" host system: 3 = Unix (so the high word of
+          # external_attr is read as st_mode by unzip / macOS / Linux).
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Zip a directory preserving Unix exec bits.")
+    ap.add_argument("source_dir")
+    ap.add_argument("dest_zip")
+    ap.add_argument("--exec", action="append", default=[], dest="execs",
+                    metavar="RELPATH", help="path that must exist; marked 0755")
+    ap.add_argument("--exec-optional", action="append", default=[], dest="execs_optional",
+                    metavar="RELPATH", help="path marked 0755 if present")
+    args = ap.parse_args()
+
+    source = os.path.abspath(args.source_dir)
+    if not os.path.isdir(source):
+        sys.exit(f"error: source dir not found: {source}")
+
+    required = {p.replace("\\", "/").strip("/") for p in args.execs}
+    optional = {p.replace("\\", "/").strip("/") for p in args.execs_optional}
+
+    # Walk first so we can validate that every required exec path is present
+    # before we start writing the archive.
+    dir_entries = []   # arcname with trailing slash
+    file_entries = []  # (abs_path, arcname)
+    present = set()
+    for root, dirs, files in os.walk(source):
+        dirs.sort()
+        files.sort()
+        rel_root = os.path.relpath(root, source)
+        if rel_root != ".":
+            dir_entries.append(rel_root.replace("\\", "/") + "/")
+        for fn in files:
+            abs_path = os.path.join(root, fn)
+            arc = os.path.relpath(abs_path, source).replace("\\", "/")
+            file_entries.append((abs_path, arc))
+            present.add(arc)
+
+    missing = sorted(required - present)
+    if missing:
+        sys.exit("error: required --exec path(s) not found under {}: {}".format(
+            source, ", ".join(missing)))
+
+    exec_paths = set(required) | (set(optional) & present)
+
+    dest = os.path.abspath(args.dest_zip)
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+    if os.path.exists(dest):
+        os.remove(dest)
+
+    marked = []
+    with zipfile.ZipFile(dest, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for dir_arc in dir_entries:
+            zi = zipfile.ZipInfo(dir_arc)
+            zi.create_system = UNIX
+            # S_IFDIR | 0755 in the Unix high word; 0x10 = FILE_ATTRIBUTE_DIRECTORY
+            # in the DOS low word so Windows tools also see it as a directory.
+            zi.external_attr = ((stat.S_IFDIR | 0o755) << 16) | 0x10
+            zf.writestr(zi, b"")
+
+        for abs_path, arc in file_entries:
+            zi = zipfile.ZipInfo.from_file(abs_path, arc)  # carries file mtime
+            zi.create_system = UNIX
+            zi.compress_type = zipfile.ZIP_DEFLATED
+            if arc in exec_paths:
+                zi.external_attr = (stat.S_IFREG | 0o755) << 16
+                marked.append(arc)
+            else:
+                zi.external_attr = (stat.S_IFREG | 0o644) << 16
+            with open(abs_path, "rb") as src, zf.open(zi, "w") as dst:
+                shutil.copyfileobj(src, dst)
+
+    print(f"Created {dest}")
+    print(f"  {len(file_entries)} file(s), {len(dir_entries)} dir(s)")
+    print(f"  executable: {', '.join(sorted(marked)) if marked else '(none)'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -81,12 +81,17 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path releases
 
-          # Package Windows and Linux as flat zips
-          foreach ($rid in @('win-x64', 'linux-x64')) {
-            if (Test-Path 'README.md') { Copy-Item 'README.md' "publish/$rid/" }
-            if (Test-Path 'LICENSE') { Copy-Item 'LICENSE' "publish/$rid/" }
-            Compress-Archive -Path "publish/$rid/*" -DestinationPath "releases/PerformanceStudio-$rid-$env:VERSION.zip" -Force
-          }
+          # Windows: flat zip via Compress-Archive (no Unix execute bit needed).
+          if (Test-Path 'README.md') { Copy-Item 'README.md' 'publish/win-x64/' }
+          if (Test-Path 'LICENSE') { Copy-Item 'LICENSE' 'publish/win-x64/' }
+          Compress-Archive -Path 'publish/win-x64/*' -DestinationPath "releases/PerformanceStudio-win-x64-$env:VERSION.zip" -Force
+
+          # Linux: flat zip via zip_with_exec.py so the apphost keeps its execute
+          # bit. Compress-Archive stamps the archive host byte as Windows, so the
+          # Unix mode is dropped and the binary extracts non-executable.
+          if (Test-Path 'README.md') { Copy-Item 'README.md' 'publish/linux-x64/' }
+          if (Test-Path 'LICENSE') { Copy-Item 'LICENSE' 'publish/linux-x64/' }
+          python .github/scripts/zip_with_exec.py publish/linux-x64 "releases/PerformanceStudio-linux-x64-$env:VERSION.zip" --exec PlanViewer.App --exec-optional createdump
 
           # Package macOS as proper .app bundles
           foreach ($rid in @('osx-x64', 'osx-arm64')) {
@@ -115,7 +120,9 @@ jobs:
             if (Test-Path 'README.md') { Copy-Item 'README.md' "$wrapperDir/" }
             if (Test-Path 'LICENSE') { Copy-Item 'LICENSE' "$wrapperDir/" }
 
-            Compress-Archive -Path "$wrapperDir/*" -DestinationPath "releases/PerformanceStudio-$rid-$env:VERSION.zip" -Force
+            # Zip the bundle with zip_with_exec.py so the apphost inside the .app
+            # keeps its execute bit (Compress-Archive would strip it).
+            python .github/scripts/zip_with_exec.py "$wrapperDir" "releases/PerformanceStudio-$rid-$env:VERSION.zip" --exec "PerformanceStudio.app/Contents/MacOS/PlanViewer.App" --exec-optional "PerformanceStudio.app/Contents/MacOS/createdump"
           }
 
       - name: Generate checksums

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,12 +193,19 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path releases
 
-          # Package Windows (signed) and Linux as flat zips
-          foreach ($rid in @('win-x64', 'linux-x64')) {
-            if (Test-Path 'README.md') { Copy-Item 'README.md' "publish/$rid/" }
-            if (Test-Path 'LICENSE') { Copy-Item 'LICENSE' "publish/$rid/" }
-            Compress-Archive -Path "publish/$rid/*" -DestinationPath "releases/PerformanceStudio-$rid.zip" -Force
-          }
+          # Windows (signed): flat zip via Compress-Archive. Windows has no Unix
+          # execute bit, so the signed .exe needs no special handling.
+          if (Test-Path 'README.md') { Copy-Item 'README.md' 'publish/win-x64/' }
+          if (Test-Path 'LICENSE') { Copy-Item 'LICENSE' 'publish/win-x64/' }
+          Compress-Archive -Path 'publish/win-x64/*' -DestinationPath 'releases/PerformanceStudio-win-x64.zip' -Force
+
+          # Linux: flat zip via zip_with_exec.py so the apphost keeps its execute
+          # bit. Compress-Archive (and .NET's ZipArchive) stamp the archive's host
+          # byte as Windows, so unzip/macOS/Linux drop the Unix mode and the binary
+          # extracts non-executable -- it then won't launch ("permission denied").
+          if (Test-Path 'README.md') { Copy-Item 'README.md' 'publish/linux-x64/' }
+          if (Test-Path 'LICENSE') { Copy-Item 'LICENSE' 'publish/linux-x64/' }
+          python .github/scripts/zip_with_exec.py publish/linux-x64 releases/PerformanceStudio-linux-x64.zip --exec PlanViewer.App --exec-optional createdump
 
           # Package macOS as proper .app bundles
           foreach ($rid in @('osx-x64', 'osx-arm64')) {
@@ -233,7 +240,10 @@ jobs:
             if (Test-Path 'README.md') { Copy-Item 'README.md' "$wrapperDir/" }
             if (Test-Path 'LICENSE') { Copy-Item 'LICENSE' "$wrapperDir/" }
 
-            Compress-Archive -Path "$wrapperDir/*" -DestinationPath "releases/PerformanceStudio-$rid.zip" -Force
+            # Zip the bundle with zip_with_exec.py so the apphost inside the .app
+            # keeps its execute bit (Compress-Archive would strip it, leaving a
+            # bundle macOS refuses to launch).
+            python .github/scripts/zip_with_exec.py "$wrapperDir" "releases/PerformanceStudio-$rid.zip" --exec "PerformanceStudio.app/Contents/MacOS/PlanViewer.App" --exec-optional "PerformanceStudio.app/Contents/MacOS/createdump"
           }
 
           # Checksums (zips only, Velopack has its own checksums)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
     Tests and server/ projects are outside src/ and are unaffected.
   -->
   <PropertyGroup>
-    <Version>1.13.0</Version>
+    <Version>1.14.0</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.App/Info.plist
+++ b/src/PlanViewer.App/Info.plist
@@ -22,5 +22,20 @@
     <string>EDD.icns</string>
     <key>NSHighResolutionCapable</key>
     <true/>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>SQL Server Execution Plan</string>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>sqlplan</string>
+            </array>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>CFBundleTypeIconFile</key>
+            <string>EDD.icns</string>
+        </dict>
+    </array>
 </dict>
 </plist>

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.Node.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.Node.cs
@@ -234,7 +234,7 @@ public static partial class PlanAnalyzer
                     if (stmtMs > 0 && operatorMs > 0)
                     {
                         var pct = (double)operatorMs / stmtMs;
-                        w.Message += $" Operator time: {operatorMs:N0}ms ({pct:P0} of statement).";
+                        w.Message += $" Operator time: {operatorMs:N0}ms ({pct * 100:N0}% of statement).";
                     }
                 }
             }
@@ -247,7 +247,7 @@ public static partial class PlanAnalyzer
                 if (stmtMs > 0)
                 {
                     var pct = (double)operatorMs / stmtMs;
-                    w.Message += $" Operator time: {operatorMs:N0}ms ({pct:P0} of statement).";
+                    w.Message += $" Operator time: {operatorMs:N0}ms ({pct * 100:N0}% of statement).";
 
                     if (pct >= 0.5)
                         w.Severity = PlanWarningSeverity.Critical;
@@ -278,7 +278,7 @@ public static partial class PlanAnalyzer
                 var skewThreshold = workerThreads.Count <= 2 ? 0.80 : 0.50;
                 if (skewRatio >= skewThreshold)
                 {
-                    var message = $"Thread {maxThread.ThreadId} processed {skewRatio:P0} of rows ({maxThread.ActualRows:N0}/{totalRows:N0}). Work is heavily skewed to one thread, so parallelism isn't helping much.";
+                    var message = $"Thread {maxThread.ThreadId} processed {skewRatio * 100:N0}% of rows ({maxThread.ActualRows:N0}/{totalRows:N0}). Work is heavily skewed to one thread, so parallelism isn't helping much.";
                     var severity = PlanWarningSeverity.Warning;
 
                     // Batch mode sorts produce all output on a single thread by design


### PR DESCRIPTION
## Summary

Linux and macOS release artifacts were built with PowerShell's `Compress-Archive` on the `windows-latest` runner, which **cannot store Unix file-mode bits**. The self-contained apphost `PlanViewer.App` therefore extracted as non-executable, and the app failed to launch ("permission denied") on Linux/macOS — the blocker reported by a tester.

### What changed

- **`.github/scripts/zip_with_exec.py`** (new): zips a directory with `create_system=3` (Unix) so extractors honor the mode, marking the apphost — and `createdump` if present — `0755`, everything else `0644`. Hard-fails if the apphost is missing, so a broken archive fails the release loudly instead of shipping.
- **`release.yml` / `nightly.yml`**: the Linux flat zip and both macOS `.app` bundles now go through the helper. Windows stays on `Compress-Archive` (no Unix execute bit; signed-binary path untouched).
- **`Info.plist`**: added `CFBundleDocumentTypes` so Finder shows the app icon for `.sqlplan` files and offers Performance Studio in "Open With".
- **`PlanAnalyzer.Node.cs`**: fixed culture-dependent percent formatting (`:P0` → `{x * 100:N0}%`). Pre-existing bug on `dev` unrelated to packaging, but it blocks CI: `:P0` renders `100%` on en-US and `100 %` on InvariantCulture, so `WarningCharacterizationTests` failed on the ubuntu runner (baseline was recorded on en-US). Had to fix it here to get this PR green. Verified the full Core suite passes under both default and `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1`.
- Version bumped 1.13.0 → 1.14.0.

### Why not just use .NET / pwsh?

`ZipArchive` can set `ExternalAttributes`, but on Windows it stamps the archive host byte as Windows (`create_system=0`), so `unzip`/macOS ignore the Unix mode. Verified empirically — only `create_system=3` (Python's `zipfile`) yields an executable apphost on extraction.

### Test plan

- [x] Helper tested locally: exec bit lands only on the apphost/createdump, `create_system=3` on every entry, missing-apphost guard fires, optional-createdump skipped cleanly when absent, archive round-trips intact.
- [x] `Info.plist` validated with `plistlib`; both workflow YAMLs parse.
- [ ] End-to-end verified by the `release.yml` run on merge to main (produces the v1.14.0 Linux/macOS zips).

### Known follow-up (not in this PR)

On macOS the `.sqlplan` association registers the icon and launches the app, but the app discovers the file to open from `argv`/named-pipe only; macOS delivers it via a `kAEOpenDocuments` Apple Event (`IActivatableApplicationLifetime`). Double-click-to-open the plan needs that handler wired up — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
