### PR TITLE
Release v1.15.0 - Query Store colorblind-safe palette

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
     Tests and server/ projects are outside src/ and are unaffected.
   -->
   <PropertyGroup>
-    <Version>1.14.2</Version>
+    <Version>1.15.0</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.App/Controls/QueryStoreHistoryControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreHistoryControl.axaml.cs
@@ -59,16 +59,19 @@ public partial class QueryStoreHistoryControl : UserControl
 	private static readonly SolidColorBrush ActiveButtonFg = new(Avalonia.Media.Color.FromRgb(0x11, 0x12, 0x17));
 	private static readonly SolidColorBrush InactiveButtonFg = new(Avalonia.Media.Color.FromRgb(0x9D, 0xA5, 0xB4));
 
+	// Validated colorblind-safe categorical ramp (dark surface), in fixed CVD
+	// order — shared with the Multi QS Overview database palette so the two
+	// Query Store views read as one system.
 	private static readonly ScottPlot.Color[] PlanColors =
 	{
-		ScottPlot.Color.FromHex("#4FC3F7"),
-		ScottPlot.Color.FromHex("#FF7043"),
-		ScottPlot.Color.FromHex("#66BB6A"),
-		ScottPlot.Color.FromHex("#AB47BC"),
-		ScottPlot.Color.FromHex("#FFA726"),
-		ScottPlot.Color.FromHex("#26C6DA"),
-		ScottPlot.Color.FromHex("#F06292"),
-		ScottPlot.Color.FromHex("#A1887F"),
+		ScottPlot.Color.FromHex("#3987E5"),
+		ScottPlot.Color.FromHex("#199E70"),
+		ScottPlot.Color.FromHex("#C98500"),
+		ScottPlot.Color.FromHex("#008300"),
+		ScottPlot.Color.FromHex("#9085E9"),
+		ScottPlot.Color.FromHex("#E66767"),
+		ScottPlot.Color.FromHex("#D55181"),
+		ScottPlot.Color.FromHex("#D95926"),
 	};
 
 	// Map grid orderBy tags to history metric tags

--- a/src/PlanViewer.App/Controls/QueryStoreOverviewControl.Donut.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreOverviewControl.Donut.cs
@@ -81,12 +81,15 @@ public partial class QueryStoreOverviewControl : UserControl
                 var labelR = (radius + innerRadius) / 2;
                 var lx = cx + labelR * Math.Cos(midAngle);
                 var ly = cy + labelR * Math.Sin(midAngle);
+                // Pick label ink by arc luminance (same rule as the bar cards) so the
+                // percentage stays readable on light fills instead of white-on-light.
+                var labelLuminance = 0.299 * color.R + 0.587 * color.G + 0.114 * color.B;
                 var pctLabel = new TextBlock
                 {
                     Text = $"{pct:F0}%",
                     FontSize = 10,
                     FontWeight = FontWeight.SemiBold,
-                    Foreground = Brushes.White,
+                    Foreground = new SolidColorBrush(labelLuminance > 128 ? Colors.Black : Colors.White),
                 };
                 pctLabel.Measure(Size.Infinity);
                 Canvas.SetLeft(pctLabel, lx - pctLabel.DesiredSize.Width / 2);

--- a/src/PlanViewer.App/Controls/QueryStoreOverviewControl.WaitStatsChart.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreOverviewControl.WaitStatsChart.cs
@@ -89,6 +89,7 @@ public partial class QueryStoreOverviewControl : UserControl
 
         var stepX = w / n;
         var barGap = Math.Min(2.0, Math.Max(0.5, stepX * 0.1));
+        const double segGap = 1.0; // surface gap between stacked segments so bands stay distinct
 
         for (int i = 0; i < n; i++)
         {
@@ -121,7 +122,7 @@ public partial class QueryStoreOverviewControl : UserControl
                 var rect = new Rectangle
                 {
                     Width = Math.Max(1, stepX - barGap),
-                    Height = Math.Max(0.5, segH),
+                    Height = Math.Max(0.5, segH - segGap),
                     Fill = new SolidColorBrush(color),
                 };
                 Canvas.SetLeft(rect, x);
@@ -139,7 +140,7 @@ public partial class QueryStoreOverviewControl : UserControl
                 var rect = new Rectangle
                 {
                     Width = Math.Max(1, stepX - barGap),
-                    Height = Math.Max(0.5, segH),
+                    Height = Math.Max(0.5, segH - segGap),
                     Fill = new SolidColorBrush(OthersColor),
                 };
                 Canvas.SetLeft(rect, x);

--- a/src/PlanViewer.App/Services/AppSettingsService.cs
+++ b/src/PlanViewer.App/Services/AppSettingsService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -76,6 +77,12 @@ internal sealed class AppSettingsService
             settings.QueryStoreTopLimit = Math.Clamp(settings.QueryStoreTopLimit, 1, 200);
             settings.MultiQsTopDbCount = Math.Clamp(settings.MultiQsTopDbCount, 2, 20);
             settings.QueryHistoryMaxPlans = Math.Clamp(settings.QueryHistoryMaxPlans, 1, 100);
+
+            // Migrate installs still on the old default palette to the validated
+            // colorblind-safe ramp. Only touches settings that exactly match the
+            // legacy defaults, so any user-customized colors are left untouched.
+            if (settings.MultiQsTopDbColors.SequenceEqual(LegacyTopDbColors, StringComparer.OrdinalIgnoreCase))
+                settings.MultiQsTopDbColors = new List<string>(DefaultTopDbColors);
 
             _cached = settings;
             return settings;
@@ -174,9 +181,23 @@ internal sealed class AppSettingsService
     }
 
     /// <summary>
-    /// Default color palette for Multi QS Overview top databases.
+    /// Default color palette for Multi QS Overview top databases. Eight hues from
+    /// the validated colorblind-safe categorical ramp (dark surface), in fixed CVD
+    /// order. Databases beyond the eighth fold into the neutral "Others" fill, so
+    /// no invented ninth hue is ever needed.
     /// </summary>
     internal static readonly List<string> DefaultTopDbColors = new()
+    {
+        "#3987E5", "#199E70", "#C98500", "#008300",
+        "#9085E9", "#E66767", "#D55181", "#D95926",
+    };
+
+    /// <summary>
+    /// The pre-dataviz default palette. Retained only so <see cref="Load"/> can
+    /// detect an installation still on the old defaults and migrate it to
+    /// <see cref="DefaultTopDbColors"/> without clobbering a user's custom colors.
+    /// </summary>
+    private static readonly List<string> LegacyTopDbColors = new()
     {
         "#2EAEF1", "#F2994A", "#27AE60", "#9B51E0", "#EB5757",
         "#F2C94C", "#56CCF2", "#BB6BD9", "#E91E63", "#00BCD4",

--- a/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
+++ b/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
@@ -7,5 +7,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Performance Studio for SSMS")]
 [assembly: AssemblyCopyright("Copyright Darling Data 2026")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("1.14.2.0")]
-[assembly: AssemblyFileVersion("1.14.2.0")]
+[assembly: AssemblyVersion("1.15.0.0")]
+[assembly: AssemblyFileVersion("1.15.0.0")]

--- a/src/PlanViewer.Ssms/source.extension.vsixmanifest
+++ b/src/PlanViewer.Ssms/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="PlanViewer.Ssms.64F79022-9D9A-4463-A1AE-4B19426A0CB1"
-              Version="1.14.2"
+              Version="1.15.0"
               Language="en-US"
               Publisher="Darling Data" />
     <DisplayName>Performance Studio for SSMS</DisplayName>


### PR DESCRIPTION
## v1.15.0

Data-viz release. Adopts a validated colorblind-safe palette for the Query Store visualizations (#382).

Version bumped 1.14.2 -> 1.15.0 across Directory.Build.props (desktop app + SDK projects) and the SSMS extension (AssemblyInfo.cs + source.extension.vsixmanifest) in lockstep.

Merging fires release.yml: creates the v1.15.0 GitHub release with generated notes, builds win-x64/linux-x64/osx-x64/osx-arm64 Velopack packages, and the SSMS VSIX.