### PR TITLE
Bump version to 1.16.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
     Tests and server/ projects are outside src/ and are unaffected.
   -->
   <PropertyGroup>
-    <Version>1.15.0</Version>
+    <Version>1.16.0</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
+++ b/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
@@ -7,5 +7,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Performance Studio for SSMS")]
 [assembly: AssemblyCopyright("Copyright Darling Data 2026")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("1.15.0.0")]
-[assembly: AssemblyFileVersion("1.15.0.0")]
+[assembly: AssemblyVersion("1.16.0.0")]
+[assembly: AssemblyFileVersion("1.16.0.0")]

--- a/src/PlanViewer.Ssms/source.extension.vsixmanifest
+++ b/src/PlanViewer.Ssms/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="PlanViewer.Ssms.64F79022-9D9A-4463-A1AE-4B19426A0CB1"
-              Version="1.15.0"
+              Version="1.16.0"
               Language="en-US"
               Publisher="Darling Data" />
     <DisplayName>Performance Studio for SSMS</DisplayName>


### PR DESCRIPTION
Version bump for the v1.16.0 release: Directory.Build.props plus the non-SDK SSMS extension files (AssemblyInfo.cs, source.extension.vsixmanifest) which must be bumped by hand.

Since v1.15.0 (2026-07-04), dev has:
- Query Store server-side filter panel, chips, and pre-filters (#391)
- Query Store query-text search filter (#389)
- Fix operator self-time: exclude coordinator thread, look through batch subtrees (#387)
- Portable query-plan-analysis skill added, inert copy removed (#385, #386)

After this merges, dev goes to main as Release v1.16.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)