### PR TITLE
Fix PR reviewer: it was denied the tools needed to read code

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -91,9 +91,14 @@ jobs:
             `confirmed: true`) to flag specific lines.
             Only post GitHub comments - do not return review text as a message.
 
+          # --allowedTools REPLACES the default tool set rather than adding to it.
+          # Without Read/Grep/Glob the reviewer cannot open a single file in the
+          # checked-out branch, which is exactly what the prompt above asks it to
+          # do. PR #399 burned all 20 turns on denied calls
+          # (permission_denials_count was 10) and failed without posting anything.
           claude_args: |
-            --max-turns 20
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --max-turns 40
+            --allowedTools "Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*)"
 
 # Fork PRs: GitHub withholds repository secrets from `pull_request` runs on
 # forks and issues a read-only GITHUB_TOKEN, so this workflow cannot review


### PR DESCRIPTION
Fixes the PR review workflow, which failed on its first real run.

## What happened

The workflows went live with v1.17.0 (they need to be on the default branch). The first substantive PR they saw was #399, and the review failed:

```
permission_denials_count: 10
##[error]Execution failed: Reached maximum number of turns (20)
```

## Root cause

`--allowedTools` **replaces** the default tool set rather than adding to it. The resolved list in the run log was exactly the four entries I passed:

```json
"allowedTools": [
  "mcp__github_inline_comment__create_inline_comment",
  "Bash(gh pr comment:*)",
  "Bash(gh pr diff:*)",
  "Bash(gh pr view:*)"
]
```

No `Read`, no `Grep`, no `Glob`. So the prompt told the reviewer *"the PR branch is already checked out in the working directory"* and then denied it every tool needed to open a file. It spent its turns getting denied, hit the 20-turn cap, and posted nothing.

PR #400 passed only because its diff is two small files that fit inside the budget. That is why this looked like it worked.

## Fix

- Add `Read`, `Grep`, `Glob`, plus read-only `git diff` / `git log`
- Raise `--max-turns` from 20 to 40, since a real review reads several files

Cost reference: the failed 20-turn run was $0.63, so a completed review should land in the low single digits of dollars.

## Test plan

- [x] Workflow YAML parses; `claude_args` resolves to the intended flags
- [ ] Cannot be verified on this PR - it edits `claude-code-review.yml`, so the action's default-branch content check skips it (expected, documented in the file). The real test is the first PR opened after this reaches `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)