### PR TITLE
Add Query Store server-side filter panel, chips, and pre-filters

### DIFF
--- a/src/PlanViewer.App/Controls/ColumnFilterPopup.axaml
+++ b/src/PlanViewer.App/Controls/ColumnFilterPopup.axaml
@@ -1,7 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="PlanViewer.App.Controls.ColumnFilterPopup"
-             Width="220">
+             Width="280">
     <Border Background="{DynamicResource BackgroundDarkBrush}"
             BorderBrush="{DynamicResource BorderBrush}"
             BorderThickness="1" CornerRadius="6">
@@ -20,6 +20,9 @@
                      Height="28" FontSize="12" Margin="0,0,0,12"
                      KeyDown="ValueTextBox_KeyDown"/>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+                <Button x:Name="SearchServerButton" Content="Search server" IsVisible="False" Height="28"
+                        Click="SearchServerButton_Click"
+                        Theme="{StaticResource AppButton}"/>
                 <Button Content="Clear" Width="65" Height="28"
                         Click="ClearButton_Click"
                         Theme="{StaticResource AppButton}"/>

--- a/src/PlanViewer.App/Controls/ColumnFilterPopup.axaml.cs
+++ b/src/PlanViewer.App/Controls/ColumnFilterPopup.axaml.cs
@@ -9,6 +9,7 @@ public partial class ColumnFilterPopup : UserControl
 {
     public event EventHandler<FilterAppliedEventArgs>? FilterApplied;
     public event EventHandler? FilterCleared;
+    public event EventHandler<FilterAppliedEventArgs>? SearchServerRequested;
 
     private string _currentColumnName = "";
 
@@ -35,10 +36,11 @@ public partial class ColumnFilterPopup : UserControl
         OperatorComboBox.SelectedIndex = 0;
     }
 
-    public void Initialize(string columnName, ColumnFilterState? existingFilter)
+    public void Initialize(string columnName, ColumnFilterState? existingFilter, bool canSearchServer)
     {
         _currentColumnName = columnName;
         HeaderText.Text = $"Filter: {columnName}";
+        SearchServerButton.IsVisible = canSearchServer;
 
         if (existingFilter?.IsActive == true)
         {
@@ -70,12 +72,12 @@ public partial class ColumnFilterPopup : UserControl
         UpdateValueVisibility();
     }
 
-    private void ApplyFilter()
+    private FilterAppliedEventArgs? BuildFilterArgs()
     {
         var idx = OperatorComboBox.SelectedIndex;
-        if (idx < 0 || idx >= Operators.Length) return;
+        if (idx < 0 || idx >= Operators.Length) return null;
 
-        FilterApplied?.Invoke(this, new FilterAppliedEventArgs
+        return new FilterAppliedEventArgs
         {
             FilterState = new ColumnFilterState
             {
@@ -83,10 +85,22 @@ public partial class ColumnFilterPopup : UserControl
                 Operator   = Operators[idx].Op,
                 Value      = ValueTextBox.Text ?? "",
             }
-        });
+        };
+    }
+
+    private void ApplyFilter()
+    {
+        if (BuildFilterArgs() is { } args)
+            FilterApplied?.Invoke(this, args);
     }
 
     private void ApplyButton_Click(object? sender, RoutedEventArgs e) => ApplyFilter();
+
+    private void SearchServerButton_Click(object? sender, RoutedEventArgs e)
+    {
+        if (BuildFilterArgs() is { } args)
+            SearchServerRequested?.Invoke(this, args);
+    }
 
     private void ClearButton_Click(object? sender, RoutedEventArgs e)
     {

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.Fetch.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.Fetch.cs
@@ -26,6 +26,11 @@ public partial class QueryStoreGridControl : UserControl
 {
     private async void Fetch_Click(object? sender, RoutedEventArgs e)
     {
+        // Commit any pending toolbar "Search by" entry into the server-filter state first,
+        // then refresh the chip strip, before running the fetch.
+        CommitSearchByCriterion();
+        RebuildChips();
+
         _fetchCts?.Cancel();
         _fetchCts?.Dispose();
         _fetchCts = new CancellationTokenSource();
@@ -69,7 +74,7 @@ public partial class QueryStoreGridControl : UserControl
 
         var topN = (int)(TopNBox.Value ?? 25);
         var orderBy = _lastFetchedOrderBy;
-        var filter = BuildSearchFilter();
+        var filter = _serverFilterState.BuildFilter();
 
         FetchButton.IsEnabled = false;
         LoadButton.IsEnabled = false;

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.Filters.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.Filters.cs
@@ -35,63 +35,70 @@ public partial class QueryStoreGridControl : UserControl
         ExecutionTypePanel.IsVisible = isExecutionType;
     }
 
-    private QueryStoreFilter? BuildSearchFilter()
+    /// <summary>
+    /// Commits the toolbar "Search by" selection into <see cref="_serverFilterState"/>.
+    /// No-ops when no search type is chosen or the value is empty; sets StatusText and does
+    /// not commit on a malformed query-id/plan-id. On a successful commit the toolbar inputs
+    /// are reset (the criterion now lives as a chip).
+    /// </summary>
+    private void CommitSearchByCriterion()
     {
         var searchType = (SearchTypeBox.SelectedItem as ComboBoxItem)?.Tag?.ToString();
 
         if (string.IsNullOrEmpty(searchType))
-            return null;
+            return;
 
         if (searchType == "execution-type")
         {
             var tag = (ExecutionTypeBox.SelectedItem as ComboBoxItem)?.Tag?.ToString();
-            // "any" tag (first item) means no filter
-            if (string.IsNullOrEmpty(tag) || tag == "any")
-                return null;
-            // "Failed" bundles Aborted + Exception into an IN predicate
-            if (tag == "Failed")
-                return new QueryStoreFilter { ExecutionTypeDescs = ["Aborted", "Exception"] };
-            return new QueryStoreFilter { ExecutionTypeDescs = [tag] };
+            _serverFilterState.SetExecutionType(QueryStoreFilter.ParseExecutionType(tag));
+            ResetSearchInputs();
+            return;
         }
 
         var searchValue = SearchValueBox.Text?.Trim();
         if (string.IsNullOrEmpty(searchValue))
-            return null;
-
-        var filter = new QueryStoreFilter();
+            return;
 
         switch (searchType)
         {
             case "query-id" when long.TryParse(searchValue, out var qid):
-                filter.QueryId = qid;
+                _serverFilterState.SetQueryId(qid);
                 break;
             case "query-id":
                 StatusText.Text = "Invalid Query ID";
-                return null;
+                return;
             case "plan-id" when long.TryParse(searchValue, out var pid):
-                filter.PlanId = pid;
+                _serverFilterState.SetPlanId(pid);
                 break;
             case "plan-id":
                 StatusText.Text = "Invalid Plan ID";
-                return null;
+                return;
             case "query-hash":
-                filter.QueryHash = searchValue;
+                _serverFilterState.SetQueryHash(searchValue);
                 break;
             case "plan-hash":
-                filter.QueryPlanHash = searchValue;
+                _serverFilterState.SetQueryPlanHash(searchValue);
                 break;
             case "module":
                 // Default to dbo schema if no schema specified, following sp_QuickieStore pattern
-                filter.ModuleName = searchValue.Contains('.') ? searchValue : $"dbo.{searchValue}";
+                _serverFilterState.SetModule(searchValue.Contains('.') ? searchValue : $"dbo.{searchValue}");
                 break;
             case "query-text":
-                filter.QueryTextSearch = searchValue;
+                _serverFilterState.SetQueryTextSearch(searchValue);
                 break;
             default:
-                return null;
+                return;
         }
 
-        return filter;
+        ResetSearchInputs();
+    }
+
+    /// <summary>Resets the toolbar search inputs after a criterion is committed.</summary>
+    private void ResetSearchInputs()
+    {
+        SearchTypeBox.SelectedIndex = 0;
+        SearchValueBox.Text = "";
     }
 
     private void SearchValue_KeyDown(object? sender, Avalonia.Input.KeyEventArgs e)
@@ -103,12 +110,18 @@ public partial class QueryStoreGridControl : UserControl
         }
     }
 
-    private void ClearSearch_Click(object? sender, RoutedEventArgs e)
+    private async void ClearSearch_Click(object? sender, RoutedEventArgs e)
     {
         SearchTypeBox.SelectedIndex = 0;
         SearchValueBox.Text = "";
         // Resetting SearchTypeBox triggers SearchType_SelectionChanged which hides ExecutionTypePanel.
         ExecutionTypeBox.SelectedIndex = 0;
+
+        // Also clear every accumulated server filter and its panel input, then re-fetch.
+        _serverFilterState.Clear();
+        ResetServerFilterPanelInputs();
+        RebuildChips();
+        await FetchPlansForRangeAsync();
     }
 
     private void SetupColumnHeaders()
@@ -193,6 +206,7 @@ public partial class QueryStoreGridControl : UserControl
         ((Grid)Content!).Children.Add(_filterPopup);
         _filterPopupContent.FilterApplied += OnFilterApplied;
         _filterPopupContent.FilterCleared += OnFilterCleared;
+        _filterPopupContent.SearchServerRequested += OnSearchServerRequested;
     }
 
     private void ColumnFilter_Click(object? sender, RoutedEventArgs e)
@@ -200,7 +214,8 @@ public partial class QueryStoreGridControl : UserControl
         if (sender is not Button button || button.Tag is not string columnId) return;
         EnsureFilterPopup();
         _activeFilters.TryGetValue(columnId, out var existing);
-        _filterPopupContent!.Initialize(columnId, existing);
+        var canSearchServer = MapColumnToServerKind(columnId) is not null;
+        _filterPopupContent!.Initialize(columnId, existing, canSearchServer);
         _filterPopup!.PlacementTarget = button;
         _filterPopup.IsOpen = true;
     }

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.ServerFilters.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.ServerFilters.cs
@@ -1,0 +1,230 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using PlanViewer.App.Services;
+using PlanViewer.Core.Models;
+
+namespace PlanViewer.App.Controls;
+
+public partial class QueryStoreGridControl : UserControl
+{
+    /// <summary>
+    /// Server-side Query Store filter, accumulated from the filter panel, the toolbar
+    /// "Search by" box, and promoted column filters. Projected to chips for display and to
+    /// a <see cref="QueryStoreFilter"/> for fetching.
+    /// </summary>
+    private readonly QueryStoreServerFilterState _serverFilterState = new();
+
+    /// <summary>
+    /// Commits every panel input to the filter state as one transaction, then re-fetches.
+    /// All four id boxes are parsed first; if any is malformed the state is left untouched
+    /// and no fetch happens, so a typo never partially applies.
+    /// </summary>
+    private async void ApplyServerFilters_Click(object? sender, RoutedEventArgs e)
+    {
+        long[]? includeQueryIds, ignoreQueryIds, includePlanIds, ignorePlanIds;
+        try
+        {
+            includeQueryIds = QueryStoreFilter.ParseIdList(IncludeQueryIdsBox.Text);
+            ignoreQueryIds  = QueryStoreFilter.ParseIdList(IgnoreQueryIdsBox.Text);
+            includePlanIds  = QueryStoreFilter.ParseIdList(IncludePlanIdsBox.Text);
+            ignorePlanIds   = QueryStoreFilter.ParseIdList(IgnorePlanIdsBox.Text);
+        }
+        catch (ArgumentException ex)
+        {
+            StatusText.Text = ex.Message;
+            return;
+        }
+
+        _serverFilterState.SetMinExecutions((long?)MinExecBox.Value);
+        _serverFilterState.SetMinCpuMs((long?)MinCpuBox.Value);
+        _serverFilterState.SetMinDurationMs((long?)MinDurBox.Value);
+        _serverFilterState.SetQueryTextSearch(TextSearchBox.Text);
+        _serverFilterState.SetQueryTextSearchNot(TextExcludeBox.Text);
+        _serverFilterState.SetEscapeBrackets(EscapeBracketsBox.IsChecked == true);
+        _serverFilterState.SetIncludeQueryIds(includeQueryIds);
+        _serverFilterState.SetIgnoreQueryIds(ignoreQueryIds);
+        _serverFilterState.SetIncludePlanIds(includePlanIds);
+        _serverFilterState.SetIgnorePlanIds(ignorePlanIds);
+
+        RebuildChips();
+        await FetchPlansForRangeAsync();
+    }
+
+    /// <summary>Clears all server filters, resets the panel inputs, and re-fetches.</summary>
+    private async void ClearServerFilters_Click(object? sender, RoutedEventArgs e)
+    {
+        _serverFilterState.Clear();
+        ResetServerFilterPanelInputs();
+        RebuildChips();
+        await FetchPlansForRangeAsync();
+    }
+
+    /// <summary>Removes the single criterion behind the clicked chip, clears its matching panel input, and re-fetches.</summary>
+    private async void ChipRemove_Click(object? sender, RoutedEventArgs e)
+    {
+        if (sender is Button b && b.Tag is ServerFilterKind kind)
+        {
+            _serverFilterState.Remove(kind);
+            ResetPanelInputForKind(kind);
+            RebuildChips();
+            await FetchPlansForRangeAsync();
+        }
+    }
+
+    /// <summary>Reprojects the active criteria to chips and shows the strip only when at least one is active.</summary>
+    private void RebuildChips()
+    {
+        var chips = _serverFilterState.GetActiveChips();
+        ChipItems.ItemsSource = chips;
+        ChipStrip.IsVisible = chips.Count > 0;
+    }
+
+    /// <summary>Persists the panel's expanded/collapsed state whenever the user toggles it.</summary>
+    private void ServerFilterExpander_StateChanged(object? sender, RoutedEventArgs e)
+    {
+        var s = AppSettingsService.Load().Clone();
+        s.QueryStoreFilterPanelExpanded = ServerFilterExpander.IsExpanded;
+        AppSettingsService.Save(s);
+    }
+
+    /// <summary>Resets every input in the server-filter panel to its empty state.</summary>
+    private void ResetServerFilterPanelInputs()
+    {
+        MinExecBox.Value = null;
+        MinCpuBox.Value = null;
+        MinDurBox.Value = null;
+        TextSearchBox.Text = "";
+        TextExcludeBox.Text = "";
+        EscapeBracketsBox.IsChecked = false;
+        IncludeQueryIdsBox.Text = "";
+        IgnoreQueryIdsBox.Text = "";
+        IncludePlanIdsBox.Text = "";
+        IgnorePlanIdsBox.Text = "";
+    }
+
+    /// <summary>Resets the single panel input backing a criterion. Search-by-only kinds have no panel input and are skipped.</summary>
+    private void ResetPanelInputForKind(ServerFilterKind kind)
+    {
+        switch (kind)
+        {
+            case ServerFilterKind.MinExecutions: MinExecBox.Value = null; break;
+            case ServerFilterKind.MinCpuMs: MinCpuBox.Value = null; break;
+            case ServerFilterKind.MinDurationMs: MinDurBox.Value = null; break;
+            case ServerFilterKind.QueryTextSearch: TextSearchBox.Text = ""; break;
+            case ServerFilterKind.QueryTextSearchNot: TextExcludeBox.Text = ""; break;
+            case ServerFilterKind.IncludeQueryIds: IncludeQueryIdsBox.Text = ""; break;
+            case ServerFilterKind.IgnoreQueryIds: IgnoreQueryIdsBox.Text = ""; break;
+            case ServerFilterKind.IncludePlanIds: IncludePlanIdsBox.Text = ""; break;
+            case ServerFilterKind.IgnorePlanIds: IgnorePlanIdsBox.Text = ""; break;
+            // QueryId, PlanId, QueryHash, QueryPlanHash, Module, ExecutionType are
+            // search-by-only criteria with no dedicated panel input — nothing to reset.
+        }
+    }
+
+    /// <summary>
+    /// Maps a grid column id to the server-filter criterion it can be promoted to, or null
+    /// when the column has no server equivalent. Total CPU/Duration are intentionally not
+    /// mapped: a total must never promote onto an average threshold.
+    /// </summary>
+    private static ServerFilterKind? MapColumnToServerKind(string columnId) => columnId switch
+    {
+        "Executions"  => ServerFilterKind.MinExecutions,
+        "AvgCpu"      => ServerFilterKind.MinCpuMs,
+        "AvgDuration" => ServerFilterKind.MinDurationMs,
+        "QueryId"     => ServerFilterKind.QueryId,
+        "PlanId"      => ServerFilterKind.PlanId,
+        "QueryHash"   => ServerFilterKind.QueryHash,
+        "PlanHash"    => ServerFilterKind.QueryPlanHash,
+        "ModuleName"  => ServerFilterKind.Module,
+        "QueryText"   => ServerFilterKind.QueryTextSearch,
+        _             => null,
+    };
+
+    /// <summary>
+    /// Promotes a client-side column filter to the matching server criterion when the
+    /// filter's operator is compatible with that criterion's class. On an incompatible
+    /// operator the state is left untouched and the user is told why; on success the
+    /// criterion is committed and the grid re-fetched.
+    /// </summary>
+    private async void PromoteColumnFilterToServer(string columnId, ColumnFilterState state)
+    {
+        if (MapColumnToServerKind(columnId) is not { } kind)
+            return;
+
+        const string incompatibleMessage =
+            "This filter's operator can't be used to search the server for this column";
+
+        switch (kind)
+        {
+            // Numeric thresholds: only > / >=. Floor to long so promoted rows always qualify.
+            case ServerFilterKind.MinExecutions:
+            case ServerFilterKind.MinCpuMs:
+            case ServerFilterKind.MinDurationMs:
+                if (state.Operator is not (FilterOperator.GreaterThan or FilterOperator.GreaterThanOrEqual))
+                {
+                    StatusText.Text = incompatibleMessage;
+                    return;
+                }
+                if (!double.TryParse(state.Value, out var value))
+                    return;
+                var threshold = (long)Math.Floor(value);
+                switch (kind)
+                {
+                    case ServerFilterKind.MinExecutions: _serverFilterState.SetMinExecutions(threshold); break;
+                    case ServerFilterKind.MinCpuMs: _serverFilterState.SetMinCpuMs(threshold); break;
+                    case ServerFilterKind.MinDurationMs: _serverFilterState.SetMinDurationMs(threshold); break;
+                }
+                break;
+
+            // Ids: only equality.
+            case ServerFilterKind.QueryId:
+            case ServerFilterKind.PlanId:
+                if (state.Operator is not FilterOperator.Equals)
+                {
+                    StatusText.Text = incompatibleMessage;
+                    return;
+                }
+                if (!long.TryParse(state.Value, out var id))
+                    return;
+                if (kind == ServerFilterKind.QueryId) _serverFilterState.SetQueryId(id);
+                else _serverFilterState.SetPlanId(id);
+                break;
+
+            // Hashes, module, and query text: equality or contains, on the raw value.
+            case ServerFilterKind.QueryHash:
+            case ServerFilterKind.QueryPlanHash:
+            case ServerFilterKind.Module:
+            case ServerFilterKind.QueryTextSearch:
+                if (state.Operator is not (FilterOperator.Equals or FilterOperator.Contains))
+                {
+                    StatusText.Text = incompatibleMessage;
+                    return;
+                }
+                switch (kind)
+                {
+                    case ServerFilterKind.QueryHash: _serverFilterState.SetQueryHash(state.Value); break;
+                    case ServerFilterKind.QueryPlanHash: _serverFilterState.SetQueryPlanHash(state.Value); break;
+                    case ServerFilterKind.Module:
+                        // Default to the dbo schema when none is given, matching the toolbar search.
+                        _serverFilterState.SetModule(state.Value.Contains('.') ? state.Value : $"dbo.{state.Value}");
+                        break;
+                    case ServerFilterKind.QueryTextSearch: _serverFilterState.SetQueryTextSearch(state.Value); break;
+                }
+                break;
+
+            default:
+                return;
+        }
+
+        RebuildChips();
+        await FetchPlansForRangeAsync();
+    }
+
+    /// <summary>Closes the column-filter popup and promotes its filter to a server criterion.</summary>
+    private void OnSearchServerRequested(object? sender, FilterAppliedEventArgs e)
+    {
+        _filterPopup!.IsOpen = false;
+        PromoteColumnFilterToServer(e.FilterState.ColumnName, e.FilterState);
+    }
+}

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml
@@ -1,9 +1,10 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="using:PlanViewer.App.Controls"
+             xmlns:models="using:PlanViewer.Core.Models"
              x:Class="PlanViewer.App.Controls.QueryStoreGridControl"
              Background="{DynamicResource BackgroundBrush}">
-    <Grid RowDefinitions="Auto,Auto,*">
+    <Grid RowDefinitions="Auto,Auto,Auto,Auto,*">
         <!-- Time Range Slicer + Wait Stats Profile -->
         <Grid Grid.Row="0" x:Name="SlicerRow" ColumnDefinitions="2*,Auto,*">
             <local:TimeRangeSlicerControl x:Name="TimeRangeSlicer" Grid.Column="0"/>
@@ -131,8 +132,122 @@
             </StackPanel>
         </Border>
 
+        <!-- Server Filters panel (collapsible) -->
+        <Border Grid.Row="2" Background="{DynamicResource BackgroundDarkBrush}"
+                BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,0,1">
+            <Expander x:Name="ServerFilterExpander" IsExpanded="False"
+                      Foreground="{DynamicResource ForegroundBrush}"
+                      Background="Transparent"
+                      BorderThickness="0"
+                      Padding="0"
+                      HorizontalAlignment="Stretch"
+                      HorizontalContentAlignment="Stretch">
+                <Expander.Header>
+                    <TextBlock Text="  Server Filters" FontWeight="SemiBold"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </Expander.Header>
+                <StackPanel Margin="12,6" Spacing="10">
+                    <!-- Row A: numeric thresholds -->
+                    <StackPanel Orientation="Horizontal" Spacing="12">
+                        <StackPanel Spacing="2">
+                            <TextBlock Text="Min executions" FontSize="11"
+                                       Foreground="{DynamicResource ForegroundBrush}"/>
+                            <NumericUpDown x:Name="MinExecBox" Minimum="0" Width="130" Height="32" FormatString="0"/>
+                        </StackPanel>
+                        <StackPanel Spacing="2">
+                            <TextBlock Text="Min avg CPU (ms)" FontSize="11"
+                                       Foreground="{DynamicResource ForegroundBrush}"/>
+                            <NumericUpDown x:Name="MinCpuBox" Minimum="0" Width="130" Height="32" FormatString="0"/>
+                        </StackPanel>
+                        <StackPanel Spacing="2">
+                            <TextBlock Text="Min avg duration (ms)" FontSize="11"
+                                       Foreground="{DynamicResource ForegroundBrush}"/>
+                            <NumericUpDown x:Name="MinDurBox" Minimum="0" Width="130" Height="32" FormatString="0"/>
+                        </StackPanel>
+                    </StackPanel>
+                    <!-- Row B: query text search -->
+                    <StackPanel Orientation="Horizontal" Spacing="12">
+                        <StackPanel Spacing="2">
+                            <TextBlock Text="Query text contains" FontSize="11"
+                                       Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBox x:Name="TextSearchBox" Width="220" Height="32" Watermark="e.g. Votes"/>
+                        </StackPanel>
+                        <StackPanel Spacing="2">
+                            <TextBlock Text="Query text excludes" FontSize="11"
+                                       Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBox x:Name="TextExcludeBox" Width="220" Height="32" Watermark="e.g. #temp"/>
+                        </StackPanel>
+                        <CheckBox x:Name="EscapeBracketsBox" Content="Treat [ ] _ as literals"
+                                  VerticalAlignment="Bottom"
+                                  Foreground="{DynamicResource ForegroundBrush}"/>
+                    </StackPanel>
+                    <!-- Row C: id lists -->
+                    <StackPanel Orientation="Horizontal" Spacing="12">
+                        <StackPanel Spacing="2">
+                            <TextBlock Text="Include query IDs" FontSize="11"
+                                       Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBox x:Name="IncludeQueryIdsBox" Width="180" Height="32" Watermark="1, 2, 3"/>
+                        </StackPanel>
+                        <StackPanel Spacing="2">
+                            <TextBlock Text="Ignore query IDs" FontSize="11"
+                                       Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBox x:Name="IgnoreQueryIdsBox" Width="180" Height="32" Watermark="4, 5"/>
+                        </StackPanel>
+                        <StackPanel Spacing="2">
+                            <TextBlock Text="Include plan IDs" FontSize="11"
+                                       Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBox x:Name="IncludePlanIdsBox" Width="180" Height="32" Watermark="10, 11"/>
+                        </StackPanel>
+                        <StackPanel Spacing="2">
+                            <TextBlock Text="Ignore plan IDs" FontSize="11"
+                                       Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBox x:Name="IgnorePlanIdsBox" Width="180" Height="32" Watermark="12"/>
+                        </StackPanel>
+                    </StackPanel>
+                    <!-- Actions -->
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+                        <Button Content="Clear filters" Click="ClearServerFilters_Click"
+                                Height="28" FontSize="12" Theme="{StaticResource AppButton}"/>
+                        <Button Content="Apply &amp; Fetch" Click="ApplyServerFilters_Click"
+                                Height="28" FontSize="12" Theme="{StaticResource AppButton}"/>
+                    </StackPanel>
+                </StackPanel>
+            </Expander>
+        </Border>
+
+        <!-- Active server-filter chips -->
+        <Border Grid.Row="3" x:Name="ChipStrip" IsVisible="False"
+                Background="{DynamicResource BackgroundDarkBrush}"
+                BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,0,1"
+                Padding="8,4">
+            <ItemsControl x:Name="ChipItems">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <WrapPanel Orientation="Horizontal"/>
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="models:ServerFilterChip">
+                        <Border Background="{DynamicResource BackgroundLightBrush}"
+                                BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
+                                CornerRadius="10" Padding="8,2" Margin="0,2,6,2">
+                            <StackPanel Orientation="Horizontal" Spacing="4">
+                                <TextBlock Text="{Binding Label}" FontSize="11"
+                                           VerticalAlignment="Center"
+                                           Foreground="{DynamicResource ForegroundBrush}"/>
+                                <Button Content="✕" Tag="{Binding Kind}" Click="ChipRemove_Click"
+                                        Width="16" Height="16" Padding="0" FontSize="10"
+                                        Background="Transparent" BorderThickness="0"
+                                        Foreground="{DynamicResource ForegroundMutedBrush}"/>
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </Border>
+
         <!-- DataGrid + loading overlay -->
-        <Grid Grid.Row="2">
+        <Grid Grid.Row="4">
         <DataGrid x:Name="ResultsGrid"
                   AutoGenerateColumns="False"
                   CanUserSortColumns="True"

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
@@ -78,6 +78,12 @@ public partial class QueryStoreGridControl : UserControl
             _ => "query-hash"
         });
 
+        // Restore the server-filter panel's expanded state, then subscribe — restoring first
+        // means the restore itself never triggers a save.
+        ServerFilterExpander.IsExpanded = userSettings.QueryStoreFilterPanelExpanded;
+        ServerFilterExpander.Expanded += ServerFilterExpander_StateChanged;
+        ServerFilterExpander.Collapsed += ServerFilterExpander_StateChanged;
+
         ResultsGrid.ItemsSource = _filteredRows;
         Helpers.DataGridBehaviors.Attach(ResultsGrid);
         EnsureFilterPopup();

--- a/src/PlanViewer.App/Mcp/McpQueryStoreTools.cs
+++ b/src/PlanViewer.App/Mcp/McpQueryStoreTools.cs
@@ -55,7 +55,8 @@ public sealed class McpQueryStoreTools
         "Each fetched plan is automatically loaded into the application for further analysis " +
         "with analyze_plan, get_plan_warnings, etc. Returns summary stats and session IDs. " +
         "Optional filters narrow results server-side by query_id, plan_id, query_hash, " +
-        "plan_hash, module name (schema.name, supports % wildcards), or query text (query_text_search).")]
+        "plan_hash, module name (schema.name, supports % wildcards), query text (query_text_search / query_text_search_not), " +
+        "minimum execution count or average duration/CPU thresholds, execution type, and query-id / plan-id include/ignore lists.")]
     public static async Task<string> GetQueryStoreTop(
         PlanSessionManager sessionManager,
         ConnectionStore connectionStore,
@@ -73,7 +74,16 @@ public sealed class McpQueryStoreTools
         [Description("Filter by query plan hash (hex, e.g. 0x1AB2C3D4).")] string? plan_hash = null,
         [Description("Filter by module name (schema.name, supports % wildcards).")] string? module = null,
         [Description("Filter to queries whose SQL text contains this string. Matched with SQL LIKE (auto-wrapped in %); % _ [ ] act as wildcards.")] string? query_text_search = null,
-        [Description("Filter by execution type: regular, aborted, exception, or failed (= aborted + exception).")] string? execution_type = null)
+        [Description("Exclude queries whose SQL text contains this string. Matched with SQL LIKE (auto-wrapped in %); % _ [ ] act as wildcards. Inverse of query_text_search.")] string? query_text_search_not = null,
+        [Description("When true, treat [ ] _ in query_text_search / query_text_search_not as literal characters instead of LIKE wildcards. Default false.")] bool escape_brackets = false,
+        [Description("Filter by execution type: regular, aborted, exception, or failed (= aborted + exception).")] string? execution_type = null,
+        [Description("Only include plans executed at least this many times (the plan's total execution count over the selected time window). Values <= 0 mean no filter.")] long? min_executions = null,
+        [Description("Only include plans whose average duration per execution over the selected time window is at least this many milliseconds. Values <= 0 mean no filter.")] long? min_duration_ms = null,
+        [Description("Only include plans whose average CPU time per execution over the selected time window is at least this many milliseconds. Values <= 0 mean no filter.")] long? min_cpu_ms = null,
+        [Description("Comma-separated Query Store query IDs to include, e.g. \"123,456\". Only these query IDs are returned.")] string? include_query_ids = null,
+        [Description("Comma-separated Query Store query IDs to exclude, e.g. \"123,456\".")] string? ignore_query_ids = null,
+        [Description("Comma-separated Query Store plan IDs to include, e.g. \"12,34\".")] string? include_plan_ids = null,
+        [Description("Comma-separated Query Store plan IDs to exclude, e.g. \"12,34\".")] string? ignore_plan_ids = null)
     {
         try
         {
@@ -88,9 +98,17 @@ public sealed class McpQueryStoreTools
                 return "Invalid hours_back value. Must be between 1 and 168.";
 
             string[]? executionTypes;
+            long[]? includeQueryIds;
+            long[]? ignoreQueryIds;
+            long[]? includePlanIds;
+            long[]? ignorePlanIds;
             try
             {
                 executionTypes = QueryStoreFilter.ParseExecutionType(execution_type);
+                includeQueryIds = QueryStoreFilter.ParseIdList(include_query_ids);
+                ignoreQueryIds = QueryStoreFilter.ParseIdList(ignore_query_ids);
+                includePlanIds = QueryStoreFilter.ParseIdList(include_plan_ids);
+                ignorePlanIds = QueryStoreFilter.ParseIdList(ignore_plan_ids);
             }
             catch (ArgumentException ex)
             {
@@ -100,7 +118,9 @@ public sealed class McpQueryStoreTools
             QueryStoreFilter? filter = null;
             if (query_id != null || plan_id != null ||
                 query_hash != null || plan_hash != null || module != null || query_text_search != null ||
-                executionTypes != null)
+                executionTypes != null ||
+                query_text_search_not != null || min_executions != null || min_duration_ms != null || min_cpu_ms != null ||
+                includeQueryIds != null || ignoreQueryIds != null || includePlanIds != null || ignorePlanIds != null)
             {
                 filter = new QueryStoreFilter
                 {
@@ -110,7 +130,16 @@ public sealed class McpQueryStoreTools
                     QueryPlanHash = plan_hash,
                     ModuleName = module,
                     QueryTextSearch = query_text_search,
+                    QueryTextSearchNot = query_text_search_not,
+                    EscapeBrackets = escape_brackets,
                     ExecutionTypeDescs = executionTypes,
+                    MinExecutions = min_executions,
+                    MinDurationMs = min_duration_ms,
+                    MinCpuMs = min_cpu_ms,
+                    IncludeQueryIds = includeQueryIds,
+                    IgnoreQueryIds = ignoreQueryIds,
+                    IncludePlanIds = includePlanIds,
+                    IgnorePlanIds = ignorePlanIds,
                 };
             }
 

--- a/src/PlanViewer.App/Services/AppSettingsService.cs
+++ b/src/PlanViewer.App/Services/AppSettingsService.cs
@@ -265,6 +265,12 @@ internal sealed class AppSettings
     [JsonPropertyName("query_store_default_group_by")]
     public string QueryStoreDefaultGroupBy { get; set; } = "QueryHash";
 
+    /// <summary>
+    /// Whether the Query Store server-filter panel is expanded. Default false (collapsed).
+    /// </summary>
+    [JsonPropertyName("query_store_filter_panel_expanded")]
+    public bool QueryStoreFilterPanelExpanded { get; set; }
+
     // ── Multi QS Overview Settings ───────────────────────────────────
 
     /// <summary>

--- a/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
+++ b/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
@@ -134,9 +134,54 @@ public static class QueryStoreCommand
             Description = "Filter to queries whose text contains this string (SQL LIKE match, auto-wrapped in %; % _ [ ] are wildcards)"
         };
 
+        var queryTextSearchNotOption = new Option<string?>("--query-text-search-not")
+        {
+            Description = "Exclude queries whose text contains this string (SQL LIKE match, auto-wrapped in %; % _ [ ] are wildcards)"
+        };
+
+        var escapeBracketsOption = new Option<bool>("--escape-brackets")
+        {
+            Description = "Treat [ ] _ in --query-text-search/--query-text-search-not as literals, not wildcards"
+        };
+
         var executionTypeOption = new Option<string?>("--execution-type")
         {
             Description = "Filter by execution type: regular, aborted, exception, or failed (= aborted + exception)"
+        };
+
+        var minExecutionsOption = new Option<long?>("--min-executions")
+        {
+            Description = "Only include plans executed at least this many times (total count over the window)"
+        };
+
+        var minDurationMsOption = new Option<long?>("--min-duration-ms")
+        {
+            Description = "Only include plans whose average duration per execution is at least this many ms"
+        };
+
+        var minCpuMsOption = new Option<long?>("--min-cpu-ms")
+        {
+            Description = "Only include plans whose average CPU per execution is at least this many ms"
+        };
+
+        var includeQueryIdsOption = new Option<string?>("--include-query-ids")
+        {
+            Description = "Comma-separated Query Store query IDs to include (e.g. 123,456)"
+        };
+
+        var ignoreQueryIdsOption = new Option<string?>("--ignore-query-ids")
+        {
+            Description = "Comma-separated Query Store query IDs to exclude (e.g. 123,456)"
+        };
+
+        var includePlanIdsOption = new Option<string?>("--include-plan-ids")
+        {
+            Description = "Comma-separated Query Store plan IDs to include (e.g. 12,34)"
+        };
+
+        var ignorePlanIdsOption = new Option<string?>("--ignore-plan-ids")
+        {
+            Description = "Comma-separated Query Store plan IDs to exclude (e.g. 12,34)"
         };
 
         var cmd = new Command("query-store", "Analyze top queries from Query Store")
@@ -145,7 +190,9 @@ public static class QueryStoreCommand
             outputDirOption, outputOption, compactOption, warningsOnlyOption, configOption,
             authOption, trustCertOption, loginOption, passwordOption, passwordStdinOption,
             queryIdOption, planIdOption, queryHashOption, planHashOption, moduleOption,
-            queryTextSearchOption, executionTypeOption
+            queryTextSearchOption, queryTextSearchNotOption, escapeBracketsOption, executionTypeOption,
+            minExecutionsOption, minDurationMsOption, minCpuMsOption,
+            includeQueryIdsOption, ignoreQueryIdsOption, includePlanIdsOption, ignorePlanIdsOption
         };
 
         cmd.SetAction(async (parseResult, ct) =>
@@ -171,7 +218,16 @@ public static class QueryStoreCommand
             var filterPlanHash = parseResult.GetValue(planHashOption);
             var filterModule = parseResult.GetValue(moduleOption);
             var filterQueryTextSearch = parseResult.GetValue(queryTextSearchOption);
+            var filterQueryTextSearchNot = parseResult.GetValue(queryTextSearchNotOption);
+            var filterEscapeBrackets = parseResult.GetValue(escapeBracketsOption);
             var filterExecutionType = parseResult.GetValue(executionTypeOption);
+            var filterMinExecutions = parseResult.GetValue(minExecutionsOption);
+            var filterMinDurationMs = parseResult.GetValue(minDurationMsOption);
+            var filterMinCpuMs = parseResult.GetValue(minCpuMsOption);
+            var filterIncludeQueryIds = parseResult.GetValue(includeQueryIdsOption);
+            var filterIgnoreQueryIds = parseResult.GetValue(ignoreQueryIdsOption);
+            var filterIncludePlanIds = parseResult.GetValue(includePlanIdsOption);
+            var filterIgnorePlanIds = parseResult.GetValue(ignorePlanIdsOption);
 
             // Load .env file if present (CLI args take precedence)
             var env = ConnectionHelper.LoadEnvFile();
@@ -204,9 +260,17 @@ public static class QueryStoreCommand
             }
 
             string[]? executionTypes;
+            long[]? includeQueryIds;
+            long[]? ignoreQueryIds;
+            long[]? includePlanIds;
+            long[]? ignorePlanIds;
             try
             {
                 executionTypes = QueryStoreFilter.ParseExecutionType(filterExecutionType);
+                includeQueryIds = QueryStoreFilter.ParseIdList(filterIncludeQueryIds);
+                ignoreQueryIds = QueryStoreFilter.ParseIdList(filterIgnoreQueryIds);
+                includePlanIds = QueryStoreFilter.ParseIdList(filterIncludePlanIds);
+                ignorePlanIds = QueryStoreFilter.ParseIdList(filterIgnorePlanIds);
             }
             catch (ArgumentException ex)
             {
@@ -218,7 +282,9 @@ public static class QueryStoreCommand
             QueryStoreFilter? filter = null;
             if (filterQueryId != null || filterPlanId != null ||
                 filterQueryHash != null || filterPlanHash != null || filterModule != null || filterQueryTextSearch != null ||
-                executionTypes != null)
+                executionTypes != null ||
+                filterQueryTextSearchNot != null || filterMinExecutions != null || filterMinDurationMs != null || filterMinCpuMs != null ||
+                includeQueryIds != null || ignoreQueryIds != null || includePlanIds != null || ignorePlanIds != null)
             {
                 filter = new QueryStoreFilter
                 {
@@ -228,7 +294,16 @@ public static class QueryStoreCommand
                     QueryPlanHash = filterPlanHash,
                     ModuleName = filterModule,
                     QueryTextSearch = filterQueryTextSearch,
+                    QueryTextSearchNot = filterQueryTextSearchNot,
+                    EscapeBrackets = filterEscapeBrackets,
                     ExecutionTypeDescs = executionTypes,
+                    MinExecutions = filterMinExecutions,
+                    MinDurationMs = filterMinDurationMs,
+                    MinCpuMs = filterMinCpuMs,
+                    IncludeQueryIds = includeQueryIds,
+                    IgnoreQueryIds = ignoreQueryIds,
+                    IncludePlanIds = includePlanIds,
+                    IgnorePlanIds = ignorePlanIds,
                 };
             }
 

--- a/src/PlanViewer.Core/Models/QueryStorePlan.cs
+++ b/src/PlanViewer.Core/Models/QueryStorePlan.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 
 namespace PlanViewer.Core.Models;
 
@@ -20,6 +21,16 @@ public class QueryStoreFilter
     public string[]? ExecutionTypeDescs { get; set; }
 
     public string? QueryTextSearch { get; set; }
+
+    public long? MinExecutions { get; set; }
+    public long? MinDurationMs { get; set; }
+    public long? MinCpuMs { get; set; }
+    public string? QueryTextSearchNot { get; set; }
+    public bool EscapeBrackets { get; set; }
+    public long[]? IncludeQueryIds { get; set; }
+    public long[]? IgnoreQueryIds { get; set; }
+    public long[]? IncludePlanIds { get; set; }
+    public long[]? IgnorePlanIds { get; set; }
 
     /// <summary>
     /// Parses a user-friendly execution-type string into the matching SQL execution_type_desc values.
@@ -44,17 +55,44 @@ public class QueryStoreFilter
     /// <summary>
     /// Builds the LIKE pattern for a query-text search, mirroring sp_QuickieStore's
     /// @query_text_search default behavior: trims, then wraps the term in leading/
-    /// trailing % wildcards when not already present. %, _, [, ] remain LIKE
-    /// wildcards (sp_QuickieStore's default @escape_brackets = 0). Returns null for
-    /// null/whitespace input (no filter), matching ParseExecutionType's contract.
+    /// trailing % wildcards when not already present. When <paramref name="escapeBrackets"/>
+    /// is true, escapes [ ] _ with a backslash for use with ESCAPE '\' (so they match
+    /// literally); % always stays a LIKE wildcard. The default (false) preserves phase-1
+    /// behavior: %, _, [, ] all remain LIKE wildcards (sp_QuickieStore's default
+    /// @escape_brackets = 0). Returns null for null/whitespace input (no filter),
+    /// matching ParseExecutionType's contract.
     /// </summary>
-    public static string? BuildQueryTextSearchPattern(string? input)
+    public static string? BuildQueryTextSearchPattern(string? input, bool escapeBrackets = false)
     {
         if (string.IsNullOrWhiteSpace(input)) return null;
         var s = input.Trim();
         if (!s.StartsWith('%')) s = "%" + s;
         if (!s.EndsWith('%')) s += "%";
+        if (escapeBrackets)
+            s = s.Replace("[", "\\[").Replace("]", "\\]").Replace("_", "\\_");
         return s;
+    }
+
+    /// <summary>
+    /// Parses a comma-separated id list into distinct ids (first-seen order).
+    /// Null/whitespace/all-empty input returns null (no filter). Empty tokens from
+    /// leading/trailing/doubled commas are skipped. Any non-integer token (including
+    /// overflow) throws ArgumentException naming the token.
+    /// </summary>
+    public static long[]? ParseIdList(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input)) return null;
+        var result = new List<long>();
+        var seen = new HashSet<long>();
+        foreach (var raw in input.Split(','))
+        {
+            var t = raw.Trim();
+            if (t.Length == 0) continue;
+            if (!long.TryParse(t, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id))
+                throw new ArgumentException($"Invalid id '{t}' in list. Expected comma-separated integers.");
+            if (seen.Add(id)) result.Add(id);
+        }
+        return result.Count > 0 ? result.ToArray() : null;
     }
 }
 

--- a/src/PlanViewer.Core/Models/QueryStoreServerFilterState.cs
+++ b/src/PlanViewer.Core/Models/QueryStoreServerFilterState.cs
@@ -1,0 +1,259 @@
+namespace PlanViewer.Core.Models;
+
+/// <summary>
+/// The kinds of server-side Query Store filter criteria — one per user-settable predicate.
+/// Declaration order is canonical: it is the order active criteria are rendered as chips.
+/// <c>EscapeBrackets</c> is deliberately NOT a member: it is a pure modifier on the
+/// query-text search, not a standalone criterion.
+/// </summary>
+public enum ServerFilterKind
+{
+    MinExecutions,
+    MinCpuMs,
+    MinDurationMs,
+    QueryTextSearch,
+    QueryTextSearchNot,
+    IncludeQueryIds,
+    IgnoreQueryIds,
+    IncludePlanIds,
+    IgnorePlanIds,
+    QueryId,
+    PlanId,
+    QueryHash,
+    QueryPlanHash,
+    Module,
+    ExecutionType,
+}
+
+/// <summary>
+/// One active filter criterion projected for display as a removable chip: its
+/// <see cref="Kind"/> (used to remove it) and a human-readable <see cref="Label"/>
+/// that includes the criterion's value.
+/// </summary>
+public readonly record struct ServerFilterChip(ServerFilterKind Kind, string Label);
+
+/// <summary>
+/// Mutable, UI-facing model of the server Query Store filter. Holds already-parsed
+/// criteria (no parsing happens here — callers use <see cref="QueryStoreFilter.ParseIdList"/>
+/// and friends first), exposes typed setters that normalize and clear, and projects to
+/// ordered chips (for display) and to a <see cref="QueryStoreFilter"/> (for fetching).
+/// <para>
+/// EscapeBrackets is a pure modifier on the query-text search: it never counts toward
+/// <see cref="IsEmpty"/>, never produces its own chip, and is always copied onto any
+/// filter <see cref="BuildFilter"/> produces.
+/// </para>
+/// </summary>
+public sealed class QueryStoreServerFilterState
+{
+    private long? _minExecutions;
+    private long? _minCpuMs;
+    private long? _minDurationMs;
+    private string? _queryTextSearch;
+    private string? _queryTextSearchNot;
+    private long[]? _includeQueryIds;
+    private long[]? _ignoreQueryIds;
+    private long[]? _includePlanIds;
+    private long[]? _ignorePlanIds;
+    private long? _queryId;
+    private long? _planId;
+    private string? _queryHash;
+    private string? _queryPlanHash;
+    private string? _module;
+    private string[]? _executionType;
+    private bool _escapeBrackets;
+
+    // Typed setters. Each normalizes its input and clears the criterion on an "empty" value.
+
+    /// <summary>Sets the minimum executions; null or a non-positive value clears it.</summary>
+    public void SetMinExecutions(long? v) => _minExecutions = v is > 0 ? v : null;
+
+    /// <summary>Sets the minimum CPU milliseconds; null or a non-positive value clears it.</summary>
+    public void SetMinCpuMs(long? v) => _minCpuMs = v is > 0 ? v : null;
+
+    /// <summary>Sets the minimum duration milliseconds; null or a non-positive value clears it.</summary>
+    public void SetMinDurationMs(long? v) => _minDurationMs = v is > 0 ? v : null;
+
+    /// <summary>Sets the query-text search term; null/whitespace clears, otherwise the value is trimmed.</summary>
+    public void SetQueryTextSearch(string? v) => _queryTextSearch = Normalize(v);
+
+    /// <summary>Sets the negated query-text search term; null/whitespace clears, otherwise trimmed.</summary>
+    public void SetQueryTextSearchNot(string? v) => _queryTextSearchNot = Normalize(v);
+
+    /// <summary>Sets the query hash; null/whitespace clears, otherwise trimmed.</summary>
+    public void SetQueryHash(string? v) => _queryHash = Normalize(v);
+
+    /// <summary>Sets the query plan hash; null/whitespace clears, otherwise trimmed.</summary>
+    public void SetQueryPlanHash(string? v) => _queryPlanHash = Normalize(v);
+
+    /// <summary>Sets the module name; null/whitespace clears, otherwise trimmed.</summary>
+    public void SetModule(string? v) => _module = Normalize(v);
+
+    /// <summary>Sets the single query id; null clears. Any non-null id is kept as-is (no clamp).</summary>
+    public void SetQueryId(long? v) => _queryId = v;
+
+    /// <summary>Sets the single plan id; null clears. Any non-null id is kept as-is (no clamp).</summary>
+    public void SetPlanId(long? v) => _planId = v;
+
+    /// <summary>Sets the execution-type descriptions; null or an empty array clears.</summary>
+    public void SetExecutionType(string[]? v) => _executionType = v is { Length: > 0 } ? v : null;
+
+    /// <summary>Sets the included query ids; null or an empty array clears.</summary>
+    public void SetIncludeQueryIds(long[]? ids) => _includeQueryIds = ids is { Length: > 0 } ? ids : null;
+
+    /// <summary>Sets the ignored query ids; null or an empty array clears.</summary>
+    public void SetIgnoreQueryIds(long[]? ids) => _ignoreQueryIds = ids is { Length: > 0 } ? ids : null;
+
+    /// <summary>Sets the included plan ids; null or an empty array clears.</summary>
+    public void SetIncludePlanIds(long[]? ids) => _includePlanIds = ids is { Length: > 0 } ? ids : null;
+
+    /// <summary>Sets the ignored plan ids; null or an empty array clears.</summary>
+    public void SetIgnorePlanIds(long[]? ids) => _ignorePlanIds = ids is { Length: > 0 } ? ids : null;
+
+    /// <summary>
+    /// Toggles literal-bracket ("escape") mode for the query-text search. A pure modifier:
+    /// excluded from <see cref="IsEmpty"/> and from chips, always copied onto the built filter.
+    /// </summary>
+    public void SetEscapeBrackets(bool v) => _escapeBrackets = v;
+
+    private static string? Normalize(string? v) => string.IsNullOrWhiteSpace(v) ? null : v.Trim();
+
+    /// <summary>
+    /// Clears exactly the given criterion. An inactive criterion, or a kind outside the
+    /// enum, is a no-op. Does not touch EscapeBrackets.
+    /// </summary>
+    public void Remove(ServerFilterKind kind)
+    {
+        switch (kind)
+        {
+            case ServerFilterKind.MinExecutions: _minExecutions = null; break;
+            case ServerFilterKind.MinCpuMs: _minCpuMs = null; break;
+            case ServerFilterKind.MinDurationMs: _minDurationMs = null; break;
+            case ServerFilterKind.QueryTextSearch: _queryTextSearch = null; break;
+            case ServerFilterKind.QueryTextSearchNot: _queryTextSearchNot = null; break;
+            case ServerFilterKind.IncludeQueryIds: _includeQueryIds = null; break;
+            case ServerFilterKind.IgnoreQueryIds: _ignoreQueryIds = null; break;
+            case ServerFilterKind.IncludePlanIds: _includePlanIds = null; break;
+            case ServerFilterKind.IgnorePlanIds: _ignorePlanIds = null; break;
+            case ServerFilterKind.QueryId: _queryId = null; break;
+            case ServerFilterKind.PlanId: _planId = null; break;
+            case ServerFilterKind.QueryHash: _queryHash = null; break;
+            case ServerFilterKind.QueryPlanHash: _queryPlanHash = null; break;
+            case ServerFilterKind.Module: _module = null; break;
+            case ServerFilterKind.ExecutionType: _executionType = null; break;
+        }
+    }
+
+    /// <summary>Resets every criterion, including the EscapeBrackets modifier.</summary>
+    public void Clear()
+    {
+        _minExecutions = null;
+        _minCpuMs = null;
+        _minDurationMs = null;
+        _queryTextSearch = null;
+        _queryTextSearchNot = null;
+        _includeQueryIds = null;
+        _ignoreQueryIds = null;
+        _includePlanIds = null;
+        _ignorePlanIds = null;
+        _queryId = null;
+        _planId = null;
+        _queryHash = null;
+        _queryPlanHash = null;
+        _module = null;
+        _executionType = null;
+        _escapeBrackets = false;
+    }
+
+    /// <summary>True when no criterion is set. The EscapeBrackets modifier is ignored.</summary>
+    public bool IsEmpty =>
+        _minExecutions is null &&
+        _minCpuMs is null &&
+        _minDurationMs is null &&
+        _queryTextSearch is null &&
+        _queryTextSearchNot is null &&
+        _includeQueryIds is null &&
+        _ignoreQueryIds is null &&
+        _includePlanIds is null &&
+        _ignorePlanIds is null &&
+        _queryId is null &&
+        _planId is null &&
+        _queryHash is null &&
+        _queryPlanHash is null &&
+        _module is null &&
+        _executionType is null;
+
+    /// <summary>
+    /// One chip per active criterion, in <see cref="ServerFilterKind"/> declaration order.
+    /// When EscapeBrackets is set, the query-text chip labels carry a literal-mode hint.
+    /// </summary>
+    public IReadOnlyList<ServerFilterChip> GetActiveChips()
+    {
+        var chips = new List<ServerFilterChip>();
+        if (_minExecutions.HasValue)
+            chips.Add(new ServerFilterChip(ServerFilterKind.MinExecutions, $"execs >= {_minExecutions.Value}"));
+        if (_minCpuMs.HasValue)
+            chips.Add(new ServerFilterChip(ServerFilterKind.MinCpuMs, $"cpu ms >= {_minCpuMs.Value}"));
+        if (_minDurationMs.HasValue)
+            chips.Add(new ServerFilterChip(ServerFilterKind.MinDurationMs, $"duration ms >= {_minDurationMs.Value}"));
+        if (_queryTextSearch is not null)
+            chips.Add(new ServerFilterChip(ServerFilterKind.QueryTextSearch, $"text: {_queryTextSearch}{EscapeHint()}"));
+        if (_queryTextSearchNot is not null)
+            chips.Add(new ServerFilterChip(ServerFilterKind.QueryTextSearchNot, $"not text: {_queryTextSearchNot}{EscapeHint()}"));
+        if (_includeQueryIds is not null)
+            chips.Add(new ServerFilterChip(ServerFilterKind.IncludeQueryIds, $"query ids: {Join(_includeQueryIds)}"));
+        if (_ignoreQueryIds is not null)
+            chips.Add(new ServerFilterChip(ServerFilterKind.IgnoreQueryIds, $"ignore query ids: {Join(_ignoreQueryIds)}"));
+        if (_includePlanIds is not null)
+            chips.Add(new ServerFilterChip(ServerFilterKind.IncludePlanIds, $"plan ids: {Join(_includePlanIds)}"));
+        if (_ignorePlanIds is not null)
+            chips.Add(new ServerFilterChip(ServerFilterKind.IgnorePlanIds, $"ignore plan ids: {Join(_ignorePlanIds)}"));
+        if (_queryId.HasValue)
+            chips.Add(new ServerFilterChip(ServerFilterKind.QueryId, $"query id: {_queryId.Value}"));
+        if (_planId.HasValue)
+            chips.Add(new ServerFilterChip(ServerFilterKind.PlanId, $"plan id: {_planId.Value}"));
+        if (_queryHash is not null)
+            chips.Add(new ServerFilterChip(ServerFilterKind.QueryHash, $"query hash: {_queryHash}"));
+        if (_queryPlanHash is not null)
+            chips.Add(new ServerFilterChip(ServerFilterKind.QueryPlanHash, $"query plan hash: {_queryPlanHash}"));
+        if (_module is not null)
+            chips.Add(new ServerFilterChip(ServerFilterKind.Module, $"module: {_module}"));
+        if (_executionType is not null)
+            chips.Add(new ServerFilterChip(ServerFilterKind.ExecutionType, $"type: {string.Join(",", _executionType)}"));
+        return chips;
+    }
+
+    // Literal-mode hint appended to query-text chip labels when escape mode is on.
+    private string EscapeHint() => _escapeBrackets ? " (literal [ ] _)" : "";
+
+    private static string Join(long[] ids) => string.Join(",", ids);
+
+    /// <summary>
+    /// Projects the active criteria to a <see cref="QueryStoreFilter"/>, or null when
+    /// <see cref="IsEmpty"/>. Fields map 1:1 by name, except <c>Module</c> →
+    /// <c>ModuleName</c> and <c>ExecutionType</c> → <c>ExecutionTypeDescs</c>. The
+    /// EscapeBrackets modifier is always copied onto the result.
+    /// </summary>
+    public QueryStoreFilter? BuildFilter()
+    {
+        if (IsEmpty) return null;
+        return new QueryStoreFilter
+        {
+            MinExecutions = _minExecutions,
+            MinCpuMs = _minCpuMs,
+            MinDurationMs = _minDurationMs,
+            QueryTextSearch = _queryTextSearch,
+            QueryTextSearchNot = _queryTextSearchNot,
+            IncludeQueryIds = _includeQueryIds,
+            IgnoreQueryIds = _ignoreQueryIds,
+            IncludePlanIds = _includePlanIds,
+            IgnorePlanIds = _ignorePlanIds,
+            QueryId = _queryId,
+            PlanId = _planId,
+            QueryHash = _queryHash,
+            QueryPlanHash = _queryPlanHash,
+            ModuleName = _module,
+            ExecutionTypeDescs = _executionType,
+            EscapeBrackets = _escapeBrackets,
+        };
+    }
+}

--- a/src/PlanViewer.Core/Services/QueryStoreService.Grouped.cs
+++ b/src/PlanViewer.Core/Services/QueryStoreService.Grouped.cs
@@ -60,17 +60,82 @@ public static partial class QueryStoreService
                 filterClauses.Add("AND OBJECT_SCHEMA_NAME(q.object_id) + N'.' + OBJECT_NAME(q.object_id) = @filterModule");
             parameters.Add(new SqlParameter("@filterModule", moduleVal));
         }
-        var queryTextPattern = QueryStoreFilter.BuildQueryTextSearchPattern(filter?.QueryTextSearch);
+        var escapeBrackets = filter?.EscapeBrackets ?? false;
+        var escapeSuffix = escapeBrackets ? " ESCAPE '\\'" : "";
+        var queryTextPattern = QueryStoreFilter.BuildQueryTextSearchPattern(filter?.QueryTextSearch, escapeBrackets);
         if (queryTextPattern != null)
         {
-            filterClauses.Add(@"AND EXISTS (
+            filterClauses.Add($@"AND EXISTS (
             SELECT 1
             FROM sys.query_store_query AS qsq
             JOIN sys.query_store_query_text AS qsqt
                 ON qsqt.query_text_id = qsq.query_text_id
             WHERE qsq.query_id = p.query_id
-            AND qsqt.query_sql_text LIKE @filterQueryText)");
+            AND qsqt.query_sql_text LIKE @filterQueryText{escapeSuffix})");
             parameters.Add(new SqlParameter("@filterQueryText", queryTextPattern));
+        }
+        var queryTextNotPattern = QueryStoreFilter.BuildQueryTextSearchPattern(filter?.QueryTextSearchNot, escapeBrackets);
+        if (queryTextNotPattern != null)
+        {
+            filterClauses.Add($@"AND NOT EXISTS (
+            SELECT 1
+            FROM sys.query_store_query AS qsq
+            JOIN sys.query_store_query_text AS qsqt
+                ON qsqt.query_text_id = qsq.query_text_id
+            WHERE qsq.query_id = p.query_id
+            AND qsqt.query_sql_text LIKE @filterQueryTextNot{escapeSuffix})");
+            parameters.Add(new SqlParameter("@filterQueryTextNot", queryTextNotPattern));
+        }
+        if (filter?.MinExecutions > 0)
+        {
+            filterClauses.Add("AND ps.total_executions >= @minExecutions");
+            parameters.Add(new SqlParameter("@minExecutions", filter.MinExecutions.Value));
+        }
+        if (filter?.MinDurationMs > 0)
+        {
+            filterClauses.Add("AND ps.total_duration_us >= (@minDurationMs * 1000e0 * ps.total_executions)");
+            parameters.Add(new SqlParameter("@minDurationMs", filter.MinDurationMs.Value));
+        }
+        if (filter?.MinCpuMs > 0)
+        {
+            filterClauses.Add("AND ps.total_cpu_us >= (@minCpuMs * 1000e0 * ps.total_executions)");
+            parameters.Add(new SqlParameter("@minCpuMs", filter.MinCpuMs.Value));
+        }
+        if (filter?.IncludeQueryIds is { Length: > 0 })
+        {
+            var paramNames = filter.IncludeQueryIds
+                .Select((_, i) => $"@includeQueryId{i}")
+                .ToList();
+            filterClauses.Add($"AND q.query_id IN ({string.Join(", ", paramNames)})");
+            for (var i = 0; i < filter.IncludeQueryIds.Length; i++)
+                parameters.Add(new SqlParameter($"@includeQueryId{i}", filter.IncludeQueryIds[i]));
+        }
+        if (filter?.IgnoreQueryIds is { Length: > 0 })
+        {
+            var paramNames = filter.IgnoreQueryIds
+                .Select((_, i) => $"@ignoreQueryId{i}")
+                .ToList();
+            filterClauses.Add($"AND q.query_id NOT IN ({string.Join(", ", paramNames)})");
+            for (var i = 0; i < filter.IgnoreQueryIds.Length; i++)
+                parameters.Add(new SqlParameter($"@ignoreQueryId{i}", filter.IgnoreQueryIds[i]));
+        }
+        if (filter?.IncludePlanIds is { Length: > 0 })
+        {
+            var paramNames = filter.IncludePlanIds
+                .Select((_, i) => $"@includePlanId{i}")
+                .ToList();
+            filterClauses.Add($"AND ps.plan_id IN ({string.Join(", ", paramNames)})");
+            for (var i = 0; i < filter.IncludePlanIds.Length; i++)
+                parameters.Add(new SqlParameter($"@includePlanId{i}", filter.IncludePlanIds[i]));
+        }
+        if (filter?.IgnorePlanIds is { Length: > 0 })
+        {
+            var paramNames = filter.IgnorePlanIds
+                .Select((_, i) => $"@ignorePlanId{i}")
+                .ToList();
+            filterClauses.Add($"AND ps.plan_id NOT IN ({string.Join(", ", paramNames)})");
+            for (var i = 0; i < filter.IgnorePlanIds.Length; i++)
+                parameters.Add(new SqlParameter($"@ignorePlanId{i}", filter.IgnorePlanIds[i]));
         }
         var filterSql = filterClauses.Count > 0 ? "\n" + string.Join("\n", filterClauses) : "";
         var phase2ExecutionTypeClause = "";
@@ -352,17 +417,82 @@ SELECT * FROM #plan_hash_rows ORDER BY query_hash, total_executions DESC;
             filterClauses.Add("AND q.query_hash = CONVERT(binary(8), @filterQueryHash, 1)");
             parameters.Add(new SqlParameter("@filterQueryHash", filter.QueryHash.Trim()));
         }
-        var queryTextPattern = QueryStoreFilter.BuildQueryTextSearchPattern(filter?.QueryTextSearch);
+        var escapeBrackets = filter?.EscapeBrackets ?? false;
+        var escapeSuffix = escapeBrackets ? " ESCAPE '\\'" : "";
+        var queryTextPattern = QueryStoreFilter.BuildQueryTextSearchPattern(filter?.QueryTextSearch, escapeBrackets);
         if (queryTextPattern != null)
         {
-            filterClauses.Add(@"AND EXISTS (
+            filterClauses.Add($@"AND EXISTS (
             SELECT 1
             FROM sys.query_store_query AS qsq
             JOIN sys.query_store_query_text AS qsqt
                 ON qsqt.query_text_id = qsq.query_text_id
             WHERE qsq.query_id = p.query_id
-            AND qsqt.query_sql_text LIKE @filterQueryText)");
+            AND qsqt.query_sql_text LIKE @filterQueryText{escapeSuffix})");
             parameters.Add(new SqlParameter("@filterQueryText", queryTextPattern));
+        }
+        var queryTextNotPattern = QueryStoreFilter.BuildQueryTextSearchPattern(filter?.QueryTextSearchNot, escapeBrackets);
+        if (queryTextNotPattern != null)
+        {
+            filterClauses.Add($@"AND NOT EXISTS (
+            SELECT 1
+            FROM sys.query_store_query AS qsq
+            JOIN sys.query_store_query_text AS qsqt
+                ON qsqt.query_text_id = qsq.query_text_id
+            WHERE qsq.query_id = p.query_id
+            AND qsqt.query_sql_text LIKE @filterQueryTextNot{escapeSuffix})");
+            parameters.Add(new SqlParameter("@filterQueryTextNot", queryTextNotPattern));
+        }
+        if (filter?.MinExecutions > 0)
+        {
+            filterClauses.Add("AND ps.total_executions >= @minExecutions");
+            parameters.Add(new SqlParameter("@minExecutions", filter.MinExecutions.Value));
+        }
+        if (filter?.MinDurationMs > 0)
+        {
+            filterClauses.Add("AND ps.total_duration_us >= (@minDurationMs * 1000e0 * ps.total_executions)");
+            parameters.Add(new SqlParameter("@minDurationMs", filter.MinDurationMs.Value));
+        }
+        if (filter?.MinCpuMs > 0)
+        {
+            filterClauses.Add("AND ps.total_cpu_us >= (@minCpuMs * 1000e0 * ps.total_executions)");
+            parameters.Add(new SqlParameter("@minCpuMs", filter.MinCpuMs.Value));
+        }
+        if (filter?.IncludeQueryIds is { Length: > 0 })
+        {
+            var paramNames = filter.IncludeQueryIds
+                .Select((_, i) => $"@includeQueryId{i}")
+                .ToList();
+            filterClauses.Add($"AND q.query_id IN ({string.Join(", ", paramNames)})");
+            for (var i = 0; i < filter.IncludeQueryIds.Length; i++)
+                parameters.Add(new SqlParameter($"@includeQueryId{i}", filter.IncludeQueryIds[i]));
+        }
+        if (filter?.IgnoreQueryIds is { Length: > 0 })
+        {
+            var paramNames = filter.IgnoreQueryIds
+                .Select((_, i) => $"@ignoreQueryId{i}")
+                .ToList();
+            filterClauses.Add($"AND q.query_id NOT IN ({string.Join(", ", paramNames)})");
+            for (var i = 0; i < filter.IgnoreQueryIds.Length; i++)
+                parameters.Add(new SqlParameter($"@ignoreQueryId{i}", filter.IgnoreQueryIds[i]));
+        }
+        if (filter?.IncludePlanIds is { Length: > 0 })
+        {
+            var paramNames = filter.IncludePlanIds
+                .Select((_, i) => $"@includePlanId{i}")
+                .ToList();
+            filterClauses.Add($"AND ps.plan_id IN ({string.Join(", ", paramNames)})");
+            for (var i = 0; i < filter.IncludePlanIds.Length; i++)
+                parameters.Add(new SqlParameter($"@includePlanId{i}", filter.IncludePlanIds[i]));
+        }
+        if (filter?.IgnorePlanIds is { Length: > 0 })
+        {
+            var paramNames = filter.IgnorePlanIds
+                .Select((_, i) => $"@ignorePlanId{i}")
+                .ToList();
+            filterClauses.Add($"AND ps.plan_id NOT IN ({string.Join(", ", paramNames)})");
+            for (var i = 0; i < filter.IgnorePlanIds.Length; i++)
+                parameters.Add(new SqlParameter($"@ignorePlanId{i}", filter.IgnorePlanIds[i]));
         }
         var filterSql = filterClauses.Count > 0 ? "\n" + string.Join("\n", filterClauses) : "";
         var phase2ExecutionTypeClause = "";

--- a/src/PlanViewer.Core/Services/QueryStoreService.cs
+++ b/src/PlanViewer.Core/Services/QueryStoreService.cs
@@ -163,20 +163,87 @@ FROM sys.database_query_store_options;";
             needsQueryJoin = true;
         }
 
-        var queryTextPattern = QueryStoreFilter.BuildQueryTextSearchPattern(filter?.QueryTextSearch);
+        var escapeBrackets = filter?.EscapeBrackets ?? false;
+        var escapeSuffix = escapeBrackets ? " ESCAPE '\\'" : "";
+        var queryTextPattern = QueryStoreFilter.BuildQueryTextSearchPattern(filter?.QueryTextSearch, escapeBrackets);
         if (queryTextPattern != null)
         {
-            filterClauses.Add(@"AND EXISTS (
+            filterClauses.Add($@"AND EXISTS (
             SELECT 1
             FROM sys.query_store_query AS qsq
             JOIN sys.query_store_query_text AS qsqt
                 ON qsqt.query_text_id = qsq.query_text_id
             WHERE qsq.query_id = p.query_id
-            AND qsqt.query_sql_text LIKE @filterQueryText)");
+            AND qsqt.query_sql_text LIKE @filterQueryText{escapeSuffix})");
             parameters.Add(new SqlParameter("@filterQueryText", queryTextPattern));
         }
+        var queryTextNotPattern = QueryStoreFilter.BuildQueryTextSearchPattern(filter?.QueryTextSearchNot, escapeBrackets);
+        if (queryTextNotPattern != null)
+        {
+            filterClauses.Add($@"AND NOT EXISTS (
+            SELECT 1
+            FROM sys.query_store_query AS qsq
+            JOIN sys.query_store_query_text AS qsqt
+                ON qsqt.query_text_id = qsq.query_text_id
+            WHERE qsq.query_id = p.query_id
+            AND qsqt.query_sql_text LIKE @filterQueryTextNot{escapeSuffix})");
+            parameters.Add(new SqlParameter("@filterQueryTextNot", queryTextNotPattern));
+        }
+        if (filter?.MinExecutions > 0)
+        {
+            filterClauses.Add("AND ps.total_executions >= @minExecutions");
+            parameters.Add(new SqlParameter("@minExecutions", filter.MinExecutions.Value));
+        }
+        if (filter?.MinDurationMs > 0)
+        {
+            filterClauses.Add("AND ps.total_duration_us >= (@minDurationMs * 1000e0 * ps.total_executions)");
+            parameters.Add(new SqlParameter("@minDurationMs", filter.MinDurationMs.Value));
+        }
+        if (filter?.MinCpuMs > 0)
+        {
+            filterClauses.Add("AND ps.total_cpu_us >= (@minCpuMs * 1000e0 * ps.total_executions)");
+            parameters.Add(new SqlParameter("@minCpuMs", filter.MinCpuMs.Value));
+        }
+        if (filter?.IncludeQueryIds is { Length: > 0 })
+        {
+            var paramNames = filter.IncludeQueryIds
+                .Select((_, i) => $"@includeQueryId{i}")
+                .ToList();
+            filterClauses.Add($"AND p.query_id IN ({string.Join(", ", paramNames)})");
+            for (var i = 0; i < filter.IncludeQueryIds.Length; i++)
+                parameters.Add(new SqlParameter($"@includeQueryId{i}", filter.IncludeQueryIds[i]));
+        }
+        if (filter?.IgnoreQueryIds is { Length: > 0 })
+        {
+            var paramNames = filter.IgnoreQueryIds
+                .Select((_, i) => $"@ignoreQueryId{i}")
+                .ToList();
+            filterClauses.Add($"AND p.query_id NOT IN ({string.Join(", ", paramNames)})");
+            for (var i = 0; i < filter.IgnoreQueryIds.Length; i++)
+                parameters.Add(new SqlParameter($"@ignoreQueryId{i}", filter.IgnoreQueryIds[i]));
+        }
+        if (filter?.IncludePlanIds is { Length: > 0 })
+        {
+            var paramNames = filter.IncludePlanIds
+                .Select((_, i) => $"@includePlanId{i}")
+                .ToList();
+            filterClauses.Add($"AND ps.plan_id IN ({string.Join(", ", paramNames)})");
+            for (var i = 0; i < filter.IncludePlanIds.Length; i++)
+                parameters.Add(new SqlParameter($"@includePlanId{i}", filter.IncludePlanIds[i]));
+        }
+        if (filter?.IgnorePlanIds is { Length: > 0 })
+        {
+            var paramNames = filter.IgnorePlanIds
+                .Select((_, i) => $"@ignorePlanId{i}")
+                .ToList();
+            filterClauses.Add($"AND ps.plan_id NOT IN ({string.Join(", ", paramNames)})");
+            for (var i = 0; i < filter.IgnorePlanIds.Length; i++)
+                parameters.Add(new SqlParameter($"@ignorePlanId{i}", filter.IgnorePlanIds[i]));
+        }
 
-        var rnClause = filter?.PlanId != null ? "" : "AND r.rn = 1";
+        var rnClause = (filter?.PlanId != null || filter?.IncludePlanIds?.Length > 0)
+            ? ""
+            : "AND r.rn = 1";
         var filterSql = filterClauses.Count > 0
             ? "\n        " + string.Join("\n        ", filterClauses)
             : "";

--- a/tests/PlanViewer.Core.Tests/QueryStoreFilterStateTests.cs
+++ b/tests/PlanViewer.Core.Tests/QueryStoreFilterStateTests.cs
@@ -1,0 +1,381 @@
+using PlanViewer.Core.Models;
+
+namespace PlanViewer.Core.Tests;
+
+// Locks in QueryStoreServerFilterState — the UI-side model that holds parsed Query Store
+// filter criteria, normalizes them through typed setters, projects active criteria to
+// ordered chips, and builds a QueryStoreFilter for fetching. EscapeBrackets is a pure
+// modifier: it never counts toward IsEmpty, never produces its own chip, and is always
+// copied onto the built filter.
+public class QueryStoreFilterStateTests
+{
+    // ---- IsEmpty / chip basics ----
+
+    [Fact]
+    public void NewState_IsEmpty_NoChips_NoFilter()
+    {
+        var s = new QueryStoreServerFilterState();
+        Assert.True(s.IsEmpty);
+        Assert.Empty(s.GetActiveChips());
+        Assert.Null(s.BuildFilter());
+    }
+
+    [Fact]
+    public void SingleSetter_ProducesOneChipOfThatKind_WithValueInLabel()
+    {
+        var s = new QueryStoreServerFilterState();
+        s.SetMinExecutions(100);
+
+        var chip = Assert.Single(s.GetActiveChips());
+        Assert.Equal(ServerFilterKind.MinExecutions, chip.Kind);
+        Assert.Contains("100", chip.Label);
+        Assert.False(s.IsEmpty);
+    }
+
+    [Fact]
+    public void QueryTextSearch_Chip_ContainsSearchValue()
+    {
+        var s = new QueryStoreServerFilterState();
+        s.SetQueryTextSearch("Votes");
+
+        var chip = Assert.Single(s.GetActiveChips());
+        Assert.Equal(ServerFilterKind.QueryTextSearch, chip.Kind);
+        Assert.Contains("Votes", chip.Label);
+    }
+
+    [Fact]
+    public void GetActiveChips_EnumeratesInEnumDeclarationOrder_RegardlessOfSetOrder()
+    {
+        var s = new QueryStoreServerFilterState();
+
+        // Every criterion, set in a deliberately scrambled order.
+        s.SetModule("dbo.p");
+        s.SetMinDurationMs(30);
+        s.SetIgnorePlanIds(new long[] { 9 });
+        s.SetQueryId(5);
+        s.SetQueryTextSearchNot("#temp");
+        s.SetMinExecutions(100);
+        s.SetExecutionType(new[] { "Regular" });
+        s.SetIncludePlanIds(new long[] { 7 });
+        s.SetQueryHash("0xAA");
+        s.SetMinCpuMs(20);
+        s.SetPlanId(6);
+        s.SetIncludeQueryIds(new long[] { 1, 2 });
+        s.SetQueryTextSearch("Votes");
+        s.SetQueryPlanHash("0xBB");
+        s.SetIgnoreQueryIds(new long[] { 3 });
+
+        var kinds = s.GetActiveChips().Select(c => c.Kind).ToArray();
+
+        Assert.Equal(new[]
+        {
+            ServerFilterKind.MinExecutions,
+            ServerFilterKind.MinCpuMs,
+            ServerFilterKind.MinDurationMs,
+            ServerFilterKind.QueryTextSearch,
+            ServerFilterKind.QueryTextSearchNot,
+            ServerFilterKind.IncludeQueryIds,
+            ServerFilterKind.IgnoreQueryIds,
+            ServerFilterKind.IncludePlanIds,
+            ServerFilterKind.IgnorePlanIds,
+            ServerFilterKind.QueryId,
+            ServerFilterKind.PlanId,
+            ServerFilterKind.QueryHash,
+            ServerFilterKind.QueryPlanHash,
+            ServerFilterKind.Module,
+            ServerFilterKind.ExecutionType,
+        }, kinds);
+    }
+
+    [Fact]
+    public void IsEmpty_TracksChipCount()
+    {
+        var s = new QueryStoreServerFilterState();
+        Assert.True(s.IsEmpty);
+        Assert.Empty(s.GetActiveChips());
+
+        s.SetMinExecutions(1);
+        Assert.False(s.IsEmpty);
+        Assert.NotEmpty(s.GetActiveChips());
+
+        s.SetMinExecutions(null);
+        Assert.True(s.IsEmpty);
+        Assert.Empty(s.GetActiveChips());
+    }
+
+    // ---- Scalar setters: normalize + clear ----
+
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(-5L)]
+    [InlineData(null)]
+    public void SetMinExecutions_NonPositiveOrNull_Clears(long? v)
+    {
+        var s = new QueryStoreServerFilterState();
+        s.SetMinExecutions(v);
+        Assert.True(s.IsEmpty);
+        Assert.Null(s.BuildFilter());
+    }
+
+    [Fact]
+    public void SetMinExecutions_Positive_Sets()
+    {
+        var s = new QueryStoreServerFilterState();
+        s.SetMinExecutions(100);
+        Assert.False(s.IsEmpty);
+        Assert.Equal(100L, s.BuildFilter()!.MinExecutions);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SetQueryTextSearch_NullOrWhitespace_Clears(string? v)
+    {
+        var s = new QueryStoreServerFilterState();
+        s.SetQueryTextSearch(v);
+        Assert.True(s.IsEmpty);
+    }
+
+    [Fact]
+    public void SetQueryTextSearch_TrimsStoredValue()
+    {
+        var s = new QueryStoreServerFilterState();
+        s.SetQueryTextSearch("  x  ");
+        Assert.Equal("x", s.BuildFilter()!.QueryTextSearch);
+        Assert.Contains("x", Assert.Single(s.GetActiveChips()).Label);
+    }
+
+    [Fact]
+    public void SetExecutionType_NullOrEmpty_Clears()
+    {
+        var s = new QueryStoreServerFilterState();
+
+        s.SetExecutionType(new[] { "Regular" });
+        Assert.False(s.IsEmpty);
+
+        s.SetExecutionType(Array.Empty<string>());
+        Assert.True(s.IsEmpty);
+
+        s.SetExecutionType(new[] { "Regular" });
+        s.SetExecutionType(null);
+        Assert.True(s.IsEmpty);
+    }
+
+    [Fact]
+    public void Setter_LastWriteWins()
+    {
+        var s = new QueryStoreServerFilterState();
+        s.SetMinExecutions(100);
+        s.SetMinExecutions(200);
+
+        Assert.Equal(200L, s.BuildFilter()!.MinExecutions);
+        Assert.Contains("200", Assert.Single(s.GetActiveChips()).Label);
+    }
+
+    // ---- Remove / Clear ----
+
+    [Fact]
+    public void Remove_ClearsExactlyThatCriterion()
+    {
+        var s = new QueryStoreServerFilterState();
+        s.SetMinExecutions(100);
+        s.SetQueryTextSearch("Votes");
+
+        s.Remove(ServerFilterKind.MinExecutions);
+
+        var chip = Assert.Single(s.GetActiveChips());
+        Assert.Equal(ServerFilterKind.QueryTextSearch, chip.Kind);
+        Assert.False(s.IsEmpty);
+    }
+
+    [Fact]
+    public void Remove_InactiveOrUnknownKind_IsNoOp()
+    {
+        var s = new QueryStoreServerFilterState();
+        s.SetMinExecutions(100);
+
+        s.Remove(ServerFilterKind.PlanId);   // inactive criterion
+        s.Remove((ServerFilterKind)999);     // outside the enum
+
+        var chip = Assert.Single(s.GetActiveChips());
+        Assert.Equal(ServerFilterKind.MinExecutions, chip.Kind);
+    }
+
+    [Fact]
+    public void Clear_ResetsEverythingIncludingEscapeBrackets()
+    {
+        var s = new QueryStoreServerFilterState();
+        s.SetMinExecutions(100);
+        s.SetQueryTextSearch("Votes");
+        s.SetEscapeBrackets(true);
+
+        s.Clear();
+
+        Assert.True(s.IsEmpty);
+        Assert.Empty(s.GetActiveChips());
+        Assert.Null(s.BuildFilter());
+
+        // The EscapeBrackets modifier was reset too: a fresh text criterion now
+        // builds a filter with escape off.
+        s.SetQueryTextSearch("Votes");
+        Assert.False(s.BuildFilter()!.EscapeBrackets);
+    }
+
+    // ---- Array setters ----
+
+    [Fact]
+    public void SetArrayCriteria_NullOrEmpty_Clears()
+    {
+        var s = new QueryStoreServerFilterState();
+
+        s.SetIncludeQueryIds(null);
+        s.SetIncludeQueryIds(Array.Empty<long>());
+        s.SetIgnoreQueryIds(Array.Empty<long>());
+        s.SetIncludePlanIds(Array.Empty<long>());
+        s.SetIgnorePlanIds(Array.Empty<long>());
+
+        Assert.True(s.IsEmpty);
+    }
+
+    [Fact]
+    public void SetIncludeQueryIds_ProducesChipAndFilter()
+    {
+        var s = new QueryStoreServerFilterState();
+        s.SetIncludeQueryIds(new long[] { 1, 2 });
+
+        var chip = Assert.Single(s.GetActiveChips());
+        Assert.Equal(ServerFilterKind.IncludeQueryIds, chip.Kind);
+        Assert.Contains("1,2", chip.Label);
+        Assert.Equal(new long[] { 1, 2 }, s.BuildFilter()!.IncludeQueryIds);
+    }
+
+    [Fact]
+    public void SetIgnoreQueryIds_ProducesChipAndFilter()
+    {
+        var s = new QueryStoreServerFilterState();
+        s.SetIgnoreQueryIds(new long[] { 1, 2 });
+
+        Assert.Equal(ServerFilterKind.IgnoreQueryIds, Assert.Single(s.GetActiveChips()).Kind);
+        Assert.Equal(new long[] { 1, 2 }, s.BuildFilter()!.IgnoreQueryIds);
+    }
+
+    [Fact]
+    public void SetIncludePlanIds_ProducesChipAndFilter()
+    {
+        var s = new QueryStoreServerFilterState();
+        s.SetIncludePlanIds(new long[] { 1, 2 });
+
+        Assert.Equal(ServerFilterKind.IncludePlanIds, Assert.Single(s.GetActiveChips()).Kind);
+        Assert.Equal(new long[] { 1, 2 }, s.BuildFilter()!.IncludePlanIds);
+    }
+
+    [Fact]
+    public void SetIgnorePlanIds_ProducesChipAndFilter()
+    {
+        var s = new QueryStoreServerFilterState();
+        s.SetIgnorePlanIds(new long[] { 1, 2 });
+
+        Assert.Equal(ServerFilterKind.IgnorePlanIds, Assert.Single(s.GetActiveChips()).Kind);
+        Assert.Equal(new long[] { 1, 2 }, s.BuildFilter()!.IgnorePlanIds);
+    }
+
+    // ---- EscapeBrackets modifier ----
+
+    [Fact]
+    public void SetEscapeBrackets_Alone_DoesNotActivateFilter()
+    {
+        var s = new QueryStoreServerFilterState();
+        s.SetEscapeBrackets(true);
+
+        Assert.True(s.IsEmpty);
+        Assert.Empty(s.GetActiveChips());
+        Assert.Null(s.BuildFilter());
+    }
+
+    [Fact]
+    public void EscapeBrackets_WithTextSearch_ShowsLiteralModeInChip_AndOnFilter()
+    {
+        var s = new QueryStoreServerFilterState();
+        s.SetQueryTextSearch("x");
+        s.SetEscapeBrackets(true);
+
+        var chip = Assert.Single(s.GetActiveChips());
+        Assert.Equal(ServerFilterKind.QueryTextSearch, chip.Kind);
+        Assert.Contains("x", chip.Label);
+        Assert.Contains("literal", chip.Label);   // literal-mode hint token
+
+        Assert.True(s.BuildFilter()!.EscapeBrackets);
+    }
+
+    [Fact]
+    public void EscapeBrackets_Off_TextChipHasNoLiteralHint()
+    {
+        var s = new QueryStoreServerFilterState();
+        s.SetQueryTextSearch("x");
+
+        Assert.DoesNotContain("literal", Assert.Single(s.GetActiveChips()).Label);
+        Assert.False(s.BuildFilter()!.EscapeBrackets);
+    }
+
+    // ---- BuildFilter mapping ----
+
+    [Fact]
+    public void BuildFilter_NullWhenEmpty()
+    {
+        Assert.Null(new QueryStoreServerFilterState().BuildFilter());
+    }
+
+    [Fact]
+    public void BuildFilter_MapsEveryField()
+    {
+        var s = new QueryStoreServerFilterState();
+        s.SetMinExecutions(100);
+        s.SetMinCpuMs(20);
+        s.SetMinDurationMs(30);
+        s.SetQueryTextSearch("Votes");
+        s.SetQueryTextSearchNot("#temp");
+        s.SetIncludeQueryIds(new long[] { 1, 2 });
+        s.SetIgnoreQueryIds(new long[] { 3 });
+        s.SetIncludePlanIds(new long[] { 4 });
+        s.SetIgnorePlanIds(new long[] { 5 });
+        s.SetQueryId(6);
+        s.SetPlanId(7);
+        s.SetQueryHash("0xAA");
+        s.SetQueryPlanHash("0xBB");
+        s.SetModule("dbo.p");
+        s.SetExecutionType(new[] { "Regular" });
+        s.SetEscapeBrackets(true);
+
+        var f = s.BuildFilter()!;
+
+        Assert.Equal(100L, f.MinExecutions);
+        Assert.Equal(20L, f.MinCpuMs);
+        Assert.Equal(30L, f.MinDurationMs);
+        Assert.Equal("Votes", f.QueryTextSearch);
+        Assert.Equal("#temp", f.QueryTextSearchNot);
+        Assert.Equal(new long[] { 1, 2 }, f.IncludeQueryIds);
+        Assert.Equal(new long[] { 3 }, f.IgnoreQueryIds);
+        Assert.Equal(new long[] { 4 }, f.IncludePlanIds);
+        Assert.Equal(new long[] { 5 }, f.IgnorePlanIds);
+        Assert.Equal(6L, f.QueryId);
+        Assert.Equal(7L, f.PlanId);
+        Assert.Equal("0xAA", f.QueryHash);
+        Assert.Equal("0xBB", f.QueryPlanHash);
+        Assert.Equal("dbo.p", f.ModuleName);                    // Module -> ModuleName
+        Assert.Equal(new[] { "Regular" }, f.ExecutionTypeDescs); // ExecutionType -> ExecutionTypeDescs
+        Assert.True(f.EscapeBrackets);
+    }
+
+    [Fact]
+    public void BuildFilter_QueryIdAndIncludeQueryIds_Coexist()
+    {
+        var s = new QueryStoreServerFilterState();
+        s.SetQueryId(5);
+        s.SetIncludeQueryIds(new long[] { 1, 2 });
+
+        var f = s.BuildFilter()!;
+        Assert.Equal(5L, f.QueryId);
+        Assert.Equal(new long[] { 1, 2 }, f.IncludeQueryIds);
+    }
+}

--- a/tests/PlanViewer.Core.Tests/QueryStoreIdListParseTests.cs
+++ b/tests/PlanViewer.Core.Tests/QueryStoreIdListParseTests.cs
@@ -1,0 +1,51 @@
+using PlanViewer.Core.Models;
+
+namespace PlanViewer.Core.Tests;
+
+// Locks in QueryStoreFilter.ParseIdList — the comma-separated id-list parser behind the
+// Query Store include/ignore query-id and plan-id filters. Contract: distinct ids in
+// first-seen order (never sorted), empty tokens from stray commas skipped, and any
+// non-integer or overflowing token throws ArgumentException.
+public class QueryStoreIdListParseTests
+{
+    [Theory]
+    // Basic comma-separated list and a lone id.
+    [InlineData("1,2,3", new long[] { 1, 2, 3 })]
+    [InlineData("5", new long[] { 5 })]
+    // Whitespace around each token is trimmed.
+    [InlineData(" 1, 2 , 3 ", new long[] { 1, 2, 3 })]
+    // Empty tokens from doubled / trailing / leading commas are skipped.
+    [InlineData("1,,2", new long[] { 1, 2 })]
+    [InlineData("1,2,", new long[] { 1, 2 })]
+    [InlineData(",1", new long[] { 1 })]
+    // Duplicates collapse to the first occurrence.
+    [InlineData("1,1,2", new long[] { 1, 2 })]
+    // Order is first-seen, NOT sorted.
+    [InlineData("3,1,2,1", new long[] { 3, 1, 2 })]
+    // Negative ids are valid integers.
+    [InlineData("-1", new long[] { -1 })]
+    // Null / empty / whitespace / comma-only input -> no filter.
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    [InlineData("   ", null)]
+    [InlineData(",", null)]
+    [InlineData(" , ", null)]
+    public void ParseIdList_ParsesDistinctFirstSeen(string? input, long[]? expected)
+    {
+        Assert.Equal(expected, QueryStoreFilter.ParseIdList(input));
+    }
+
+    [Theory]
+    // A non-integer token throws.
+    [InlineData("abc")]
+    [InlineData("1,x,2")]
+    // A token past Int64 range throws like any other non-integer token.
+    [InlineData("9999999999999999999999")]
+    // An internal space is not a separator, so "1 2" is one invalid token.
+    [InlineData("1 2")]
+    public void ParseIdList_ThrowsOnNonIntegerToken(string input)
+    {
+        // Assert the exception TYPE only — never its message text.
+        Assert.Throws<ArgumentException>(() => QueryStoreFilter.ParseIdList(input));
+    }
+}

--- a/tests/PlanViewer.Core.Tests/QueryTextSearchPatternTests.cs
+++ b/tests/PlanViewer.Core.Tests/QueryTextSearchPatternTests.cs
@@ -39,6 +39,32 @@ public class QueryTextSearchPatternTests
     }
 
     [Theory]
+    // escape_brackets = 1 (sp_QuickieStore @escape_brackets = 1): [ ] and _ become
+    // literals, backslash-escaped for ESCAPE '\', while % stays a live LIKE wildcard.
+    [InlineData("[dbo]", @"%\[dbo\]%")]
+    [InlineData("a_b", @"%a\_b%")]
+    [InlineData("[a_b]", @"%\[a\_b\]%")]
+    [InlineData("[dbo].[t]", @"%\[dbo\].\[t\]%")]
+    [InlineData("_", @"%\_%")]
+    // Pre-wrapped term keeps its % ends; interior brackets are still escaped.
+    [InlineData("%[x]%", @"%\[x\]%")]
+    // No bracket/underscore metacharacters -> escaping is a no-op.
+    [InlineData("SELECT", "%SELECT%")]
+    // Discriminator: % is a wildcard even in escape mode and is never escaped.
+    [InlineData("a%b", "%a%b%")]
+    // Known parity limitation: a literal backslash in the term is passed through
+    // unescaped, so it collides with ESCAPE '\'. Documented here, not fixed.
+    [InlineData(@"a\b", @"%a\b%")]
+    // Null / empty / whitespace -> no filter, regardless of escape mode.
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    [InlineData("   ", null)]
+    public void BuildQueryTextSearchPattern_EscapeBrackets_EscapesBracketsAndUnderscore(string? input, string? expected)
+    {
+        Assert.Equal(expected, QueryStoreFilter.BuildQueryTextSearchPattern(input, escapeBrackets: true));
+    }
+
+    [Theory]
     // Single friendly value -> single execution_type_desc.
     [InlineData("regular", new[] { "Regular" })]
     [InlineData("aborted", new[] { "Aborted" })]


### PR DESCRIPTION
## Summary
- Builds the full server-side Query Store filtering architecture on top of #390's query-text search: users can now stack `sp_QuickieStore`-style pre-filters that apply **before TOP N** in all three SQL builders, so target queries are found even when they aren't in the top N by the chosen metric.
- New criteria (three-surface parity — Desktop, MCP, CLI): minimum executions, minimum **average** duration/CPU per execution (ms, over the selected window — deliberately grid-consistent rather than mirroring the proc's per-interval semantics), query-text exclude, an escape-brackets toggle for literal `[ ] _` matching (EF-style bracketed text), and include/ignore lists for query IDs and plan IDs.
- Desktop gains the filter architecture: a collapsible **Server Filters** panel with transactional Apply, an always-visible **chip strip** showing every criterion that shaped the fetch (chips are removable and re-fetch), and **promotion** — column-filter popups offer "Search server" on columns with server equivalents.

Closes #391

## Changes
- **Core model** (`QueryStorePlan.cs`): nine new `QueryStoreFilter` properties; `ParseIdList` (strict: ordered first-seen dedupe, throws naming any bad token); `BuildQueryTextSearchPattern` gains an `escapeBrackets` overload (wrap-then-escape, `%` never escaped, pairs with `ESCAPE '\'`).
- **SQL builders** (`QueryStoreService.cs`, `QueryStoreService.Grouped.cs`): all criteria added to the pre-TOP-N filter mechanism in the flat and both grouped builders, fully parameterized (per-element `IN`/`NOT IN` params); thresholds use null-safe `> 0` guards and a float-literal multiplication form that avoids a numeric-precision overflow edge; `rn = 1` is relaxed when plans are explicitly included so a non-best plan isn't dropped; with everything unset the generated SQL is byte-identical to before.
- **Filter-state model** (`QueryStoreServerFilterState.cs`, Core — unit-testable): typed normalizing setters, ordered chip projection, 1:1 `BuildFilter()`; `EscapeBrackets` is a pure modifier (no chip, ignored by `IsEmpty`, always copied).
- **Desktop** (`QueryStoreGridControl.*`, `ColumnFilterPopup.*`, `AppSettingsService.cs`): panel + chips rows; Search-by commits now flow into the shared filter state as chips; `Fetch_Click` commits before fetching; Clear clears all server filters and re-fetches; promotion maps Executions/AvgCpu/AvgDuration (measure-preserving; totals deliberately excluded), ids/hashes (Equals), text/module (Contains) with operator validation at click; panel expanded state persisted.
- **MCP** (`McpQueryStoreTools.cs`): nine additive `get_query_store_top` params. **CLI** (`QueryStoreCommand.cs`): nine additive options. Malformed id lists error cleanly on both surfaces before any connection attempt.
- **Tests**: 59 new — escape-mode pattern matrix (including the documented backslash parity limitation), full `ParseIdList` contract, and the filter-state model (chips, normalization, mapping, coexistence).

## Test Plan
- [x] `dotnet build PlanViewer.sln -c Debug` — no new warnings
- [x] `dotnet test` — 182/182 (123 existing + 59 new)
- [x] Live end-to-end on SQL Server 2022 / StackOverflow2013: thresholds filter and back-fill pre-TOP-N; include/ignore id lists return exact sets; explicitly included plans survive the rn relaxation; `--escape-brackets` flips `[Users]` between literal and character-class matching; text include+exclude compose correctly (empty results ground-truthed against raw Query Store DMVs); stacked filters AND together
- [x] CLI `--help` shows all nine options; malformed `--include-query-ids "1,x,3"` exits 1 with a clear message before connecting
- [ ] Desktop smoke: panel apply/clear, chip render/remove/re-fetch, Search-by-as-chips, promotion popup (code-verified and compiled; UI not driven — reviewer note: popup widened to 280px for the third button)

Generated with [Claude Code](https://claude.com/claude-code)
