### PR TITLE
Add Query Store query-text search filter

### DIFF
--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.Filters.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.Filters.cs
@@ -84,6 +84,9 @@ public partial class QueryStoreGridControl : UserControl
                 // Default to dbo schema if no schema specified, following sp_QuickieStore pattern
                 filter.ModuleName = searchValue.Contains('.') ? searchValue : $"dbo.{searchValue}";
                 break;
+            case "query-text":
+                filter.QueryTextSearch = searchValue;
+                break;
             default:
                 return null;
         }

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
@@ -86,6 +86,7 @@
                         <ComboBoxItem Content="Query Hash" Tag="query-hash"/>
                         <ComboBoxItem Content="Plan Hash" Tag="plan-hash"/>
                         <ComboBoxItem Content="Module" Tag="module"/>
+                        <ComboBoxItem Content="Query Text" Tag="query-text"/>
                         <ComboBoxItem Content="Execution Type" Tag="execution-type"/>
                     </ComboBox>
                 </StackPanel>

--- a/src/PlanViewer.App/Mcp/McpQueryStoreTools.cs
+++ b/src/PlanViewer.App/Mcp/McpQueryStoreTools.cs
@@ -55,7 +55,7 @@ public sealed class McpQueryStoreTools
         "Each fetched plan is automatically loaded into the application for further analysis " +
         "with analyze_plan, get_plan_warnings, etc. Returns summary stats and session IDs. " +
         "Optional filters narrow results server-side by query_id, plan_id, query_hash, " +
-        "plan_hash, or module name (schema.name, supports % wildcards).")]
+        "plan_hash, module name (schema.name, supports % wildcards), or query text (query_text_search).")]
     public static async Task<string> GetQueryStoreTop(
         PlanSessionManager sessionManager,
         ConnectionStore connectionStore,
@@ -72,6 +72,7 @@ public sealed class McpQueryStoreTools
         [Description("Filter by query hash (hex, e.g. 0x1AB2C3D4).")] string? query_hash = null,
         [Description("Filter by query plan hash (hex, e.g. 0x1AB2C3D4).")] string? plan_hash = null,
         [Description("Filter by module name (schema.name, supports % wildcards).")] string? module = null,
+        [Description("Filter to queries whose SQL text contains this string. Matched with SQL LIKE (auto-wrapped in %); % _ [ ] act as wildcards.")] string? query_text_search = null,
         [Description("Filter by execution type: regular, aborted, exception, or failed (= aborted + exception).")] string? execution_type = null)
     {
         try
@@ -98,7 +99,7 @@ public sealed class McpQueryStoreTools
 
             QueryStoreFilter? filter = null;
             if (query_id != null || plan_id != null ||
-                query_hash != null || plan_hash != null || module != null ||
+                query_hash != null || plan_hash != null || module != null || query_text_search != null ||
                 executionTypes != null)
             {
                 filter = new QueryStoreFilter
@@ -108,6 +109,7 @@ public sealed class McpQueryStoreTools
                     QueryHash = query_hash,
                     QueryPlanHash = plan_hash,
                     ModuleName = module,
+                    QueryTextSearch = query_text_search,
                     ExecutionTypeDescs = executionTypes,
                 };
             }

--- a/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
+++ b/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
@@ -129,6 +129,11 @@ public static class QueryStoreCommand
             Description = "Filter by module name (schema.name, supports % wildcards)"
         };
 
+        var queryTextSearchOption = new Option<string?>("--query-text-search")
+        {
+            Description = "Filter to queries whose text contains this string (SQL LIKE match, auto-wrapped in %; % _ [ ] are wildcards)"
+        };
+
         var executionTypeOption = new Option<string?>("--execution-type")
         {
             Description = "Filter by execution type: regular, aborted, exception, or failed (= aborted + exception)"
@@ -140,7 +145,7 @@ public static class QueryStoreCommand
             outputDirOption, outputOption, compactOption, warningsOnlyOption, configOption,
             authOption, trustCertOption, loginOption, passwordOption, passwordStdinOption,
             queryIdOption, planIdOption, queryHashOption, planHashOption, moduleOption,
-            executionTypeOption
+            queryTextSearchOption, executionTypeOption
         };
 
         cmd.SetAction(async (parseResult, ct) =>
@@ -165,6 +170,7 @@ public static class QueryStoreCommand
             var filterQueryHash = parseResult.GetValue(queryHashOption);
             var filterPlanHash = parseResult.GetValue(planHashOption);
             var filterModule = parseResult.GetValue(moduleOption);
+            var filterQueryTextSearch = parseResult.GetValue(queryTextSearchOption);
             var filterExecutionType = parseResult.GetValue(executionTypeOption);
 
             // Load .env file if present (CLI args take precedence)
@@ -211,7 +217,7 @@ public static class QueryStoreCommand
 
             QueryStoreFilter? filter = null;
             if (filterQueryId != null || filterPlanId != null ||
-                filterQueryHash != null || filterPlanHash != null || filterModule != null ||
+                filterQueryHash != null || filterPlanHash != null || filterModule != null || filterQueryTextSearch != null ||
                 executionTypes != null)
             {
                 filter = new QueryStoreFilter
@@ -221,6 +227,7 @@ public static class QueryStoreCommand
                     QueryHash = filterQueryHash,
                     QueryPlanHash = filterPlanHash,
                     ModuleName = filterModule,
+                    QueryTextSearch = filterQueryTextSearch,
                     ExecutionTypeDescs = executionTypes,
                 };
             }

--- a/src/PlanViewer.Core/Models/QueryStorePlan.cs
+++ b/src/PlanViewer.Core/Models/QueryStorePlan.cs
@@ -19,6 +19,8 @@ public class QueryStoreFilter
     /// </summary>
     public string[]? ExecutionTypeDescs { get; set; }
 
+    public string? QueryTextSearch { get; set; }
+
     /// <summary>
     /// Parses a user-friendly execution-type string into the matching SQL execution_type_desc values.
     /// Accepts (case-insensitive): regular, aborted, exception, failed (= aborted + exception), any.
@@ -37,6 +39,22 @@ public class QueryStoreFilter
             _ => throw new ArgumentException(
                 $"Unknown execution type '{input}'. Valid values: regular, aborted, exception, failed, any."),
         };
+    }
+
+    /// <summary>
+    /// Builds the LIKE pattern for a query-text search, mirroring sp_QuickieStore's
+    /// @query_text_search default behavior: trims, then wraps the term in leading/
+    /// trailing % wildcards when not already present. %, _, [, ] remain LIKE
+    /// wildcards (sp_QuickieStore's default @escape_brackets = 0). Returns null for
+    /// null/whitespace input (no filter), matching ParseExecutionType's contract.
+    /// </summary>
+    public static string? BuildQueryTextSearchPattern(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input)) return null;
+        var s = input.Trim();
+        if (!s.StartsWith('%')) s = "%" + s;
+        if (!s.EndsWith('%')) s += "%";
+        return s;
     }
 }
 

--- a/src/PlanViewer.Core/Services/QueryStoreService.Grouped.cs
+++ b/src/PlanViewer.Core/Services/QueryStoreService.Grouped.cs
@@ -60,6 +60,18 @@ public static partial class QueryStoreService
                 filterClauses.Add("AND OBJECT_SCHEMA_NAME(q.object_id) + N'.' + OBJECT_NAME(q.object_id) = @filterModule");
             parameters.Add(new SqlParameter("@filterModule", moduleVal));
         }
+        var queryTextPattern = QueryStoreFilter.BuildQueryTextSearchPattern(filter?.QueryTextSearch);
+        if (queryTextPattern != null)
+        {
+            filterClauses.Add(@"AND EXISTS (
+            SELECT 1
+            FROM sys.query_store_query AS qsq
+            JOIN sys.query_store_query_text AS qsqt
+                ON qsqt.query_text_id = qsq.query_text_id
+            WHERE qsq.query_id = p.query_id
+            AND qsqt.query_sql_text LIKE @filterQueryText)");
+            parameters.Add(new SqlParameter("@filterQueryText", queryTextPattern));
+        }
         var filterSql = filterClauses.Count > 0 ? "\n" + string.Join("\n", filterClauses) : "";
         var phase2ExecutionTypeClause = "";
         if (filter?.ExecutionTypeDescs?.Length > 0)
@@ -339,6 +351,18 @@ SELECT * FROM #plan_hash_rows ORDER BY query_hash, total_executions DESC;
         {
             filterClauses.Add("AND q.query_hash = CONVERT(binary(8), @filterQueryHash, 1)");
             parameters.Add(new SqlParameter("@filterQueryHash", filter.QueryHash.Trim()));
+        }
+        var queryTextPattern = QueryStoreFilter.BuildQueryTextSearchPattern(filter?.QueryTextSearch);
+        if (queryTextPattern != null)
+        {
+            filterClauses.Add(@"AND EXISTS (
+            SELECT 1
+            FROM sys.query_store_query AS qsq
+            JOIN sys.query_store_query_text AS qsqt
+                ON qsqt.query_text_id = qsq.query_text_id
+            WHERE qsq.query_id = p.query_id
+            AND qsqt.query_sql_text LIKE @filterQueryText)");
+            parameters.Add(new SqlParameter("@filterQueryText", queryTextPattern));
         }
         var filterSql = filterClauses.Count > 0 ? "\n" + string.Join("\n", filterClauses) : "";
         var phase2ExecutionTypeClause = "";

--- a/src/PlanViewer.Core/Services/QueryStoreService.cs
+++ b/src/PlanViewer.Core/Services/QueryStoreService.cs
@@ -163,6 +163,19 @@ FROM sys.database_query_store_options;";
             needsQueryJoin = true;
         }
 
+        var queryTextPattern = QueryStoreFilter.BuildQueryTextSearchPattern(filter?.QueryTextSearch);
+        if (queryTextPattern != null)
+        {
+            filterClauses.Add(@"AND EXISTS (
+            SELECT 1
+            FROM sys.query_store_query AS qsq
+            JOIN sys.query_store_query_text AS qsqt
+                ON qsqt.query_text_id = qsq.query_text_id
+            WHERE qsq.query_id = p.query_id
+            AND qsqt.query_sql_text LIKE @filterQueryText)");
+            parameters.Add(new SqlParameter("@filterQueryText", queryTextPattern));
+        }
+
         var rnClause = filter?.PlanId != null ? "" : "AND r.rn = 1";
         var filterSql = filterClauses.Count > 0
             ? "\n        " + string.Join("\n        ", filterClauses)

--- a/tests/PlanViewer.Core.Tests/QueryTextSearchPatternTests.cs
+++ b/tests/PlanViewer.Core.Tests/QueryTextSearchPatternTests.cs
@@ -1,0 +1,65 @@
+using PlanViewer.Core.Models;
+
+namespace PlanViewer.Core.Tests;
+
+// Locks in the two static helpers on QueryStoreFilter that back the Query Store
+// query-text search filter (feature/qs-query-text-search).
+// BuildQueryTextSearchPattern mirrors sp_QuickieStore's @query_text_search default:
+// trim, then wrap the term in leading/trailing % when not already present. With
+// sp_QuickieStore's default @escape_brackets = 0, the LIKE metacharacters %, _, [
+// and ] are left live (this is the documented phase-1 wildcard behavior).
+// ParseExecutionType is a sibling helper on the same model; its mapping and error
+// contract are backfilled here.
+public class QueryTextSearchPatternTests
+{
+    [Theory]
+    // Bare term gets wrapped on both sides.
+    [InlineData("SELECT", "%SELECT%")]
+    // A % already on one end is kept, not doubled.
+    [InlineData("%SELECT", "%SELECT%")]
+    [InlineData("SELECT%", "%SELECT%")]
+    // Fully wrapped term is returned unchanged.
+    [InlineData("%SELECT%", "%SELECT%")]
+    // Interior wildcards survive; only the ends are padded.
+    [InlineData("a%b", "%a%b%")]
+    // A lone % already starts and ends with %, so it stays match-anything.
+    [InlineData("%", "%")]
+    // Surrounding whitespace is trimmed before wrapping.
+    [InlineData("  foo  ", "%foo%")]
+    // Phase-1 wildcard semantics: brackets and underscore are NOT escaped.
+    [InlineData("[dbo]", "%[dbo]%")]
+    [InlineData("a_b", "%a_b%")]
+    // Null / empty / whitespace -> no filter.
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    [InlineData("   ", null)]
+    public void BuildQueryTextSearchPattern_WrapsTermInWildcards(string? input, string? expected)
+    {
+        Assert.Equal(expected, QueryStoreFilter.BuildQueryTextSearchPattern(input));
+    }
+
+    [Theory]
+    // Single friendly value -> single execution_type_desc.
+    [InlineData("regular", new[] { "Regular" })]
+    [InlineData("aborted", new[] { "Aborted" })]
+    [InlineData("exception", new[] { "Exception" })]
+    // "failed" fans out to both failure descs.
+    [InlineData("failed", new[] { "Aborted", "Exception" })]
+    // "any" and null / empty / whitespace mean no filter.
+    [InlineData("any", null)]
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    [InlineData("   ", null)]
+    // Matching is case-insensitive (Trim().ToLowerInvariant()).
+    [InlineData("REGULAR", new[] { "Regular" })]
+    public void ParseExecutionType_MapsFriendlyValues(string? input, string[]? expected)
+    {
+        Assert.Equal(expected, QueryStoreFilter.ParseExecutionType(input));
+    }
+
+    [Fact]
+    public void ParseExecutionType_ThrowsOnUnknownValue()
+    {
+        Assert.Throws<ArgumentException>(() => QueryStoreFilter.ParseExecutionType("garbage"));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a server-side query-text search to the Query Store integration, so users can find plans touching a specific table or statement fragment even when those plans aren't in the top N by the chosen metric — mirroring `sp_QuickieStore`'s `@query_text_search` default behavior (requested in #389).
- The filter is applied **pre-TOP-N** in all three Query Store SQL builders (flat, grouped-by-hash, grouped-by-module), fully parameterized, and exposed with parity across all three surfaces: Desktop Search-by combo, MCP `get_query_store_top`, and the CLI `query-store` command.
- Semantics match the proc's defaults exactly: input is trimmed and auto-wrapped in `%` when missing; `%`, `_`, `[`, `]` remain live LIKE wildcards (bracket escaping is a possible follow-up, matching `@escape_brackets`).

Closes #389

## Changes
- **Core**: `QueryStoreFilter.QueryTextSearch` property + shared `QueryStoreFilter.BuildQueryTextSearchPattern` helper (`QueryStorePlan.cs`); identical parameterized `EXISTS` predicate against `sys.query_store_query_text` added to `FetchTopPlansAsync` and both grouped builders (`QueryStoreService.cs`, `QueryStoreService.Grouped.cs`). With the filter unset, generated SQL is byte-identical to before.
- **Desktop**: "Query Text" item in the Search-by combo + one switch case (`QueryStoreGridControl.axaml`, `QueryStoreGridControl.Filters.cs`).
- **MCP**: additive `query_text_search` parameter on `get_query_store_top` (named to avoid colliding with the tool's existing `query_text` output field).
- **CLI**: additive `--query-text-search` option.
- **Tests**: `QueryTextSearchPatternTests.cs` — full wrap/trim/wildcard/null matrix for the helper, plus backfilled coverage for the previously untested `ParseExecutionType` (22 new cases; 123 total pass).

## Test Plan
- [x] `dotnet build PlanViewer.sln -c Debug` — no new warnings
- [x] `dotnet test` — 123/123 pass (101 existing + 22 new)
- [x] Live end-to-end on SQL Server 2022 / StackOverflow2013: unfiltered top-5 vs `--query-text-search Votes` return different query sets (proving pre-TOP-N filtering); no-match input exits cleanly with "no data"; returned query verified to match via substring (`DownVotes`)
- [x] `planview query-store --help` shows the new option with wildcard semantics
- [ ] Desktop Search-by "Query Text" smoke (code-verified; UI not driven)

Generated with [Claude Code](https://claude.com/claude-code)
