### PR TITLE
Bump version to 1.17.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
     website: "https://erikdarling.com"
 repository-code: "https://github.com/erikdarlingdata/PerformanceStudio"
 license: MIT
-version: "1.2.0"
-date-released: "2026-03-18"
+version: "1.17.0"
+date-released: "2026-07-25"
 keywords:
   - sql-server
   - execution-plan

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
     Tests and server/ projects are outside src/ and are unaffected.
   -->
   <PropertyGroup>
-    <Version>1.16.0</Version>
+    <Version>1.17.0</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
+++ b/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
@@ -7,5 +7,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Performance Studio for SSMS")]
 [assembly: AssemblyCopyright("Copyright Darling Data 2026")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("1.16.0.0")]
-[assembly: AssemblyFileVersion("1.16.0.0")]
+[assembly: AssemblyVersion("1.17.0.0")]
+[assembly: AssemblyFileVersion("1.17.0.0")]

--- a/src/PlanViewer.Ssms/source.extension.vsixmanifest
+++ b/src/PlanViewer.Ssms/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="PlanViewer.Ssms.64F79022-9D9A-4463-A1AE-4B19426A0CB1"
-              Version="1.16.0"
+              Version="1.17.0"
               Language="en-US"
               Publisher="Darling Data" />
     <DisplayName>Performance Studio for SSMS</DisplayName>


### PR DESCRIPTION
Bumps the version to 1.17.0 ahead of the `dev` -> `main` release merge.

Bumped in all three places, since `PlanViewer.Ssms` is a legacy non-SDK project not covered by `Directory.Build.props` (these have drifted on past releases):

- `src/Directory.Build.props` -> `1.17.0`
- `src/PlanViewer.Ssms/source.extension.vsixmanifest` -> `1.17.0`
- `src/PlanViewer.Ssms/Properties/AssemblyInfo.cs` -> `1.17.0.0` (both AssemblyVersion and AssemblyFileVersion)

Keeping the vsixmanifest in sync also means the "Build SSMS extension" step in `release.yml` will not emit its version-mismatch warning.

## What 1.17.0 contains

**#395 - quarterly maintenance**
- **CVE-2025-6965 (High)** fixed: `server/PlanShare` pulled a vulnerable SQLite transitively; pinned `SQLitePCLRaw.bundle_e_sqlite3` 2.1.12
- **MCP DNS-rebinding guard** - `ListenLocalhost` alone did not prevent a malicious page from rebinding a DNS name to 127.0.0.1 and reading saved server names, query text, and plan XML. Runtime-verified: rebound Host and hostile Origin both 403, legitimate loopback handshake 200
- **Generated T-SQL hardened** - untrusted plan XML could splice statements into the executed `sp_executesql` batch; DDL identifier escaping did not double `]`
- 9 dependency bumps, removal of the unused deprecated `Avalonia.Diagnostics`, zero-warning build restored (drag/drop migrated to Avalonia's `DataTransfer` API), 5 GitHub Actions bumped
- Tests 182 -> 202

**#396 - Claude Code PR review workflows.** Note these only become active once they land on `main`, which this release accomplishes: the action refuses to run unless the workflow file is byte-identical on the default branch.

## Test plan

- [x] Clean Release build of the merged result: 0 warnings
- [x] 202/202 tests pass in Release
- [x] All three version strings verified at 1.17.0
- [x] `release.yml` confirmed to trigger only on a merged PR to `main` with head ref `dev`, so the follow-up merge is what cuts the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)