### PR TITLE
Add SignPath GitHub policy and raise the signing timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,12 @@ jobs:
           github-artifact-id: '${{ steps.upload-unsigned.outputs.artifact-id }}'
           wait-for-completion: true
           output-artifact-directory: 'signed/win-x64'
+          # The action's 600s default means a signing policy that requires manual
+          # approval has to be approved inside a 10-minute window or the release
+          # fails partway, leaving a published release with no app assets (this
+          # happened on v1.17.0). 30 minutes is enough to notice the mail and
+          # approve. Irrelevant once approval is automatic, but harmless.
+          wait-for-completion-timeout-in-seconds: 1800
 
       - name: Replace unsigned Windows build with signed
         shell: pwsh

--- a/.signpath/policies/PerformanceStudio/release-signing.yml
+++ b/.signpath/policies/PerformanceStudio/release-signing.yml
@@ -1,0 +1,40 @@
+# SignPath GitHub policy for the "release-signing" signing policy.
+#
+# Path is significant and must match the SignPath project + policy slugs used in
+# .github/workflows/release.yml:
+#   project-slug:        PerformanceStudio
+#   signing-policy-slug: release-signing
+#
+# This file only takes effect from the repository's DEFAULT branch (main). On any
+# other branch it is inert, so changes here do nothing until they are merged to
+# main via the usual dev -> main release merge.
+#
+# What this file does NOT do: it does not enable automatic approval. Approval mode
+# lives on the signing policy in the SignPath dashboard. This file adds constraints
+# that SignPath enforces on a build before it is willing to sign it.
+
+github-policies:
+  runners:
+    # release.yml runs on `windows-latest`. Requiring GitHub-hosted runners means a
+    # self-hosted runner (which an attacker could register, or which could carry
+    # dirty state between jobs) can never produce a signed build.
+    require_github_hosted: true
+
+# Deliberately omitted, with reasons - do not add these without the matching
+# repository change, or releases will start failing to sign:
+#
+#   build.disallow_reruns: true
+#     Blocks signing any build produced by a workflow re-run. A re-run is
+#     currently the documented recovery path for this repo: `gh release create`
+#     runs before signing, so a signing failure leaves a published-but-empty
+#     release that is fixed by re-running (all uploads use --clobber). v1.17.0
+#     was recovered exactly this way. Enabling this would make that recovery
+#     impossible. Revisit only if release.yml is restructured so a failed
+#     signing never publishes anything.
+#
+#   branch_rulesets:
+#     Requires the protections it lists to actually exist on the branch. `main`
+#     currently has NO branch protection configured at all, so any ruleset
+#     requirement here would reject every signing request. Add protection to
+#     `main` first (e.g. block force pushes, require PRs), then encode the same
+#     rules here so SignPath verifies they were in force.


### PR DESCRIPTION
Adds the SignPath GitHub policy file and fixes the timeout that broke the v1.17.0 release.

## Correction to something I said earlier

The policy file does **not** enable automatic approval. Having read [the actual schema](https://docs.signpath.io/trusted-build-systems/github), it does close to the opposite kind of job: it lets SignPath **impose constraints** on a build before it is willing to sign it. Approval mode is a separate setting on the signing policy in the SignPath dashboard. Two different mechanisms.

## What the file does

`.signpath/policies/PerformanceStudio/release-signing.yml` - the path is significant and must match the `project-slug` and `signing-policy-slug` passed to the action in `release.yml`.

```yaml
github-policies:
  runners:
    require_github_hosted: true
```

That means a self-hosted runner - one an attacker registered, or one carrying dirty state between jobs - can never produce a signed build. Modest, but real, and it is true of `release.yml` today (`windows-latest`).

Like the Claude review workflows, **this only takes effect from the default branch**, so it is inert until the next `dev` -> `main` merge.

## Two fields deliberately left out

Both are documented inline in the file, because adding either without the matching repository change would break signing outright:

- **`build.disallow_reruns: true`** blocks signing any build from a workflow re-run. A re-run is currently the *documented recovery path* for this repo - `gh release create` runs before signing, so a signing failure leaves a published-but-empty release that gets fixed by re-running (all uploads use `--clobber`). v1.17.0 was recovered exactly that way, minutes ago. Enabling this would have made that recovery impossible.
- **`branch_rulesets`** requires the protections it names to actually exist on the branch. `main` currently has **no branch protection configured at all**, so any ruleset rule here would reject every signing request. Worth adding later, but branch protection has to come first.

## Timeout fix

The SignPath action defaults to `wait-for-completion-timeout-in-seconds: 600`. With a policy that requires manual approval, that means the approval must be caught inside a 10-minute window or the job dies *after* the release is already public - which is precisely how v1.17.0 ended up published with only the VSIX attached. Raised to 1800s. Irrelevant once approval is automatic, harmless either way.

## On moving `gh release create` after signing

I suggested this earlier and you pushed back that there were ordering dependencies. **You were right**, and I was too glib. `gh release upload` requires the release to already exist, and the SSMS extension uploads at step 11, well before signing at step 15. So creation cannot simply move to the end without also moving that upload.

There are two real options, neither included here:

1. **Create the release as a draft, publish at the very end.** Uploads work against drafts, so ordering is preserved. The catch: GitHub does not create the git tag until a draft is published, and `vpk upload github` looks the release up by tag - so Velopack may not find it. Needs testing before trusting.
2. **Move both the release creation and the SSMS upload after signing.** No draft weirdness, but a larger reordering of a workflow that only executes on a real release, making it awkward to test.

Given `release.yml` cannot be exercised outside an actual release, I would rather do that deliberately than fold it into this PR.

## Test plan

- [x] Policy file parses; resolves to `{'github-policies': {'runners': {'require_github_hosted': True}}}`
- [x] `release.yml` still parses; signing timeout reads 1800
- [ ] Cannot be verified until it is on `main` and a release runs - policy files are read from the default branch only

🤖 Generated with [Claude Code](https://claude.com/claude-code)