### PR TITLE
Add Dependabot config and automated PlanShare deployment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,96 @@
+version: 2
+
+# Coverage note: PlanViewer.sln does NOT contain server/PlanShare, PlanViewer.Ssms,
+# or PlanViewer.Ssms.Installer, so any solution-level scan silently skips them.
+# Every project directory is therefore listed explicitly below. If a new .csproj
+# is added anywhere, add its directory here too.
+updates:
+  - package-ecosystem: nuget
+    directories:
+      - "/src/PlanViewer.App"
+      - "/src/PlanViewer.Core"
+      - "/src/PlanViewer.Cli"
+      - "/src/PlanViewer.Web"
+      - "/src/PlanViewer.Ssms"
+      - "/src/PlanViewer.Ssms.Installer"
+      - "/tests/PlanViewer.Core.Tests"
+      - "/server/PlanShare"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
+    labels:
+      - dependencies
+    # One PR per batch instead of per package. Majors stay separate so a breaking
+    # change is never buried in a routine batch.
+    groups:
+      patch-and-minor:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # --- Deliberate pins. Removing an ignore here without doing the matching
+      #     migration will produce a PR that builds but breaks at runtime. ---
+
+      # Avalonia 12 is a completed-but-parked migration on branch
+      # upgrade/avalonia-12. Take 11.x servicing, never the major.
+      - dependency-name: "Avalonia*"
+        update-types:
+          - version-update:semver-major
+
+      # 5.1.58 is the last build targeting Avalonia 11; 5.1.59+ requires
+      # Avalonia >= 12 and hard-fails restore with NU1605. This is a PATCH bump,
+      # so an update-type ignore would not catch it. Drop this entry as part of
+      # the Avalonia 12 migration.
+      - dependency-name: "ScottPlot.Avalonia"
+        versions:
+          - ">= 5.1.59"
+
+      # Pinned to keep the native libs in the [119.0, 120.0) range that managed
+      # SkiaSharp 3.x requires. A 4.x bump reintroduces GitHub issue #139
+      # (TypeInitializationException on Linux at startup).
+      - dependency-name: "SkiaSharp.NativeAssets.*"
+        update-types:
+          - version-update:semver-major
+
+      # The VSIX targets VS 2022. The 18.x line targets VS 18 and is not
+      # restorable from nuget.org, so the 17.x line is intentional.
+      - dependency-name: "Microsoft.VisualStudio.SDK"
+        update-types:
+          - version-update:semver-major
+      - dependency-name: "Microsoft.VSSDK.BuildTools"
+        update-types:
+          - version-update:semver-major
+
+      # The Velopack library version must move in lockstep with the `vpk` CLI
+      # pin in .github/workflows/release.yml. A PR bumping only the library
+      # would desync them and can produce incompatible update packages, so this
+      # one is handled by hand.
+      - dependency-name: "Velopack"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/deploy-planshare.yml
+++ b/.github/workflows/deploy-planshare.yml
@@ -1,0 +1,134 @@
+name: Deploy PlanShare
+
+# PlanShare is not built by ci.yml (server/** is paths-ignored) and is not in
+# PlanViewer.sln, so before this workflow existed a merged PR shipped nothing.
+# Production once drifted ~3.5 months behind main, missing two security fixes.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'server/PlanShare/**'
+      - '.github/workflows/deploy-planshare.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Never run two deploys at once, and never cancel one mid-flight - an
+# interrupted binary swap would leave the service down.
+concurrency:
+  group: deploy-planshare
+  cancel-in-progress: false
+
+env:
+  DEPLOY_HOST: stats.erikdarling.com
+  DEPLOY_USER: deploy
+  APP_DIR: /opt/planshare
+  PUBLIC_URL: https://stats.erikdarling.com
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup .NET 10.0
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Publish linux-x64 self-contained
+        run: |
+          dotnet publish server/PlanShare/PlanShare.csproj \
+            -c Release -r linux-x64 --self-contained \
+            -p:PublishSingleFile=true \
+            -o publish/planshare
+
+      - name: Verify build output
+        run: |
+          test -f publish/planshare/PlanShare      || { echo "::error::binary missing"; exit 1; }
+          test -f publish/planshare/libe_sqlite3.so || { echo "::error::libe_sqlite3.so missing"; exit 1; }
+          ls -la publish/planshare/
+
+      - name: Configure SSH
+        env:
+          DEPLOY_KEY: ${{ secrets.PLANSHARE_DEPLOY_KEY }}
+        run: |
+          if [ -z "$DEPLOY_KEY" ]; then
+            echo "::error::PLANSHARE_DEPLOY_KEY secret is not set - cannot deploy."
+            exit 1
+          fi
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          # Pinned host key: fail closed rather than trusting on first use.
+          echo 'stats.erikdarling.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICIrnTBiPVE5ulZiFZTBw9/DR/dPVwbAr8ZIvu47/w2J' > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Upload to staging paths
+        run: |
+          scp -i ~/.ssh/deploy_key -o BatchMode=yes \
+            publish/planshare/PlanShare \
+            "$DEPLOY_USER@$DEPLOY_HOST:$APP_DIR/planshare.new"
+          scp -i ~/.ssh/deploy_key -o BatchMode=yes \
+            publish/planshare/libe_sqlite3.so \
+            "$DEPLOY_USER@$DEPLOY_HOST:$APP_DIR/libe_sqlite3.so.new"
+
+      - name: Back up, swap, restart
+        run: |
+          ssh -i ~/.ssh/deploy_key -o BatchMode=yes "$DEPLOY_USER@$DEPLOY_HOST" bash -euo pipefail <<'REMOTE'
+            APP_DIR=/opt/planshare
+            STAMP=$(date -u +%Y%m%d-%H%M%S)
+
+            # Keep one rollback set, plus a DB snapshot. Cheap insurance.
+            cp -a "$APP_DIR/planshare"        "$APP_DIR/planshare.bak-$STAMP"
+            cp -a "$APP_DIR/libe_sqlite3.so"  "$APP_DIR/libe_sqlite3.so.bak-$STAMP"
+            cp -a "$APP_DIR/data/plans.db"    "$APP_DIR/data/plans.db.bak-$STAMP"
+            echo "$STAMP" > "$APP_DIR/.last-deploy-stamp"
+
+            mv "$APP_DIR/planshare.new"       "$APP_DIR/planshare"
+            mv "$APP_DIR/libe_sqlite3.so.new" "$APP_DIR/libe_sqlite3.so"
+            chmod +x "$APP_DIR/planshare"
+
+            sudo /bin/systemctl restart planshare.service
+            sleep 5
+            sudo /bin/systemctl is-active planshare.service
+
+            # Prune all but the 3 most recent backup sets.
+            ls -1t "$APP_DIR"/planshare.bak-*       2>/dev/null | tail -n +4 | xargs -r rm -f
+            ls -1t "$APP_DIR"/libe_sqlite3.so.bak-* 2>/dev/null | tail -n +4 | xargs -r rm -f
+            ls -1t "$APP_DIR"/data/plans.db.bak-*   2>/dev/null | tail -n +4 | xargs -r rm -f
+          REMOTE
+
+      - name: Verify through nginx
+        id: verify
+        run: |
+          for i in 1 2 3 4 5; do
+            code=$(curl -s -o /dev/null -w '%{http_code}' -m 20 "$PUBLIC_URL/api/stats" || echo 000)
+            echo "attempt $i: /api/stats -> $code"
+            if [ "$code" = "200" ]; then echo "verified=true" >> "$GITHUB_OUTPUT"; exit 0; fi
+            sleep 5
+          done
+          echo "::error::PlanShare did not return 200 through nginx after deploy."
+          exit 1
+
+      - name: Roll back on failed verification
+        if: failure() && steps.verify.outcome == 'failure'
+        run: |
+          echo "::warning::Verification failed - restoring the previous binary."
+          ssh -i ~/.ssh/deploy_key -o BatchMode=yes "$DEPLOY_USER@$DEPLOY_HOST" bash -euo pipefail <<'REMOTE'
+            APP_DIR=/opt/planshare
+            STAMP=$(cat "$APP_DIR/.last-deploy-stamp")
+            cp -a "$APP_DIR/planshare.bak-$STAMP"       "$APP_DIR/planshare"
+            cp -a "$APP_DIR/libe_sqlite3.so.bak-$STAMP" "$APP_DIR/libe_sqlite3.so"
+            chmod +x "$APP_DIR/planshare"
+            sudo /bin/systemctl restart planshare.service
+            sleep 5
+            sudo /bin/systemctl is-active planshare.service
+            echo "Rolled back to $STAMP"
+          REMOTE
+
+      - name: Clean up key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key


### PR DESCRIPTION
Two things: Dependabot with full coverage, and the PlanShare deploy automation that was missing.

## Dependabot

`.github/dependabot.yml` covers **all 8 project directories explicitly**, not the solution. That distinction matters: `PlanViewer.sln` does not contain `server/PlanShare`, `PlanViewer.Ssms`, or `PlanViewer.Ssms.Installer`, so a solution-level scan silently skips them — which is exactly how PlanShare went 3.5 months without an update. Also covers `github-actions`.

Minor and patch updates are grouped into one PR per ecosystem to keep the noise down; majors stay separate so a breaking change is never buried in a routine batch.

**Repository-side alerts were completely off** (`/vulnerability-alerts` returned 404). Enabled both Dependabot alerts and automated security fixes.

### Ignore rules encode the deliberate pins

Without these, Dependabot files PRs that either fail restore or ship a broken runtime:

| Pin | Why it is ignored |
|---|---|
| `Avalonia*` major | Avalonia 12 is a completed-but-parked migration (`upgrade/avalonia-12`) |
| `ScottPlot.Avalonia >= 5.1.59` | Requires Avalonia >= 12 and hard-fails restore with NU1605. This is a **patch** bump, so an update-type ignore would not catch it — it needs an explicit version range |
| `SkiaSharp.NativeAssets.*` major | The pin keeps native libs in the range managed SkiaSharp 3.x needs; a 4.x bump reintroduces #139 (Linux startup crash) |
| `Microsoft.VisualStudio.SDK`, `Microsoft.VSSDK.BuildTools` major | 18.x targets VS 18 and is not restorable from nuget.org |
| `Velopack` | Must move in lockstep with the `vpk` CLI pin in `release.yml`; a library-only bump desyncs them |

## PlanShare deployment

`.github/workflows/deploy-planshare.yml` triggers on push to `main` touching `server/PlanShare/**`, plus manual dispatch.

It backs up the binary, native lib, **and `plans.db`** before swapping, restarts, verifies through nginx, and **rolls back automatically** if verification fails. Keeps the 3 most recent backup sets.

### Security posture

Rather than putting a root key in Actions secrets, this authenticates as a dedicated unprivileged `deploy` user with a **CI-only keypair** (not a personal key). Its sudo rights are limited to exactly two verbs on one unit. I verified the restrictions actually hold:

- write to `/opt/planshare` -> **OK**
- `sudo systemctl is-active planshare.service` -> **OK**
- `sudo systemctl stop nginx` -> **refused**
- `sudo cat /etc/shadow` -> **refused**

The host key is pinned in the workflow rather than accepted on first use, so a MITM fails closed.

## Test plan

- [x] Both YAML files parse; 8 nuget dirs + github-actions confirmed
- [x] Dependabot alerts and automated security fixes enabled
- [x] `PLANSHARE_DEPLOY_KEY` secret added
- [x] Deploy path validated end-to-end **using the restricted key**: upload, backup, swap, restart, nginx verification. Service active, `/api/stats` 200, existing shared plan `ofIRdO5I` still returns 200, `plans.db` intact
- [ ] The workflow itself cannot be dispatch-tested until it is on `main` (GitHub only exposes `workflow_dispatch` for workflows present on the default branch) — same constraint as the Claude review workflows

## Known residual risk

`planshare.service` runs as **root** (no `User=` in the unit). So although the deploy account is unprivileged, the binary it installs still executes as root — meaning control of the deploy secret is effectively root-equivalent on that box. Running the service as a dedicated non-root user would close this, but it touches the systemd unit and data-dir ownership on a live service, so I did not fold it into this PR. Worth doing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)