### PR TITLE
Bump version to 1.18.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ authors:
     website: "https://erikdarling.com"
 repository-code: "https://github.com/erikdarlingdata/PerformanceStudio"
 license: MIT
-version: "1.17.0"
+version: "1.18.0"
 date-released: "2026-07-25"
 keywords:
   - sql-server

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
     Tests and server/ projects are outside src/ and are unaffected.
   -->
   <PropertyGroup>
-    <Version>1.17.0</Version>
+    <Version>1.18.0</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
+++ b/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
@@ -7,5 +7,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Performance Studio for SSMS")]
 [assembly: AssemblyCopyright("Copyright Darling Data 2026")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("1.17.0.0")]
-[assembly: AssemblyFileVersion("1.17.0.0")]
+[assembly: AssemblyVersion("1.18.0.0")]
+[assembly: AssemblyFileVersion("1.18.0.0")]

--- a/src/PlanViewer.Ssms/source.extension.vsixmanifest
+++ b/src/PlanViewer.Ssms/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="PlanViewer.Ssms.64F79022-9D9A-4463-A1AE-4B19426A0CB1"
-              Version="1.17.0"
+              Version="1.18.0"
               Language="en-US"
               Publisher="Darling Data" />
     <DisplayName>Performance Studio for SSMS</DisplayName>


### PR DESCRIPTION
Bumps the version to 1.18.0 ahead of the `dev` -> `main` release merge.

All four sources, since `PlanViewer.Ssms` is a legacy non-SDK project not covered by `Directory.Build.props`:

- `src/Directory.Build.props` -> `1.18.0`
- `src/PlanViewer.Ssms/source.extension.vsixmanifest` -> `1.18.0`
- `src/PlanViewer.Ssms/Properties/AssemblyInfo.cs` -> `1.18.0.0`
- `CITATION.cff` -> `1.18.0`

## What 1.18.0 contains

Everything here is currently **inert on `dev`** - each piece only takes effect from the default branch, which is what this release accomplishes.

**Tooling that switches on with this release**
- **Dependabot** (#399) - config covering all 8 project directories explicitly rather than the solution, because `PlanViewer.sln` omits `server/PlanShare` and both SSMS projects. Ignore rules encode the deliberate pins (Avalonia 12, ScottPlot 5.1.59, SkiaSharp natives, VSSDK 18.x, Velopack)
- **PlanShare auto-deploy** (#399) - triggers on push to `main` touching `server/PlanShare/**`; backs up binary, native lib and DB, restarts, verifies through nginx, rolls back on failure. Authenticates as an unprivileged `deploy` user, not root
- **SignPath policy + timeout** (#400) - requires GitHub-hosted runners; signing timeout raised 600s -> 1800s so a manual approval no longer has to be caught inside 10 minutes (this is what broke v1.17.0)
- **PR reviewer fix** (#401) - the reviewer was denied `Read`/`Grep`/`Glob`, so it burned its turns on permission denials and posted nothing

**Security fixes**
- **Consent before executing a plan file's query** (#402) - "Get Actual Plan" on a loaded plan prompted for a connection and then just ran the query. The query-session path already confirmed; this one did not, and it is the riskier of the two since the SQL comes from a `.sqlplan` the user opened. The dialog names the target server and database
- **SSMS launcher hardening** (#403) - `PATH` was searched before known install locations, so any writable `PATH` directory could hijack the launch; and every analysis left a `.sqlplan` containing query text in `%TEMP%` permanently

## Verification

- [x] Clean **Release** build of the merged result: 0 warnings
- [x] 202/202 tests pass
- [x] All four version strings at 1.18.0, no stale `1.17.0` anywhere
- [x] vsixmanifest matches, so the VSIX version-mismatch warning in `release.yml` will not fire
- [x] SSMS VSIX built locally with MSBuild (CI never compiles it; `release.yml` builds it under `continue-on-error`)

## Note for the release run

SignPath only offers **manual approval**, so this release will pause at the signing step and needs approving in the SignPath dashboard. The window is now 30 minutes rather than 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)