### PR TITLE
Fix operator self-time: exclude coordinator thread, look through batch subtrees

### DIFF
--- a/src/PlanViewer.Core/PlanViewer.Core.csproj
+++ b/src/PlanViewer.Core/PlanViewer.Core.csproj
@@ -19,4 +19,10 @@
     <EmbeddedResource Include="Resources\WaitStats.json" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Self-time attribution (PlanAnalyzer.Timing) is internal but is the
+         source of every operator timing the UI and BenefitScorer report. -->
+    <InternalsVisibleTo Include="PlanViewer.Core.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/PlanViewer.Core/Services/NodeTimeAttribution.cs
+++ b/src/PlanViewer.Core/Services/NodeTimeAttribution.cs
@@ -100,6 +100,13 @@ public static class NodeTimeAttribution
                     .DefaultIfEmpty(0)
                     .Max();
             }
+            else if ((child.ActualExecutionMode ?? child.ExecutionMode) == "Batch")
+            {
+                // Batch operators report STANDALONE times, so the zone's times add
+                // rather than nest. Taking only this child's value would leave the
+                // rest of the zone inside the parent's "own" time.
+                sum += SumBatchSubtreeElapsedMs(child);
+            }
             else if (child.ActualElapsedMs > 0)
             {
                 sum += child.ActualElapsedMs;
@@ -108,6 +115,27 @@ public static class NodeTimeAttribution
             {
                 sum += GetChildElapsedMsSum(child); // skip through transparent operators
             }
+        }
+        return sum;
+    }
+
+    /// <summary>
+    /// Sums elapsed across a contiguous batch-mode zone, stopping at exchange
+    /// boundaries. Mirrors the analysis path in PlanAnalyzer.Timing.
+    /// </summary>
+    private static long SumBatchSubtreeElapsedMs(PlanNode node)
+    {
+        long sum = node.ActualElapsedMs;
+        foreach (var child in node.Children)
+        {
+            if (child.PhysicalOp == "Parallelism") continue; // zone boundary
+
+            if ((child.ActualExecutionMode ?? child.ExecutionMode) == "Batch")
+                sum += SumBatchSubtreeElapsedMs(child);
+            else if (child.ActualElapsedMs > 0)
+                sum += child.ActualElapsedMs; // row mode: already cumulative
+            else
+                sum += GetChildElapsedMsSum(child); // pass-through, no stats
         }
         return sum;
     }

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.Timing.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.Timing.cs
@@ -65,35 +65,40 @@ public static partial class PlanAnalyzer
     }
 
     /// <summary>
-    /// Per-thread self-time calculation for parallel row mode operators.
-    /// For each thread: self = parent_elapsed[t] - sum(children_elapsed[t]).
-    /// Returns max across threads.
+    /// Threads that actually did work. In a parallel plan thread 0 is the
+    /// coordinator: it carries no rows, and its ActualElapsedms is the wall clock
+    /// of the whole parallel branch. Including it in a per-thread self-time
+    /// calculation hands the operator the branch's entire duration.
+    /// A serial plan has a single thread numbered 0, which IS a worker, so only
+    /// exclude thread 0 when other threads exist.
     /// </summary>
-    private static long GetPerThreadOwnElapsed(PlanNode node)
+    private static List<PerThreadRuntimeInfo> WorkThreads(PlanNode node)
     {
-        // Build lookup: threadId -> parent elapsed for this node
-        var parentByThread = new Dictionary<int, long>();
-        foreach (var ts in node.PerThreadStats)
-            parentByThread[ts.ThreadId] = ts.ActualElapsedMs;
+        var workers = node.PerThreadStats.Where(t => t.ThreadId > 0).ToList();
+        return workers.Count > 0 ? workers : node.PerThreadStats;
+    }
 
-        // Build lookup: threadId -> sum of all direct children's elapsed
+    /// <summary>
+    /// Per-thread self-time calculation for parallel row mode operators.
+    /// For each worker thread: self = parent[t] - sum(effective children[t]).
+    /// Returns max across worker threads.
+    /// </summary>
+    private static long GetPerThreadOwnElapsed(PlanNode node) =>
+        GetPerThreadOwn(node, t => t.ActualElapsedMs, n => n.ActualElapsedMs);
+
+    private static long GetPerThreadOwn(
+        PlanNode node,
+        Func<PerThreadRuntimeInfo, long> pick,
+        Func<PlanNode, long> nodeTotal)
+    {
+        var parentByThread = new Dictionary<int, long>();
+        foreach (var ts in WorkThreads(node))
+            parentByThread[ts.ThreadId] = pick(ts);
+
         var childSumByThread = new Dictionary<int, long>();
         foreach (var child in node.Children)
-        {
-            var childNode = child;
+            AddEffectiveChildByThread(child, pick, nodeTotal, childSumByThread);
 
-            // Exchange operators have unreliable times — look through to their child
-            if (child.PhysicalOp == "Parallelism" && child.Children.Count > 0)
-                childNode = child.Children.OrderByDescending(c => c.ActualElapsedMs).First();
-
-            foreach (var ts in childNode.PerThreadStats)
-            {
-                childSumByThread.TryGetValue(ts.ThreadId, out var existing);
-                childSumByThread[ts.ThreadId] = existing + ts.ActualElapsedMs;
-            }
-        }
-
-        // Self-time per thread = parent - children, take max across threads
         var maxSelf = 0L;
         foreach (var (threadId, parentMs) in parentByThread)
         {
@@ -103,6 +108,83 @@ public static partial class PlanAnalyzer
         }
 
         return maxSelf;
+    }
+
+    /// <summary>
+    /// What a child contributes to its parent's per-thread total. The per-thread
+    /// mirror of GetEffectiveChildElapsedMs, and it must look through the same two
+    /// things the serial path does, or the parent absorbs the subtree beneath them:
+    ///
+    ///   - A batch-mode child reports STANDALONE time, so only its own value would
+    ///     come off and the rest of the batch zone would stay in the parent.
+    ///   - A pass-through child (Compute Scalar) carries no runtime stats at all,
+    ///     so zero would come off.
+    ///
+    /// Together these crowned a row-mode Nested Loops above a batch Hash Aggregate
+    /// as the hottest operator in its plan, with the aggregate's time counted twice.
+    /// </summary>
+    private static void AddEffectiveChildByThread(
+        PlanNode child,
+        Func<PerThreadRuntimeInfo, long> pick,
+        Func<PlanNode, long> nodeTotal,
+        Dictionary<int, long> acc)
+    {
+        // Exchange operators have unreliable times — look through to their child.
+        if (child.PhysicalOp == "Parallelism" && child.Children.Count > 0)
+        {
+            var dominant = child.Children.OrderByDescending(nodeTotal).First();
+            AddEffectiveChildByThread(dominant, pick, nodeTotal, acc);
+            return;
+        }
+
+        var mode = child.ActualExecutionMode ?? child.ExecutionMode;
+        if (mode == "Batch" && child.HasActualStats)
+        {
+            AddBatchSubtreeByThread(child, pick, nodeTotal, acc);
+            return;
+        }
+
+        if (child.HasActualStats && nodeTotal(child) > 0)
+        {
+            foreach (var ts in WorkThreads(child))
+            {
+                acc.TryGetValue(ts.ThreadId, out var existing);
+                acc[ts.ThreadId] = existing + pick(ts);
+            }
+            return;
+        }
+
+        // No runtime stats: look through to the descendants that have them.
+        foreach (var grandchild in child.Children)
+            AddEffectiveChildByThread(grandchild, pick, nodeTotal, acc);
+    }
+
+    /// <summary>
+    /// Per-thread sum across a contiguous batch-mode zone, stopping at exchanges.
+    /// Batch operators pipeline, so their times add rather than nest.
+    /// </summary>
+    private static void AddBatchSubtreeByThread(
+        PlanNode node,
+        Func<PerThreadRuntimeInfo, long> pick,
+        Func<PlanNode, long> nodeTotal,
+        Dictionary<int, long> acc)
+    {
+        foreach (var ts in WorkThreads(node))
+        {
+            acc.TryGetValue(ts.ThreadId, out var existing);
+            acc[ts.ThreadId] = existing + pick(ts);
+        }
+
+        foreach (var child in node.Children)
+        {
+            if (child.PhysicalOp == "Parallelism") continue; // zone boundary
+
+            var childMode = child.ActualExecutionMode ?? child.ExecutionMode;
+            if (childMode == "Batch" && child.HasActualStats)
+                AddBatchSubtreeByThread(child, pick, nodeTotal, acc);
+            else
+                AddEffectiveChildByThread(child, pick, nodeTotal, acc);
+        }
     }
 
     /// <summary>
@@ -116,33 +198,7 @@ public static partial class PlanAnalyzer
         if (!node.HasActualStats || node.ActualCPUMs <= 0) return 0;
 
         if (node.PerThreadStats.Count > 1)
-        {
-            var parentByThread = new Dictionary<int, long>();
-            foreach (var ts in node.PerThreadStats)
-                parentByThread[ts.ThreadId] = ts.ActualCPUMs;
-
-            var childSumByThread = new Dictionary<int, long>();
-            foreach (var child in node.Children)
-            {
-                var childNode = child;
-                if (child.PhysicalOp == "Parallelism" && child.Children.Count > 0)
-                    childNode = child.Children.OrderByDescending(c => c.ActualCPUMs).First();
-                foreach (var ts in childNode.PerThreadStats)
-                {
-                    childSumByThread.TryGetValue(ts.ThreadId, out var existing);
-                    childSumByThread[ts.ThreadId] = existing + ts.ActualCPUMs;
-                }
-            }
-
-            var maxSelf = 0L;
-            foreach (var (threadId, parentCpu) in parentByThread)
-            {
-                childSumByThread.TryGetValue(threadId, out var childCpu);
-                var self = Math.Max(0, parentCpu - childCpu);
-                if (self > maxSelf) maxSelf = self;
-            }
-            return maxSelf;
-        }
+            return GetPerThreadOwn(node, t => t.ActualCPUMs, n => n.ActualCPUMs);
 
         // Serial: operator_cpu - Σ effective child cpu
         var totalChildCpu = 0L;

--- a/src/PlanViewer.Core/Services/ShowPlanParser.RelOp.cs
+++ b/src/PlanViewer.Core/Services/ShowPlanParser.RelOp.cs
@@ -675,7 +675,13 @@ public static partial class ShowPlanParser
             node.HasActualStats = true;
             long totalRows = 0, totalExecutions = 0, totalRowsRead = 0;
             long totalRebinds = 0, totalRewinds = 0;
-            long maxElapsed = 0, totalCpu = 0;
+            // Elapsed takes the max across threads, but thread 0 is the coordinator
+            // in a parallel plan: no rows, and an elapsed equal to the whole parallel
+            // branch's wall clock. Taking the max over it makes every operator in the
+            // branch look like it took the branch's entire duration. A serial plan has
+            // one thread numbered 0, which is a worker, so fall back to it.
+            long maxElapsed = 0, maxWorkerElapsed = 0, totalCpu = 0;
+            var sawWorkerThread = false;
             long totalLogicalReads = 0, totalPhysicalReads = 0;
             long totalScans = 0, totalReadAheads = 0;
             long totalLobLogicalReads = 0, totalLobPhysicalReads = 0, totalLobReadAheads = 0;
@@ -721,6 +727,13 @@ public static partial class ShowPlanParser
 
                 var elapsed = ParseLong(thread.Attribute("ActualElapsedms")?.Value);
                 if (elapsed > maxElapsed) maxElapsed = elapsed;
+
+                var threadId = (int)ParseDouble(thread.Attribute("Thread")?.Value);
+                if (threadId > 0)
+                {
+                    sawWorkerThread = true;
+                    if (elapsed > maxWorkerElapsed) maxWorkerElapsed = elapsed;
+                }
             }
 
             node.ActualRows = totalRows;
@@ -728,7 +741,7 @@ public static partial class ShowPlanParser
             node.ActualRowsRead = totalRowsRead;
             node.ActualRebinds = totalRebinds;
             node.ActualRewinds = totalRewinds;
-            node.ActualElapsedMs = maxElapsed;
+            node.ActualElapsedMs = sawWorkerThread ? maxWorkerElapsed : maxElapsed;
             node.ActualCPUMs = totalCpu;
             node.ActualLogicalReads = totalLogicalReads;
             node.ActualPhysicalReads = totalPhysicalReads;

--- a/tests/PlanViewer.Core.Tests/OperatorSelfTimeTests.cs
+++ b/tests/PlanViewer.Core.Tests/OperatorSelfTimeTests.cs
@@ -1,0 +1,134 @@
+using System.Linq;
+using PlanViewer.Core.Models;
+using PlanViewer.Core.Services;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// Self-time attribution for parallel operators.
+///
+/// Two traps, both of which inflated a parent operator until it was reported as
+/// the hottest in its plan:
+///
+///   1. Thread 0 is the coordinator. It carries no rows, and its ActualElapsedms
+///      is the wall clock of the whole parallel branch.
+///   2. A row-mode parent above a batch-mode subtree, or above a pass-through
+///      operator with no runtime stats, subtracted too little from itself.
+/// </summary>
+public class OperatorSelfTimeTests
+{
+    private static PlanNode? TryFindNode(PlanNode root, int nodeId)
+    {
+        if (root.NodeId == nodeId) return root;
+        foreach (var child in root.Children)
+        {
+            var found = TryFindNode(child, nodeId);
+            if (found is not null) return found;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// The statement's RootNode is a synthetic wrapper (NodeId -1). The plan's
+    /// real root operator is its first child.
+    /// </summary>
+    private static PlanNode RootOf(string planFile)
+    {
+        var plan = PlanTestHelper.LoadAndAnalyze(planFile);
+        var wrapper = plan.Batches[0].Statements[0].RootNode!;
+        return wrapper.NodeId < 0 ? wrapper.Children[0] : wrapper;
+    }
+
+    [Fact]
+    public void CoordinatorThreadIsNotCountedAsOperatorElapsedTime()
+    {
+        var root = RootOf("parallel_row_over_batch_plan.sqlplan");
+
+        // Thread 0 reports 1000ms (the branch's wall clock) with zero rows. The
+        // slowest worker also reports 1000ms here, so the node-level number is the
+        // same -- what matters is that we source it from a worker, not the
+        // coordinator, and that the coordinator never wins a max on its own.
+        var coordinator = root.PerThreadStats.Single(t => t.ThreadId == 0);
+        Assert.Equal(0, coordinator.ActualRows);
+        Assert.Equal(1000, coordinator.ActualElapsedMs);
+
+        // The Columnstore scan's coordinator row is 0ms while its workers are 0ms
+        // too, but the Hash Match's coordinator is 0ms and workers are 900/890.
+        var hashMatch = TryFindNode(root, 2)!;
+        Assert.Equal(900, hashMatch.ActualElapsedMs); // max over WORKERS, not thread 0
+    }
+
+    [Fact]
+    public void RowModeParentAboveBatchSubtreeDoesNotAbsorbIt()
+    {
+        var root = RootOf("parallel_row_over_batch_plan.sqlplan");
+
+        // Node 0 is a parallel row-mode Nested Loops. Slowest worker: 1000ms.
+        // Beneath it: a batch Compute Scalar (0ms) hiding a batch Hash Match
+        // (900ms), plus a row-mode Index Seek (50ms).
+        //
+        // Correct self time = 1000 - (0 + 900) - 50 = 50ms.
+        // Before the fix this reported 1000ms: the pass-through contributed
+        // nothing, the batch zone contributed only its topmost value, and the
+        // coordinator's 1000ms won the per-thread max outright.
+        var own = PlanAnalyzer.GetOperatorOwnElapsedMs(root);
+        Assert.InRange(own, 40, 60);
+    }
+
+    [Fact]
+    public void RowModeParentAboveBatchSubtreeDoesNotAbsorbItsCpu()
+    {
+        var root = RootOf("parallel_row_over_batch_plan.sqlplan");
+
+        // Busiest worker CPU on node 0 is 30ms. Beneath it, per that same thread:
+        // batch zone 0 + 12 = 12ms, row seek 6ms. Self CPU = 30 - 18 = 12ms.
+        var ownCpu = PlanAnalyzer.GetOperatorMaxThreadOwnCpuMs(root);
+        Assert.InRange(ownCpu, 8, 16);
+    }
+
+    [Fact]
+    public void BatchOperatorKeepsItsStandaloneTime()
+    {
+        var root = RootOf("parallel_row_over_batch_plan.sqlplan");
+        var hashMatch = TryFindNode(root, 2)!;
+
+        // Batch mode reports self time directly. Subtracting children would
+        // underflow it.
+        Assert.Equal(900, PlanAnalyzer.GetOperatorOwnElapsedMs(hashMatch));
+    }
+
+    [Fact]
+    public void ParallelPassThroughChildDoesNotInflateItsParent()
+    {
+        // join_or_clause_plan has a parallel row-mode TopN Sort above a Compute
+        // Scalar that carries no runtime statistics. Subtracting zero for it made
+        // the sort absorb everything below.
+        var root = RootOf("join_or_clause_plan.sqlplan");
+        var sort = TryFindNode(root, 8);
+        Assert.NotNull(sort);
+
+        var own = PlanAnalyzer.GetOperatorOwnElapsedMs(sort!);
+        var cumulative = sort!.ActualElapsedMs;
+
+        // Self time must be strictly less than cumulative: the subtree below it
+        // did real work, and that work is not the sort's own.
+        Assert.True(
+            own < cumulative,
+            $"sort reported {own}ms self of {cumulative}ms cumulative -- it absorbed its subtree");
+    }
+
+    [Fact]
+    public void SerialPlanStillUsesItsOnlyThread()
+    {
+        // A serial plan has a single thread numbered 0. It is a worker, not a
+        // coordinator, and excluding it would zero out every operator.
+        var root = RootOf("key_lookup_plan.sqlplan");
+        var withStats = TryFindNode(root, 0);
+        Assert.NotNull(withStats);
+        if (withStats!.HasActualStats && withStats.PerThreadStats.Count == 1)
+        {
+            Assert.Equal(0, withStats.PerThreadStats[0].ThreadId);
+            Assert.True(withStats.ActualElapsedMs >= 0);
+        }
+    }
+}

--- a/tests/PlanViewer.Core.Tests/Plans/parallel_row_over_batch_plan.sqlplan
+++ b/tests/PlanViewer.Core.Tests/Plans/parallel_row_over_batch_plan.sqlplan
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Synthetic plan. Two timing traps in one shape:
+
+  1. Thread 0 is the coordinator: zero rows, but its ActualElapsedms is the whole
+     parallel branch's wall clock (1000ms). Including it in per-thread self-time
+     hands the operator the branch's entire duration.
+
+  2. A row-mode Nested Loops sits above a BATCH-mode subtree. Batch operators
+     report standalone times, so subtracting only the topmost batch child's value
+     leaves the rest of the zone inside the parent.
+
+  Correct self elapsed for node 0 = slowest worker (1000)
+                                    - batch zone (0 + 900)
+                                    - row child (50)
+                                  = 50ms.
+  Before the fix it reported 1000ms and was crowned the hottest operator.
+-->
+<ShowPlanXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Version="1.539" Build="16.0.4003.1" xmlns="http://schemas.microsoft.com/sqlserver/2004/07/showplan">
+  <BatchSequence>
+    <Batch>
+      <Statements>
+        <StmtSimple StatementCompId="1" StatementEstRows="1" StatementId="1" StatementOptmLevel="FULL" StatementSubTreeCost="1" StatementText="SELECT 1;" StatementType="SELECT" QueryHash="0x0000000000000001" QueryPlanHash="0x0000000000000002">
+          <QueryPlan DegreeOfParallelism="2" CachedPlanSize="16" CompileTime="1" CompileCPU="1" CompileMemory="16">
+            <QueryTimeStats CpuTime="60" ElapsedTime="1000" />
+            <RelOp NodeId="0" PhysicalOp="Nested Loops" LogicalOp="Inner Join" EstimateRows="1" EstimateIO="0" EstimateCPU="0" AvgRowSize="9" EstimatedTotalSubtreeCost="1" Parallel="1" EstimateRebinds="0" EstimateRewinds="0" EstimatedExecutionMode="Row">
+              <OutputList />
+              <RunTimeInformation>
+                <RunTimeCountersPerThread Thread="0" ActualRows="0" ActualExecutions="0" ActualElapsedms="1000" ActualCPUms="0" ActualExecutionMode="Row" />
+                <RunTimeCountersPerThread Thread="1" ActualRows="1" ActualExecutions="1" ActualElapsedms="1000" ActualCPUms="30" ActualExecutionMode="Row" />
+                <RunTimeCountersPerThread Thread="2" ActualRows="1" ActualExecutions="1" ActualElapsedms="990" ActualCPUms="28" ActualExecutionMode="Row" />
+              </RunTimeInformation>
+              <NestedLoops Optimized="0">
+                <RelOp NodeId="1" PhysicalOp="Compute Scalar" LogicalOp="Compute Scalar" EstimateRows="1" EstimateIO="0" EstimateCPU="0" AvgRowSize="9" EstimatedTotalSubtreeCost="1" Parallel="1" EstimateRebinds="0" EstimateRewinds="0" EstimatedExecutionMode="Batch">
+                  <OutputList />
+                  <RunTimeInformation>
+                    <RunTimeCountersPerThread Thread="0" ActualRows="0" ActualExecutions="0" ActualElapsedms="0" ActualCPUms="0" ActualExecutionMode="Batch" />
+                    <RunTimeCountersPerThread Thread="1" ActualRows="1" ActualExecutions="1" ActualElapsedms="0" ActualCPUms="0" ActualExecutionMode="Batch" />
+                    <RunTimeCountersPerThread Thread="2" ActualRows="1" ActualExecutions="1" ActualElapsedms="0" ActualCPUms="0" ActualExecutionMode="Batch" />
+                  </RunTimeInformation>
+                  <ComputeScalar>
+                    <DefinedValues />
+                    <RelOp NodeId="2" PhysicalOp="Hash Match" LogicalOp="Aggregate" EstimateRows="1" EstimateIO="0" EstimateCPU="0" AvgRowSize="9" EstimatedTotalSubtreeCost="1" Parallel="1" EstimateRebinds="0" EstimateRewinds="0" EstimatedExecutionMode="Batch">
+                      <OutputList />
+                      <RunTimeInformation>
+                        <RunTimeCountersPerThread Thread="0" ActualRows="0" ActualExecutions="0" ActualElapsedms="0" ActualCPUms="0" ActualExecutionMode="Batch" />
+                        <RunTimeCountersPerThread Thread="1" ActualRows="1" ActualExecutions="1" ActualElapsedms="900" ActualCPUms="12" ActualExecutionMode="Batch" />
+                        <RunTimeCountersPerThread Thread="2" ActualRows="1" ActualExecutions="1" ActualElapsedms="890" ActualCPUms="11" ActualExecutionMode="Batch" />
+                      </RunTimeInformation>
+                      <Hash>
+                        <DefinedValues />
+                        <RelOp NodeId="3" PhysicalOp="Columnstore Index Scan" LogicalOp="Index Scan" EstimateRows="1" EstimateIO="0" EstimateCPU="0" AvgRowSize="9" EstimatedTotalSubtreeCost="1" Parallel="1" EstimateRebinds="0" EstimateRewinds="0" EstimatedExecutionMode="Batch" TableCardinality="1000">
+                          <OutputList />
+                          <RunTimeInformation>
+                            <RunTimeCountersPerThread Thread="0" ActualRows="0" ActualExecutions="0" ActualElapsedms="0" ActualCPUms="0" ActualExecutionMode="Batch" />
+                            <RunTimeCountersPerThread Thread="1" ActualRows="500" ActualExecutions="1" ActualElapsedms="0" ActualCPUms="0" ActualExecutionMode="Batch" />
+                            <RunTimeCountersPerThread Thread="2" ActualRows="500" ActualExecutions="1" ActualElapsedms="0" ActualCPUms="0" ActualExecutionMode="Batch" />
+                          </RunTimeInformation>
+                          <IndexScan Ordered="0" ForcedIndex="0" ForceSeek="0" ForceScan="0" NoExpandHint="0" Storage="ColumnStore">
+                            <Object Database="[d]" Schema="[dbo]" Table="[Facts]" Index="[CCI_Facts]" IndexKind="NonClustered" Storage="ColumnStore" />
+                          </IndexScan>
+                        </RelOp>
+                      </Hash>
+                    </RelOp>
+                  </ComputeScalar>
+                </RelOp>
+                <RelOp NodeId="4" PhysicalOp="Index Seek" LogicalOp="Index Seek" EstimateRows="1" EstimateIO="0" EstimateCPU="0" AvgRowSize="9" EstimatedTotalSubtreeCost="1" Parallel="1" EstimateRebinds="0" EstimateRewinds="0" EstimatedExecutionMode="Row" TableCardinality="1000">
+                  <OutputList />
+                  <RunTimeInformation>
+                    <RunTimeCountersPerThread Thread="0" ActualRows="0" ActualExecutions="0" ActualElapsedms="0" ActualCPUms="0" ActualExecutionMode="Row" />
+                    <RunTimeCountersPerThread Thread="1" ActualRows="1" ActualExecutions="1" ActualElapsedms="50" ActualCPUms="6" ActualExecutionMode="Row" />
+                    <RunTimeCountersPerThread Thread="2" ActualRows="1" ActualExecutions="1" ActualElapsedms="48" ActualCPUms="5" ActualExecutionMode="Row" />
+                  </RunTimeInformation>
+                  <IndexScan Ordered="1" ScanDirection="FORWARD" ForcedIndex="0" ForceSeek="0" ForceScan="0" NoExpandHint="0" Storage="RowStore">
+                    <Object Database="[d]" Schema="[dbo]" Table="[Dim]" Index="[PK_Dim]" IndexKind="Clustered" Storage="RowStore" />
+                  </IndexScan>
+                </RelOp>
+              </NestedLoops>
+            </RelOp>
+          </QueryPlan>
+        </StmtSimple>
+      </Statements>
+    </Batch>
+  </BatchSequence>
+</ShowPlanXML>

--- a/tests/PlanViewer.Core.Tests/WarningBaseline.txt
+++ b/tests/PlanViewer.Core.Tests/WarningBaseline.txt
@@ -93,7 +93,7 @@ Filter Operator | Warning | Filter operator discarding rows late in the plan.\nâ
 Nested Loops High Executions | Critical | Nested Loops inner side executed 17,091,572 times (DOP 8). Inner side total: 93,279,732 logical reads. Inner side time: 30,655ms (93% of statement). Consider whether a hash or merge join would be more appropriate for this row count.
 Scan With Predicate | Warning | Scan with residual predicate â€” SQL Server is reading every row and filtering after the fact. Check that you have appropriate indexes.\nPredicate: [StackOverflow2013].[dbo].[Posts].[PostTypeId] as [p].[PostTypeId]=(1) OR [StackOverflow2013].[dbo].[Posts].[PostTypeId] as [p].[PostTypeId]=(2)
 Nested Loops High Executions | Critical | Nested Loops inner side executed 30,700,008 times (DOP 8). Inner side total: 93,279,732 logical reads. Inner side time: 14,355ms (43% of statement). Consider whether a hash or merge join would be more appropriate for this row count.
-Expensive Operator | Critical | Sort took 19,602ms (59.3% of statement elapsed) but no specific rule identified a fix. Worth investigating: is the row volume necessary? Are upstream estimates driving this operator harder than it should be?
+Expensive Operator | Critical | Sort took 18,580ms (56.2% of statement elapsed) but no specific rule identified a fix. Worth investigating: is the row volume necessary? Are upstream estimates driving this operator harder than it should be?
 Join OR Clause | Warning | OR in a join predicate. SQL Server rewrote the OR as 2 separate lookups, each evaluated independently â€” this multiplies the work on the inner side. Rewrite as separate queries joined with UNION ALL. For example, change "FROM a JOIN b ON a.x = b.x OR a.y = b.y" to "FROM a JOIN b ON a.x = b.x UNION ALL FROM a JOIN b ON a.y = b.y".
 Expensive Operator | Warning | Clustered Index Seek took 14,355ms (43.4% of statement elapsed) but no specific rule identified a fix. Worth investigating: is the row volume necessary? Are upstream estimates driving this operator harder than it should be?
 
@@ -209,6 +209,10 @@ Filter Operator | Warning | Filter operator discarding rows late in the plan.\nâ
 Row Estimate Mismatch | Critical | Estimated 5,292,870 vs Actual 53,946 (13,486 rows x 4 executions) â€” 392x overestimated. The overestimate may have caused the optimizer to make poor choices.
 Parallel Skew | Warning | Thread 3 processed 100% of rows (53,946/53,946). Work is heavily skewed to one thread, so parallelism isn't helping much. Common causes: uneven data distribution across partitions or hash buckets, or a scan/seek whose predicate sends most rows to one range. Reducing DOP or rewriting the query to avoid the skewed operation may help.
 Bare Scan | Warning | Clustered index scan reads the full table with no predicate, outputting 1 column(s): Votes.PostId. Consider a nonclustered index on the output columns (as key or INCLUDE) so SQL Server can read a narrower structure. For analytical workloads, a columnstore index may be a better fit.
+
+### parallel_row_over_batch_plan.sqlplan
+Standard Edition DOP Limitation | Info | DOP is limited to 2 and the plan uses batch mode operators. This may be caused by the SQL Server Standard Edition limitation, which caps parallelism at 2 when batch mode is in use. If this server runs Standard Edition, Developer or Enterprise Edition would allow higher DOP.
+Expensive Operator | Critical | Hash Match took 900ms (90.0% of statement elapsed) but no specific rule identified a fix. Worth investigating: is the row volume necessary? Are upstream estimates driving this operator harder than it should be?
 
 ### param-sniffing-posttypeid2.sqlplan
 Wait: RESERVED_MEMORY_ALLOCATION_EXT | Info | RESERVED_MEMORY_ALLOCATION_EXT Observed 1,051 ms across 2,052,049 waits.


### PR DESCRIPTION
Two bugs in self-time attribution. Both inflate an operator until it is reported as the hottest in its plan, which is the single most damaging thing a plan analyzer can get wrong.

Found while building a portable query-plan skill that transcribed this code. I mirrored `PlanAnalyzer.Timing.cs` faithfully — including its bugs — and only found them when the Python copy started blaming the wrong operators on real plans.

## 1. Thread 0 is the coordinator

In a parallel plan, thread 0 carries **no rows**, and its `ActualElapsedms` is the wall clock of the **whole parallel branch**.

`GetPerThreadOwnElapsed` iterated every thread including it, so any operator near the top of a parallel branch was handed the branch's entire duration as its own work — and its self CPU underflowed to zero, because the coordinator burns none. `ShowPlanParser.RelOp` also took node-level elapsed as the max across all threads, coordinator included.

Measured across `.internal/examples`: of **1,014** non-exchange parallel operators, the coordinator reports rows in **0** cases and elapsed in **65**. Those 65 are precisely the operators that win a ranking by self time, so the error was concentrated exactly where it does the most damage.

Serial plans have a single thread numbered 0, which *is* a worker. Thread 0 is only excluded when other threads exist.

## 2. The parallel path didn't look through batch subtrees or pass-throughs

`GetSerialOwnElapsed` subtracts `GetEffectiveChildElapsedMs`, which looks through `Compute Scalar` pass-throughs and sums contiguous batch zones via `SumBatchSubtreeElapsedMs`.

`GetPerThreadOwnElapsed` subtracted each child's **raw per-thread value**, special-casing only `Parallelism` children. So:

- a **batch-mode child** reports standalone time, so only its topmost value came off and the rest of the zone stayed inside the parent;
- a **pass-through child** carries no runtime stats at all, so zero came off and the parent absorbed the entire subtree beneath it.

On `cross-apply-point-in-time-slow.sqlplan`, a row-mode `Nested Loops` above a batch `Compute Scalar` (0 ms) hiding a batch `Hash Match (Aggregate)` (45,683 ms) reported **45,737 ms of self time and led the ranking**. Its real self time is **1 ms**, and the aggregate's time was double-counted into both rows.

Both paths now share the same helpers, for elapsed and CPU. `NodeTimeAttribution` (the display path) gets the matching batch-subtree summation, so the graphical plan and the analyzer agree.

## Test plan

New `OperatorSelfTimeTests` with a small synthetic fixture (`parallel_row_over_batch_plan.sqlplan`) that encodes both traps in one shape: a parallel row-mode Nested Loops, a coordinator thread reporting the branch wall clock, a batch zone hidden behind a stats-less Compute Scalar, and a row-mode sibling. Correct self time is 50 ms; the unfixed code reports 1000 ms.

**Three of the six new tests fail against the unfixed code**, verified by stashing the source changes and re-running. One of the three, `ParallelPassThroughChildDoesNotInflateItsParent`, uses the **existing** `join_or_clause_plan.sqlplan` fixture — so this was live on real plans already in the repo, not only on synthetic ones.

Full suite: **101 passed, 0 failed.**

`PlanViewer.Core.csproj` now grants `InternalsVisibleTo` the test project. `PlanAnalyzer.Timing` is `internal`, but it is the source of every operator timing the UI and `BenefitScorer` report, and it had no tests.

## Baseline change

`WarningBaseline.txt` moves by exactly one line:

```
- Sort took 19,602ms (59.3% of statement elapsed) ...
+ Sort took 18,580ms (56.2% of statement elapsed) ...
```

That is `join_or_clause_plan`'s Sort giving back the Compute Scalar subtree it had absorbed. The warning still fires; the number is now correct. No warnings appear or disappear on any other plan, and no other plan's digest changes.

## Not addressed here

`DetectCeGuess` labels its selectivity bands "30% equality guess" / "10% inequality guess". The thresholds fire correctly; the names look transposed (9% is 0.3 × 0.3 and 16.4% is 0.3 × √0.3, which only reconstruct if the base inequality guess is 30%). Left alone per Erik — PlanViewer is slightly different and that's fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)