### PR TITLE
Bump version to 1.14.2 for release

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
     Tests and server/ projects are outside src/ and are unaffected.
   -->
   <PropertyGroup>
-    <Version>1.14.1</Version>
+    <Version>1.14.2</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
+++ b/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
@@ -7,5 +7,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Performance Studio for SSMS")]
 [assembly: AssemblyCopyright("Copyright Darling Data 2026")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("1.13.0.0")]
-[assembly: AssemblyFileVersion("1.13.0.0")]
+[assembly: AssemblyVersion("1.14.2.0")]
+[assembly: AssemblyFileVersion("1.14.2.0")]

--- a/src/PlanViewer.Ssms/source.extension.vsixmanifest
+++ b/src/PlanViewer.Ssms/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="PlanViewer.Ssms.64F79022-9D9A-4463-A1AE-4B19426A0CB1"
-              Version="1.13.0"
+              Version="1.14.2"
               Language="en-US"
               Publisher="Darling Data" />
     <DisplayName>Performance Studio for SSMS</DisplayName>


### PR DESCRIPTION
Bumps the product version to 1.14.2 for the next release.

## What ships in 1.14.2

- Fix Query Store gate on read-only secondary replicas (#379) -- the only change on `dev` since v1.14.1.

## Version changes

- `src/Directory.Build.props`: 1.14.1 -> 1.14.2 (App, Core, CLI, Web, SSMS installer).
- SSMS extension synced 1.13.0 -> 1.14.2 (`source.extension.vsixmanifest` + `Properties/AssemblyInfo.cs`). `Directory.Build.props` documents these must be bumped manually since the legacy non-SDK project does not inherit it; they were missed in the 1.14.0 and 1.14.1 releases.

Merge order: this PR into `dev` first, then the `dev` -> `main` release PR (which triggers `release.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
