### PR TITLE
Harden SSMS launcher: PATH search order and temp file cleanup

### DIFF
--- a/src/PlanViewer.Ssms/AppLauncher.cs
+++ b/src/PlanViewer.Ssms/AppLauncher.cs
@@ -27,6 +27,8 @@ namespace PlanViewer.Ssms
         /// </summary>
         public static string SavePlanToTemp(string planXml)
         {
+            SweepOldTempPlans();
+
             var suffix = Path.GetFileNameWithoutExtension(Path.GetRandomFileName());
             var fileName = "ssms_plan_" + suffix + ".sqlplan";
             var tempPath = Path.Combine(Path.GetTempPath(), fileName);
@@ -36,6 +38,41 @@ namespace PlanViewer.Ssms
                 writer.Write(planXml);
             }
             return tempPath;
+        }
+
+        /// <summary>
+        /// Deletes plan files this extension left in %TEMP% on earlier runs. Each
+        /// one holds the query text and any literal parameter values from the plan,
+        /// so they should not accumulate at rest indefinitely.
+        ///
+        /// Swept on the way in rather than deleted after launch: the file is handed
+        /// to another process to open, so removing it immediately would race the
+        /// app's read. Anything older than the cutoff has certainly been read.
+        /// Best-effort throughout - a file we cannot delete (still open, denied)
+        /// must never break opening a plan.
+        /// </summary>
+        private static void SweepOldTempPlans()
+        {
+            try
+            {
+                var cutoff = DateTime.UtcNow.AddHours(-1);
+                foreach (var path in Directory.GetFiles(Path.GetTempPath(), "ssms_plan_*.sqlplan"))
+                {
+                    try
+                    {
+                        if (File.GetLastWriteTimeUtc(path) < cutoff)
+                            File.Delete(path);
+                    }
+                    catch
+                    {
+                        // In use or access denied — leave it and move on.
+                    }
+                }
+            }
+            catch
+            {
+                // Temp directory unreadable — cleanup is not worth failing over.
+            }
         }
 
         /// <summary>
@@ -93,20 +130,26 @@ namespace PlanViewer.Ssms
 
         private static string FindApp()
         {
-            // 1. Check registry
+            // Order matters. PATH is searched last because any writable directory
+            // on it is enough to hijack the launch: drop a PlanViewer.App.exe there
+            // and SSMS runs it instead of the installed app. The registry value is
+            // written by our own installer, and the common locations are the real
+            // install paths, so both are trusted ahead of it.
+
+            // 1. Registry (written by the installer)
             string registryPath = GetRegistryPath();
             if (registryPath != null)
                 return registryPath;
 
-            // 2. Check PATH
-            string pathResult = FindOnPath();
-            if (pathResult != null)
-                return pathResult;
-
-            // 3. Check common install locations
+            // 2. Known install locations
             string commonPath = FindInCommonLocations();
             if (commonPath != null)
                 return commonPath;
+
+            // 3. PATH, as a last resort
+            string pathResult = FindOnPath();
+            if (pathResult != null)
+                return pathResult;
 
             return null;
         }


### PR DESCRIPTION
Two SSMS extension fixes from the quarterly maintenance security review.

## 1. Launch hijack via PATH

`FindApp` searched in this order: registry -> **PATH** -> known install locations.

Any writable directory on `PATH` containing a `PlanViewer.App.exe` therefore won the lookup, and SSMS would launch it instead of the installed app - handing it the plan file. PATH is now the last resort, behind the installer-written registry value and the real install paths, both of which we control.

## 2. Plan files accumulating in %TEMP%

Every analysis wrote `%TEMP%\ssms_plan_<random>.sqlplan` and never removed it. Each file holds the query text and any literal parameter values from that plan, so opening plans slowly built a pile of query text at rest indefinitely.

Now swept on the way in, not deleted after launch. That ordering is deliberate: the file is handed to a *separate process* to open, so deleting it immediately after `Process.Start` would race the app's read. Anything older than an hour has certainly been read. The sweep is best-effort at both levels (unreadable temp dir, individual locked file) because failing to clean up must never break opening a plan.

The existing crypto-random filename and `FileMode.CreateNew` already handled the symlink-preempt race; this is only about not leaving the data lying around afterward.

## Test plan

- [x] **Built the VSIX locally with MSBuild (VS Build Tools 2022): produces `PlanViewer.Ssms.vsix`, no errors, no warnings.**
- [ ] Not runtime-tested in SSMS

That first item is worth calling out. `ci.yml` `paths-ignore`s `src/PlanViewer.Ssms/**` and the project is not in `PlanViewer.sln`, so **nothing in CI ever compiles this**. Its only build is in `release.yml` under `continue-on-error: true`, meaning a compile break here would not fail the release - it would just silently ship a release with no VSIX attached (the known issue 343 behavior). So a local build is the only pre-release signal that exists.

Note this changes only launcher behavior, not the extension's SSMS integration surface, so the untested-in-SSMS gap is narrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)