### PR TITLE
Fix Query Store gate on read-only secondary replicas (#378)

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.QueryStore.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.QueryStore.cs
@@ -144,10 +144,12 @@ public partial class QuerySessionControl : UserControl
         SetStatus($"Checking Query Store on {database}...");
         try
         {
-            var (enabled, state) = await QueryStoreService.CheckEnabledAsync(connStr);
+            var (enabled, state, readOnlyReplica) = await QueryStoreService.CheckEnabledAsync(connStr);
             if (!enabled)
             {
-                SetStatus($"Query Store not enabled on {database} ({state ?? "unknown"})");
+                SetStatus(readOnlyReplica
+                    ? $"{database} is a read-only replica with no Query Store data ({state ?? "unknown"}); enable it on the primary"
+                    : $"Query Store not enabled on {database} ({state ?? "unknown"})");
                 return;
             }
         }
@@ -203,10 +205,12 @@ public partial class QuerySessionControl : UserControl
         SetStatus("Checking Query Store...");
         try
         {
-            var (enabled, state) = await QueryStoreService.CheckEnabledAsync(_connectionString);
+            var (enabled, state, readOnlyReplica) = await QueryStoreService.CheckEnabledAsync(_connectionString);
             if (!enabled)
             {
-                SetStatus($"Query Store not enabled ({state ?? "unknown"})");
+                SetStatus(readOnlyReplica
+                    ? $"Read-only replica with no Query Store data ({state ?? "unknown"}); enable it on the primary"
+                    : $"Query Store not enabled ({state ?? "unknown"})");
                 return;
             }
         }

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
@@ -139,10 +139,12 @@ public partial class QueryStoreGridControl : UserControl
 
         try
         {
-            var (enabled, state) = await QueryStoreService.CheckEnabledAsync(newConnStr);
+            var (enabled, state, readOnlyReplica) = await QueryStoreService.CheckEnabledAsync(newConnStr);
             if (!enabled)
             {
-                StatusText.Text = $"Query Store not enabled on {db} ({state ?? "unknown"})";
+                StatusText.Text = readOnlyReplica
+                    ? $"{db} is a read-only replica with no Query Store data ({state ?? "unknown"})"
+                    : $"Query Store not enabled on {db} ({state ?? "unknown"})";
                 QsDatabaseBox.SelectedItem = _database; // revert
                 return;
             }

--- a/src/PlanViewer.App/Mcp/McpQueryStoreTools.cs
+++ b/src/PlanViewer.App/Mcp/McpQueryStoreTools.cs
@@ -32,14 +32,15 @@ public sealed class McpQueryStoreTools
                 return ConnectionNotFound(connectionStore, connection_name);
 
             var connectionString = conn.GetConnectionString(credentialService, database);
-            var (enabled, state) = await QueryStoreService.CheckEnabledAsync(connectionString);
+            var (enabled, state, readOnlyReplica) = await QueryStoreService.CheckEnabledAsync(connectionString);
 
             return JsonSerializer.Serialize(new
             {
                 server = conn.ServerName,
                 database,
                 query_store_enabled = enabled,
-                state
+                state,
+                read_only_replica = readOnlyReplica
             }, McpHelpers.JsonOptions);
         }
         catch (Exception ex)
@@ -114,9 +115,11 @@ public sealed class McpQueryStoreTools
             var connectionString = conn.GetConnectionString(credentialService, database);
 
             // Check Query Store is enabled first
-            var (enabled, state) = await QueryStoreService.CheckEnabledAsync(connectionString);
+            var (enabled, state, readOnlyReplica) = await QueryStoreService.CheckEnabledAsync(connectionString);
             if (!enabled)
-                return $"Query Store is not enabled on [{database}]. State: {state ?? "unknown"}.";
+                return readOnlyReplica
+                    ? $"[{database}] is a read-only replica with no Query Store data to read (state: {state ?? "unknown"}). Enable Query Store on the primary replica."
+                    : $"Query Store is not enabled on [{database}]. State: {state ?? "unknown"}.";
 
             // Fetch plans using the app's built-in query
             var plans = await QueryStoreService.FetchTopPlansAsync(

--- a/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
+++ b/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
@@ -282,11 +282,14 @@ public static class QueryStoreCommand
     {
         // Verify Query Store is enabled
         Console.Error.Write($"Checking Query Store on {server}/{database}... ");
-        var (enabled, state) = await QueryStoreService.CheckEnabledAsync(connectionString);
+        var (enabled, state, readOnlyReplica) = await QueryStoreService.CheckEnabledAsync(connectionString);
         if (!enabled)
         {
             Console.Error.WriteLine($"NOT ENABLED (state: {state ?? "unknown"})");
-            Console.Error.WriteLine("Enable Query Store: ALTER DATABASE [" + database + "] SET QUERY_STORE = ON;");
+            if (readOnlyReplica)
+                Console.Error.WriteLine("This is a read-only replica with no Query Store data to read. Enable Query Store on the primary replica — it cannot be enabled here.");
+            else
+                Console.Error.WriteLine("Enable Query Store: ALTER DATABASE [" + database + "] SET QUERY_STORE = ON;");
             Environment.ExitCode = 1;
             return;
         }

--- a/src/PlanViewer.Core/Services/QueryStoreService.cs
+++ b/src/PlanViewer.Core/Services/QueryStoreService.cs
@@ -10,28 +10,60 @@ namespace PlanViewer.Core.Services;
 public static partial class QueryStoreService
 {
     /// <summary>
-    /// Verifies Query Store is enabled and in a readable state on the target database.
-    /// Returns true if Query Store is accessible.
+    /// Decides whether Query Store data can be read, given the local Query Store state and
+    /// whether the database is a read-only replica that already holds captured data.
+    /// A READ* state (READ_ONLY / READ_WRITE / READ_CAPTURE_SECONDARY) is readable directly.
+    /// A read-only replica reports its local state as OFF even though the primary's captured
+    /// data is replicated and readable, so a read-only replica that holds data is also
+    /// readable. A writable database whose Query Store is OFF/ERROR is not. See issue #378.
     /// </summary>
-    public static async Task<(bool Enabled, string? State)> CheckEnabledAsync(
+    public static bool IsQueryStoreReadable(string? state, bool readOnlyReplica, bool hasData) =>
+        (state != null && state.StartsWith("READ", StringComparison.OrdinalIgnoreCase))
+        || (readOnlyReplica && hasData);
+
+    /// <summary>
+    /// Verifies Query Store is enabled and in a readable state on the target database.
+    /// Returns true if Query Store data is accessible.
+    /// </summary>
+    /// <remarks>
+    /// On a readable secondary replica (an Always On AG secondary, or an Azure SQL
+    /// geo-replica / read-scale-out replica) the database is read-only, so the local Query
+    /// Store capture engine can't run and <c>actual_state_desc</c> reports OFF — or, on
+    /// SQL 2022+/Azure with the secondary-replica feature enabled, READ_CAPTURE_SECONDARY.
+    /// Either way the primary's captured data is replicated into the database's internal
+    /// tables and is fully readable through the sys.query_store_* views (SSMS reads it there
+    /// too). So when the database is a read-only replica that already holds Query Store data,
+    /// treat it as enabled-for-reading even though the local state isn't a READ* state;
+    /// refusing to open would block a scenario that works. See issue #378.
+    /// </remarks>
+    public static async Task<(bool Enabled, string? State, bool ReadOnlyReplica)> CheckEnabledAsync(
         string connectionString, CancellationToken ct = default)
     {
         const string sql = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 SELECT
-    actual_state_desc
+    actual_state_desc,
+    read_only_replica =
+        CONVERT(bit, CASE WHEN DATABASEPROPERTYEX(DB_NAME(), 'Updateability') = 'READ_ONLY' THEN 1 ELSE 0 END),
+    has_query_store_data =
+        CONVERT(bit, CASE WHEN EXISTS (SELECT 1 FROM sys.query_store_query) THEN 1 ELSE 0 END)
 FROM sys.database_query_store_options;";
 
         await using var conn = new SqlConnection(connectionString);
         await conn.OpenAsync(ct);
         await using var cmd = new SqlCommand(sql, conn);
-        var state = (string?)await cmd.ExecuteScalarAsync(ct);
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
 
-        if (state == null)
-            return (false, null);
+        // No row means Query Store has never been configured on this database.
+        if (!await reader.ReadAsync(ct))
+            return (false, null, false);
 
-        var enabled = state.StartsWith("READ", StringComparison.OrdinalIgnoreCase);
-        return (enabled, state);
+        var state = reader.IsDBNull(0) ? null : reader.GetString(0);
+        var readOnlyReplica = !reader.IsDBNull(1) && reader.GetBoolean(1);
+        var hasData = !reader.IsDBNull(2) && reader.GetBoolean(2);
+
+        var enabled = IsQueryStoreReadable(state, readOnlyReplica, hasData);
+        return (enabled, state, readOnlyReplica);
     }
 
     /// <summary>

--- a/tests/PlanViewer.Core.Tests/QueryStoreReadableDecisionTests.cs
+++ b/tests/PlanViewer.Core.Tests/QueryStoreReadableDecisionTests.cs
@@ -1,0 +1,32 @@
+using PlanViewer.Core.Services;
+
+namespace PlanViewer.Core.Tests;
+
+// Locks in the Query Store readability gate, including the readable-secondary-replica case
+// from issue #378 where the local state reports OFF but the primary's captured data is
+// replicated and readable. See QueryStoreService.IsQueryStoreReadable.
+public class QueryStoreReadableDecisionTests
+{
+    [Theory]
+    // Writable primary with Query Store on -> readable.
+    [InlineData("READ_WRITE", false, false, true)]
+    [InlineData("READ_ONLY", false, false, true)]
+    // SQL 2022+/Azure secondary-replica feature: local state is a READ* value -> readable.
+    [InlineData("READ_CAPTURE_SECONDARY", true, true, true)]
+    // #378: read-only replica reports OFF but the primary's data is replicated -> readable.
+    [InlineData("OFF", true, true, true)]
+    // Read-only replica that holds no Query Store data yet -> nothing to read.
+    [InlineData("OFF", true, false, false)]
+    // Writable primary with Query Store genuinely off or errored -> not readable.
+    [InlineData("OFF", false, false, false)]
+    [InlineData("ERROR", false, false, false)]
+    // Writable primary that is off: stale rows alone do not make it readable (only replicas relax).
+    [InlineData("OFF", false, true, false)]
+    // No row / null state -> not readable.
+    [InlineData(null, false, false, false)]
+    public void IsQueryStoreReadable_MatchesExpectedGate(
+        string? state, bool readOnlyReplica, bool hasData, bool expected)
+    {
+        Assert.Equal(expected, QueryStoreService.IsQueryStoreReadable(state, readOnlyReplica, hasData));
+    }
+}


### PR DESCRIPTION
## Problem

Connecting Performance Studio to a readable secondary replica reported **"Query Store not enabled (OFF)"** and refused to open Query Store, even though the primary's captured data is replicated to the secondary and is fully readable (SSMS shows it). Reported in #378 against an Azure SQL Hyperscale named replica.

## Root cause

`QueryStoreService.CheckEnabledAsync` gated access on `sys.database_query_store_options.actual_state_desc` and only accepted a `READ*` value. On a read-only secondary the local capture engine can't run, so the state reports `OFF` — a false negative. The remediation it printed (`ALTER DATABASE ... SET QUERY_STORE = ON`) is also impossible on a read-only database.

An Azure SQL DB active geo-replica instead reports `READ_CAPTURE_SECONDARY`, which already passed the old check — which is why this only reproduced on certain secondary types (e.g. Hyperscale named replicas).

## Fix

Readability no longer trusts the state string alone. A read-only database (`DATABASEPROPERTYEX(DB_NAME(),'Updateability') = 'READ_ONLY'`) that already holds Query Store data (`EXISTS (SELECT 1 FROM sys.query_store_query)`) is treated as readable, so `OFF` / `READ_ONLY` / `READ_CAPTURE_SECONDARY` on a read-only secondary all open. A genuinely-off writable primary is still reported as off, now with a message that no longer advises an impossible `ALTER`.

- Decision extracted to `QueryStoreService.IsQueryStoreReadable` with a truth-table test.
- `CheckEnabledAsync` returns a `ReadOnlyReplica` flag; all five call sites (CLI, two MCP tools, two App controls) updated to tailor messaging.

## Validation

- Live Azure SQL geo-replica: end-to-end CLI fetch works; `Updateability = READ_ONLY`, data present.
- Reporter's Hyperscale named replica (#378): diagnostic returned `OFF / READ_ONLY / ~438k` rows - the exact tuple the fix targets.
- Local repro of `(OFF, read-only, has-data)`: CLI gate now returns `OK (OFF)` and fetches plans (old code said `NOT ENABLED (state: OFF)`).
- `dotnet test`: 95/95 pass, including the new `QueryStoreReadableDecisionTests`.

Closes #378
