### PR TITLE
Quarterly maintenance: CVE-2025-6965 fix, dependency bumps, zero-warning build, CI action bumps

### DIFF
--- a/.github/workflows/check-pr-branch.yml
+++ b/.github/workflows/check-pr-branch.yml
@@ -6,6 +6,10 @@ on:
       - reopened
       - synchronize
       - edited
+
+# pull_request_target runs with the base repo's token — this job needs none of it.
+permissions: {}
+
 jobs:
   check-branches:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Get PR version
         id: pr
@@ -26,7 +26,7 @@ jobs:
           Write-Host "PR version: $version (from $path)"
 
       - name: Checkout main
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: main
           path: main-branch

--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   check-version:
     if: github.head_ref == 'dev'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ on:
       - 'src/PlanViewer.Ssms/**'
       - 'src/PlanViewer.Ssms.Installer/**'
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Setup .NET 10.0
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
           cache: true

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -27,10 +27,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Setup .NET 10.0
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
@@ -50,10 +50,10 @@ jobs:
         run: cp publish/wwwroot/index.html publish/wwwroot/404.html
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: publish/wwwroot
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       has_changes: ${{ steps.check.outputs.has_changes }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: dev
           fetch-depth: 0
@@ -38,12 +38,12 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: dev
 
       - name: Setup .NET 10.0
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Get version
         id: version
@@ -46,7 +46,7 @@ jobs:
           gh release create "v${{ steps.version.outputs.VERSION }}" --title "v${{ steps.version.outputs.VERSION }}" --generate-notes --target main
 
       - name: Setup .NET 10.0
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
@@ -143,7 +143,7 @@ jobs:
 
       - name: Upload Windows build for signing
         id: upload-unsigned
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: App-unsigned
           path: publish/win-x64/

--- a/server/PlanShare/PlanShare.csproj
+++ b/server/PlanShare/PlanShare.csproj
@@ -7,7 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
+    <!-- Direct ref lifts the transitive SQLitePCLRaw above 2.1.11, which bundles a
+         SQLite vulnerable to CVE-2025-6965 (GHSA-2m69-gcr7-jv3q). Microsoft.Data.Sqlite
+         still floors at 2.1.11 — remove this once its floor reaches 2.1.12+. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
   </ItemGroup>
 
 </Project>

--- a/src/PlanViewer.App/MainWindow.FileOps.cs
+++ b/src/PlanViewer.App/MainWindow.FileOps.cs
@@ -88,9 +88,9 @@ public partial class MainWindow : Window
     {
         e.DragEffects = DragDropEffects.None;
 
-        if (e.Data.Contains(DataFormats.Files))
+        if (e.DataTransfer.Contains(DataFormat.File))
         {
-            var files = e.Data.GetFiles();
+            var files = e.DataTransfer.TryGetFiles();
             if (files != null && files.Any(f => IsSupportedFile(f.TryGetLocalPath())))
                 e.DragEffects = DragDropEffects.Copy;
         }
@@ -98,9 +98,9 @@ public partial class MainWindow : Window
 
     private void OnDrop(object? sender, DragEventArgs e)
     {
-        if (!e.Data.Contains(DataFormats.Files)) return;
+        if (!e.DataTransfer.Contains(DataFormat.File)) return;
 
-        var files = e.Data.GetFiles();
+        var files = e.DataTransfer.TryGetFiles();
         if (files == null) return;
 
         foreach (var file in files)

--- a/src/PlanViewer.App/Mcp/McpHostService.cs
+++ b/src/PlanViewer.App/Mcp/McpHostService.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -74,6 +75,30 @@ public sealed class McpHostService : BackgroundService
                 .WithTools<McpQueryStoreTools>();
 
             _app = builder.Build();
+
+            /* DNS-rebinding guard. Kestrel only listens on loopback, but a malicious
+               web page can point a DNS name it controls at 127.0.0.1 and reach this
+               server same-origin (CORS never applies). Reject any request whose Host
+               isn't a loopback name, and any browser request whose Origin isn't a
+               loopback origin, before it can touch an MCP endpoint. */
+            _app.Use(async (context, next) =>
+            {
+                if (!IsLoopbackHost(context.Request.Host.Host))
+                {
+                    context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                    return;
+                }
+
+                var origin = context.Request.Headers.Origin;
+                if (origin.Count > 0 && !IsLoopbackOrigin(origin[0]))
+                {
+                    context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                    return;
+                }
+
+                await next();
+            });
+
             _app.MapMcp();
 
             await _app.RunAsync(stoppingToken);
@@ -86,6 +111,22 @@ public sealed class McpHostService : BackgroundService
         {
             System.Diagnostics.Debug.WriteLine($"MCP server failed to start: {ex.Message}");
         }
+    }
+
+    private static bool IsLoopbackHost(string host)
+    {
+        /* HostString.Host keeps IPv6 brackets ([::1]); Uri.Host strips them. */
+        return host.Equals("localhost", StringComparison.OrdinalIgnoreCase)
+            || host == "127.0.0.1"
+            || host == "[::1]"
+            || host == "::1";
+    }
+
+    private static bool IsLoopbackOrigin(string? origin)
+    {
+        return origin != null
+            && Uri.TryCreate(origin, UriKind.Absolute, out var uri)
+            && IsLoopbackHost(uri.Host);
     }
 
     public override async Task StopAsync(CancellationToken cancellationToken)

--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -18,11 +18,6 @@
     <PackageReference Include="Avalonia.Desktop" Version="11.3.18" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.18" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.18" />
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.18">
-      <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
-      <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="AvaloniaEdit.TextMate" Version="11.4.1" />
     <PackageReference Include="AvaloniaEdit.TextMate.Grammars" Version="0.10.12.1" />
     <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="2.0.1" />

--- a/src/PlanViewer.App/PlanViewer.App.csproj
+++ b/src/PlanViewer.App/PlanViewer.App.csproj
@@ -9,26 +9,27 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.17" />
+    <PackageReference Include="Avalonia" Version="11.3.18" />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.4.1" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.13" />
+    <!-- 5.1.58 is the last Avalonia 11 build — 5.1.59+ requires Avalonia >= 12.0.0.
+         Bump together with the Avalonia 12 migration (branch upgrade/avalonia-12). -->
     <PackageReference Include="ScottPlot.Avalonia" Version="5.1.58" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.17" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.17" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.17" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.18" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.18" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.18" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.17">
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.18">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="AvaloniaEdit.TextMate" Version="11.4.1" />
     <PackageReference Include="AvaloniaEdit.TextMate.Grammars" Version="0.10.12.1" />
     <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.1" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.1" />
     <PackageReference Include="TextMateSharp.Grammars" Version="2.0.4" />
-    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="180.37.3" />
+    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="180.59.2" />
     <PackageReference Include="Velopack" Version="1.2.0" />
 
     <!-- Pin SkiaSharp native assets to match SkiaSharp 3.119.0.

--- a/src/PlanViewer.Cli/PlanViewer.Cli.csproj
+++ b/src/PlanViewer.Cli/PlanViewer.Cli.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.9" />
+    <PackageReference Include="System.CommandLine" Version="2.0.10" />
   </ItemGroup>
 
 </Project>

--- a/src/PlanViewer.Core/PlanViewer.Core.csproj
+++ b/src/PlanViewer.Core/PlanViewer.Core.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0" />
-    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="180.37.3" />
+    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="7.0.2" />
+    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="180.59.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PlanViewer.Core/Services/DdlScripter.cs
+++ b/src/PlanViewer.Core/Services/DdlScripter.cs
@@ -237,9 +237,9 @@ public static class DdlScripter
 
     private static string BracketName(string name)
     {
-        // Already bracketed
-        if (name.StartsWith('['))
-            return name;
-        return $"[{name}]";
+        // Double embedded ']' so a name can't terminate the identifier early —
+        // this output exists to be copy/pasted and executed. Callers always pass
+        // raw catalog names, never pre-bracketed ones.
+        return "[" + name.Replace("]", "]]") + "]";
     }
 }

--- a/src/PlanViewer.Core/Services/ReproScriptBuilder.cs
+++ b/src/PlanViewer.Core/Services/ReproScriptBuilder.cs
@@ -59,12 +59,20 @@ public static class ReproScriptBuilder
             warnings.Add("Plan XML not available — parameters could not be extracted");
         }
 
+        /* Plan XML is untrusted input: names, types, and compiled values come straight
+           off ParameterList attributes. Drop parameters whose name or type isn't a
+           plausible T-SQL token before anything is interpolated — the name lands in
+           the warning comment and the sp_executesql assignment list. */
+        var safeParameters = parameters
+            .Where(p => IsValidParameterName(p.Name) && IsValidDataType(p.DataType))
+            .ToList();
+
         /* Check for temp tables and table variables in query text */
         var tempTableWarnings = DetectTempTablesAndTableVariables(queryText);
         warnings.AddRange(tempTableWarnings);
 
         /* Check for parameters with missing compiled values */
-        var missingValueParams = parameters.Where(p => string.IsNullOrEmpty(p.CompiledValue)).ToList();
+        var missingValueParams = safeParameters.Where(p => string.IsNullOrEmpty(p.CompiledValue)).ToList();
         if (missingValueParams.Count > 0)
         {
             warnings.Add($"Parameters with missing values (set to ?): {string.Join(", ", missingValueParams.Select(p => p.Name))}. Fill in values before executing.");
@@ -138,15 +146,20 @@ public static class ReproScriptBuilder
         sb.AppendLine("SET NOCOUNT ON;");
         sb.AppendLine();
 
-        /* Query body — wrap in sp_executesql if parameters found */
-        if (parameters.Count > 0)
+        /* Query body — wrap in sp_executesql if parameters found. Values that
+           aren't a single self-contained literal are emitted as ? so a crafted
+           plan can't splice statements into the generated batch. */
+        if (safeParameters.Count > 0)
         {
             /* Build parameter declaration and value assignment */
-            var paramDecl = string.Join(", ", parameters.Select(p => $"{p.Name} {p.DataType}"));
-            var paramValues = parameters.Select(p =>
+            var paramDecl = string.Join(", ", safeParameters.Select(p => $"{p.Name} {p.DataType}"));
+            var paramValues = safeParameters.Select(p =>
             {
-                /* Use ? for missing values so query can't accidentally run with wrong data */
-                var value = string.IsNullOrEmpty(p.CompiledValue) ? "?" : p.CompiledValue;
+                /* Use ? for missing or unsafe values so query can't accidentally run
+                   with wrong data */
+                var value = string.IsNullOrEmpty(p.CompiledValue) || !IsSafeLiteral(p.CompiledValue)
+                    ? "?"
+                    : p.CompiledValue;
                 return $"    {p.Name} = {value}";
             });
 
@@ -401,6 +414,50 @@ public static class ReproScriptBuilder
     private static string EscapeSqlString(string value)
     {
         return value.Replace("'", "''");
+    }
+
+    /// <summary>
+    /// Validates a parameter name from plan XML as a plain @identifier.
+    /// Anything else is dropped from the generated script.
+    /// </summary>
+    private static bool IsValidParameterName(string name)
+    {
+        return Regex.IsMatch(name, @"^@[\p{L}_@#$][\p{L}\p{Nd}_@#$]*$");
+    }
+
+    /// <summary>
+    /// Validates a parameter data type from plan XML: type name with optional
+    /// schema prefix, brackets, and (size/precision) suffix. No quotes or comment
+    /// characters, so it can't disturb the sp_executesql declaration list.
+    /// </summary>
+    private static bool IsValidDataType(string dataType)
+    {
+        return Regex.IsMatch(dataType, @"^[\p{L}\p{Nd}_\[\]., ()]+$");
+    }
+
+    /// <summary>
+    /// Accepts a compiled value only when it's a single self-contained literal:
+    /// NULL, a number, a 0x binary value, or one complete N'...' string with every
+    /// embedded quote doubled. Such values can't escape the @param = value slot.
+    /// </summary>
+    private static bool IsSafeLiteral(string value)
+    {
+        if (value.Equals("NULL", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        /* Integer/decimal/float/money forms: -12, 3.14, 1.5E+3, $9.99 */
+        if (Regex.IsMatch(value, @"^-?\$?\d+(\.\d+)?([eE][+-]?\d+)?$"))
+            return true;
+
+        /* Binary literal */
+        if (Regex.IsMatch(value, @"^0x[0-9A-Fa-f]*$"))
+            return true;
+
+        /* One complete string literal — every embedded quote must be doubled */
+        if (Regex.IsMatch(value, @"^N?'([^']|'')*'$"))
+            return true;
+
+        return false;
     }
 
     /// <summary>

--- a/src/PlanViewer.Core/Services/ReproScriptBuilder.cs
+++ b/src/PlanViewer.Core/Services/ReproScriptBuilder.cs
@@ -78,6 +78,24 @@ public static class ReproScriptBuilder
             warnings.Add($"Parameters with missing values (set to ?): {string.Join(", ", missingValueParams.Select(p => p.Name))}. Fill in values before executing.");
         }
 
+        /* Values that aren't a single self-contained literal also become ?, so say why
+           rather than leaving an unexplained placeholder. */
+        var unsafeValueParams = safeParameters
+            .Where(p => !string.IsNullOrEmpty(p.CompiledValue) && !IsSafeLiteral(p.CompiledValue))
+            .ToList();
+        if (unsafeValueParams.Count > 0)
+        {
+            warnings.Add($"Parameters whose compiled value was not a simple literal (set to ?): {string.Join(", ", unsafeValueParams.Select(p => p.Name))}. Fill in values before executing.");
+        }
+
+        /* Parameters dropped entirely because the plan's name or data type wasn't a
+           plain T-SQL token — the script would be incomplete, so don't stay silent. */
+        var droppedCount = parameters.Count - safeParameters.Count;
+        if (droppedCount > 0)
+        {
+            warnings.Add($"{droppedCount} parameter(s) omitted — the plan's parameter name or data type was not a valid T-SQL identifier. Declare them manually before executing.");
+        }
+
         /* Check for local variables: query has parameter prefix but plan has no/few parameters */
         var trimmedQuery = queryText.Trim();
         var cleanedQuery = StripParameterPrefix(trimmedQuery);

--- a/src/PlanViewer.Core/Services/SchemaQueryService.cs
+++ b/src/PlanViewer.Core/Services/SchemaQueryService.cs
@@ -57,7 +57,7 @@ SELECT
     i.is_unique,
     i.is_primary_key,
     STUFF((
-        SELECT ', ' + c.name + CASE WHEN ic2.is_descending_key = 1 THEN ' DESC' ELSE '' END
+        SELECT ', ' + QUOTENAME(c.name) + CASE WHEN ic2.is_descending_key = 1 THEN ' DESC' ELSE '' END
         FROM sys.index_columns AS ic2
         JOIN sys.columns AS c ON c.object_id = ic2.object_id AND c.column_id = ic2.column_id
         WHERE ic2.object_id = i.object_id AND ic2.index_id = i.index_id AND ic2.is_included_column = 0
@@ -65,7 +65,7 @@ SELECT
         FOR XML PATH('')
     ), 1, 2, '') AS key_columns,
     ISNULL(STUFF((
-        SELECT ', ' + c.name
+        SELECT ', ' + QUOTENAME(c.name)
         FROM sys.index_columns AS ic2
         JOIN sys.columns AS c ON c.object_id = ic2.object_id AND c.column_id = ic2.column_id
         WHERE ic2.object_id = i.object_id AND ic2.index_id = i.index_id AND ic2.is_included_column = 1

--- a/src/PlanViewer.Web/PlanViewer.Web.csproj
+++ b/src/PlanViewer.Web/PlanViewer.Web.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.10" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- Linked files from PlanViewer.Core — analysis pipeline only, no SqlClient/WASM-incompatible deps -->

--- a/src/PlanViewer.Web/Services/PlanShareService.cs
+++ b/src/PlanViewer.Web/Services/PlanShareService.cs
@@ -67,14 +67,14 @@ public sealed class PlanShareService : IPlanShareService
 
     public async Task DeleteAsync(string shareId, string deleteToken)
     {
-        var response = await _http.DeleteAsync($"{ApiBase}/api/plans/{shareId}?token={deleteToken}");
+        var response = await _http.DeleteAsync($"{ApiBase}/api/plans/{Uri.EscapeDataString(shareId)}?token={Uri.EscapeDataString(deleteToken)}");
         if (!response.IsSuccessStatusCode)
             throw new PlanShareException("Failed to delete shared plan.");
     }
 
     public async Task<SharedPlan> LoadAsync(string id)
     {
-        var response = await _http.GetAsync($"{ApiBase}/api/plans/{id}");
+        var response = await _http.GetAsync($"{ApiBase}/api/plans/{Uri.EscapeDataString(id)}");
         if (!response.IsSuccessStatusCode)
         {
             throw new PlanShareException(response.StatusCode == HttpStatusCode.NotFound

--- a/tests/PlanViewer.Core.Tests/DdlScripterTests.cs
+++ b/tests/PlanViewer.Core.Tests/DdlScripterTests.cs
@@ -91,13 +91,24 @@ public class DdlScripterTests
     }
 
     [Fact]
-    public void FormatIndexes_AlreadyBracketedName_IsNotDoubleBracketed()
+    public void FormatIndexes_NameContainingBracket_IsEscapedNotPassedThrough()
     {
-        // Canonical behavior: BracketName leaves an already-bracketed identifier alone.
+        // These scripts exist to be copy/pasted and executed, so a ']' in a catalog
+        // name must not be able to close the identifier early and start new T-SQL.
+        var sql = DdlScripter.FormatIndexes("dbo.T", new[] { Index("IX] ; DROP TABLE dbo.T --", "NONCLUSTERED", "A") });
+
+        Assert.Contains("[IX]] ; DROP TABLE dbo.T --]", sql);
+        Assert.DoesNotContain("[IX] ; DROP TABLE dbo.T --]", sql);
+    }
+
+    [Fact]
+    public void FormatIndexes_NameLookingBracketed_IsStillEscaped()
+    {
+        // Catalog names are always raw, so a leading '[' is part of the name, not
+        // pre-quoting — escaping it is what keeps a crafted name inert.
         var sql = DdlScripter.FormatIndexes("dbo.T", new[] { Index("[IX_T]", "NONCLUSTERED", "A") });
 
-        Assert.Contains("[IX_T]", sql);
-        Assert.DoesNotContain("[[IX_T]]", sql);
+        Assert.Contains("[[IX_T]]]", sql);
     }
 
     [Fact]

--- a/tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj
+++ b/tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/tests/PlanViewer.Core.Tests/ReproScriptBuilderSafetyTests.cs
+++ b/tests/PlanViewer.Core.Tests/ReproScriptBuilderSafetyTests.cs
@@ -84,6 +84,49 @@ public class ReproScriptBuilderSafetyTests
     }
 
     [Fact]
+    public void BuildReproScript_UnsafeValue_ExplainsThePlaceholder()
+    {
+        // A bare ? with no explanation would read as a tool bug rather than a
+        // deliberate refusal to emit the plan's value.
+        var plan = PlanWithParameter("@id", "int", "1; DROP TABLE dbo.Orders --");
+        var sql = ReproScriptBuilder.BuildReproScript("SELECT 1", "db", plan, null);
+
+        Assert.Contains("not a simple literal", sql);
+        Assert.Contains("@id", sql);
+    }
+
+    [Fact]
+    public void BuildReproScript_DroppedParameter_IsReportedInWarnings()
+    {
+        var plan = PlanWithParameter("@id", "int; DROP TABLE dbo.Orders --", "(1)");
+        var sql = ReproScriptBuilder.BuildReproScript("SELECT 1", "db", plan, null);
+
+        Assert.Contains("1 parameter(s) omitted", sql);
+    }
+
+    [Theory]
+    [InlineData("int", "(42)", "42")]                                  // parenthesized integer
+    [InlineData("int", "(-7)", "-7")]                                  // negative
+    [InlineData("bit", "(0)", "0")]                                    // bit
+    [InlineData("decimal(18,2)", "(1.50)", "1.50")]                    // decimal
+    [InlineData("float", "(1.0000000000000000e+000)", "1.0000000000000000e+000")] // scientific
+    [InlineData("money", "($10.50)", "$10.50")]                        // money
+    [InlineData("varbinary(8)", "(0x1234ABCD)", "0x1234ABCD")]         // binary
+    [InlineData("datetime", "('2024-01-01 00:00:00.000')", "'2024-01-01 00:00:00.000'")] // date literal
+    [InlineData("nvarchar(50)", "N'O''Brien'", "N'O''Brien'")]         // doubled quote inside
+    [InlineData("int", "NULL", "NULL")]                                // null
+    public void BuildReproScript_RealWorldCompiledValues_SurviveTheFilter(
+        string dataType, string compiledValue, string expected)
+    {
+        // Guards against the filter being so strict it degrades ordinary repro scripts.
+        var plan = PlanWithParameter("@p", dataType, compiledValue.Replace("\"", "&quot;"));
+        var sql = ReproScriptBuilder.BuildReproScript("SELECT 1", "db", plan, null);
+
+        Assert.Contains($"@p = {expected}", sql);
+        Assert.DoesNotContain("@p = ?", sql);
+    }
+
+    [Fact]
     public void ExtractParametersFromPlan_StillReturnsRawParameters()
     {
         // The filter lives in script generation, not extraction — callers that only

--- a/tests/PlanViewer.Core.Tests/ReproScriptBuilderSafetyTests.cs
+++ b/tests/PlanViewer.Core.Tests/ReproScriptBuilderSafetyTests.cs
@@ -1,0 +1,98 @@
+using PlanViewer.Core.Services;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// Plan XML is untrusted input — a .sqlplan can be crafted or emailed. These cover the
+/// generated script staying inert: the repro script is executed by ActualPlanExecutor
+/// and handed to users to run, so a hostile ParameterList must not reach it intact.
+/// </summary>
+public class ReproScriptBuilderSafetyTests
+{
+    private static string PlanWithParameter(string column, string dataType, string compiledValue) =>
+        $"""
+         <ShowPlanXML xmlns="http://schemas.microsoft.com/sqlserver/2004/07/showplan">
+           <BatchSequence><Batch><Statements>
+             <StmtSimple>
+               <QueryPlan>
+                 <ParameterList>
+                   <ColumnReference Column="{column}" ParameterDataType="{dataType}" ParameterCompiledValue="{compiledValue}" />
+                 </ParameterList>
+               </QueryPlan>
+             </StmtSimple>
+           </Statements></Batch></BatchSequence>
+         </ShowPlanXML>
+         """;
+
+    [Fact]
+    public void BuildReproScript_LegitimateParameter_IsEmittedVerbatim()
+    {
+        var plan = PlanWithParameter("@id", "int", "(42)");
+        var sql = ReproScriptBuilder.BuildReproScript("SELECT 1", "db", plan, null);
+
+        Assert.Contains("EXECUTE sys.sp_executesql", sql);
+        Assert.Contains("@id int", sql);
+        Assert.Contains("@id = 42", sql);
+    }
+
+    [Fact]
+    public void BuildReproScript_StringParameter_KeepsQuotedLiteral()
+    {
+        var plan = PlanWithParameter("@name", "nvarchar(50)", "N'Erik'");
+        var sql = ReproScriptBuilder.BuildReproScript("SELECT 1", "db", plan, null);
+
+        Assert.Contains("@name = N'Erik'", sql);
+    }
+
+    [Fact]
+    public void BuildReproScript_CompiledValueBreakingOutOfLiteral_BecomesPlaceholder()
+    {
+        // The injection this guards: a value that closes its own literal and appends T-SQL.
+        var plan = PlanWithParameter("@id", "int", "1; DROP TABLE dbo.Orders --");
+        var sql = ReproScriptBuilder.BuildReproScript("SELECT 1", "db", plan, null);
+
+        Assert.DoesNotContain("DROP TABLE", sql);
+        Assert.Contains("@id = ?", sql);
+    }
+
+    [Fact]
+    public void BuildReproScript_CompiledValueWithUnbalancedQuote_BecomesPlaceholder()
+    {
+        var plan = PlanWithParameter("@name", "nvarchar(50)", "N'x'; EXEC sp_who --'");
+        var sql = ReproScriptBuilder.BuildReproScript("SELECT 1", "db", plan, null);
+
+        Assert.DoesNotContain("sp_who", sql);
+        Assert.Contains("@name = ?", sql);
+    }
+
+    [Fact]
+    public void BuildReproScript_HostileParameterName_IsDroppedEntirely()
+    {
+        var plan = PlanWithParameter("@id = 1, @x int = 1; SHUTDOWN --", "int", "(1)");
+        var sql = ReproScriptBuilder.BuildReproScript("SELECT 1", "db", plan, null);
+
+        Assert.DoesNotContain("SHUTDOWN", sql);
+    }
+
+    [Fact]
+    public void BuildReproScript_HostileDataType_IsDroppedEntirely()
+    {
+        var plan = PlanWithParameter("@id", "int; DROP TABLE dbo.Orders --", "(1)");
+        var sql = ReproScriptBuilder.BuildReproScript("SELECT 1", "db", plan, null);
+
+        Assert.DoesNotContain("DROP TABLE", sql);
+    }
+
+    [Fact]
+    public void ExtractParametersFromPlan_StillReturnsRawParameters()
+    {
+        // The filter lives in script generation, not extraction — callers that only
+        // display parameters should still see what the plan actually contained.
+        var plan = PlanWithParameter("@id", "int", "(42)");
+        var parameters = ReproScriptBuilder.ExtractParametersFromPlan(plan);
+
+        Assert.Single(parameters);
+        Assert.Equal("@id", parameters[0].Name);
+        Assert.Equal("42", parameters[0].CompiledValue);
+    }
+}


### PR DESCRIPTION
Quarterly maintenance pass (July 2026). Read-only scans + low-risk fixes per the /maintenance skill.

## Security
- **CVE-2025-6965 (High, GHSA-2m69-gcr7-jv3q)**: PlanShare pulled SQLitePCLRaw.lib.e_sqlite3 2.1.11 transitively via Microsoft.Data.Sqlite (SQLite < 3.50.2 memory corruption). Fixed with a direct `SQLitePCLRaw.bundle_e_sqlite3` 2.1.12 reference (Microsoft.Data.Sqlite 10.0.10 still floors at the vulnerable 2.1.11). NU1903 no longer fires.

## Dependency bumps (patch/minor only)
| Package | From | To |
|---|---|---|
| Avalonia (App, 5 pkgs) | 11.3.17 | 11.3.18 |
| Microsoft.Data.SqlClient | 7.0.1 | 7.0.2 |
| Microsoft.Data.SqlClient.Extensions.Azure | 1.0.0 | 7.0.2 (version-scheme alignment w/ SqlClient) |
| Microsoft.SqlServer.TransactSql.ScriptDom | 180.37.3 | 180.59.2 |
| ModelContextProtocol (+AspNetCore) | 1.4.0 | 1.4.1 |
| System.CommandLine | 2.0.9 | 2.0.10 |
| AspNetCore WASM (+DevServer) | 10.0.9 | 10.0.10 |
| Microsoft.NET.Test.Sdk | 18.6.0 | 18.8.1 |
| Microsoft.Data.Sqlite (PlanShare) | 10.0.9 | 10.0.10 |

**Held back on purpose:** ScottPlot.Avalonia stays 5.1.58 — 5.1.59+ requires Avalonia >= 12 (NU1605s against 11.x). That means the parked `upgrade/avalonia-12` branch is now unblocked; it gets its own effort. `Microsoft.Win32.Registry` removed (in-box on net10.0, NU1510). SkiaSharp.NativeAssets.Linux pin (issue #139 guard) unchanged. VSIX stays on the 17.x tip (17.14.x is the line's latest; 18.x targets VS 18).

## Zero-warning build
Avalonia 11.3.18 obsoletes `DragEventArgs.Data` / `DataFormats.Files` (CS0618 x6) — migrated `MainWindow.FileOps.cs` drag/drop to `e.DataTransfer.Contains(DataFormat.File)` / `TryGetFiles()` (API verified against Avalonia 11.3.18 source).

## CI actions
checkout v5->v7, setup-dotnet v5->v6, upload-artifact v6->v7, upload-pages-artifact v3->v5, deploy-pages v4->v5. setup-msbuild@v3 and signpath@v2 already current. No node-deprecation annotations were pending; vpk pin (1.2.0) still matches the Velopack PackageReference.

## Test plan
- [x] Clean Debug build of PlanViewer.sln + PlanShare: **0 warnings, 0 errors**
- [x] 182/182 Core tests pass
- [x] Publish smoke linux-x64 + osx-arm64: apphost + correct SkiaSharp natives present
- [x] `dotnet list package --vulnerable --include-transitive`: PlanShare NU1903 cleared, solution clean
- [ ] CI (this PR) validates checkout@v7 + setup-dotnet@v6; nightly + pages deploy validate the rest on their next runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)