### PR TITLE
Hold Repl packages to patch bumps only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -80,6 +80,25 @@ updates:
       # one is handled by hand.
       - dependency-name: "Velopack"
 
+      # Repl / Repl.Mcp / Repl.Testing (#388) are pre-1.0. Under semver a 0.x
+      # minor bump is allowed to break, and Dependabot classifies 0.11 -> 0.12
+      # as a *minor*, so the usual "majors only get their own PR" split does not
+      # protect anything here. Patch bumps still flow, so genuine fixes arrive.
+      # This matters more than for a normal dependency: the app ships an
+      # auto-updater, so a breaking bump reaches users without them choosing it.
+      - dependency-name: "Repl"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+      - dependency-name: "Repl.Mcp"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+      - dependency-name: "Repl.Testing"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+
   - package-ecosystem: github-actions
     target-branch: dev
     directory: "/"


### PR DESCRIPTION
Holds the `Repl` packages that arrived with #388 to patch bumps only.

## Why this is not just noise control

`Repl`, `Repl.Mcp` and `Repl.Testing` landed at **0.11.0** - pre-1.0, where semver permits a minor bump to break.

The important detail: **Dependabot classifies `0.11 -> 0.12` as a minor**, and this config groups minor and patch into one batch while giving majors their own PR. So the existing "majors stay separate" protection does nothing here - a breaking `Repl` bump would arrive folded inside a routine grouped dependency PR, which is exactly the kind of thing that gets merged on a green check.

It matters more than for a typical dependency because Performance Studio ships an **auto-updater**. Whatever lands reaches users without them choosing to take it.

## What it does

Ignores `semver-major` and `semver-minor` for all three packages. Patch bumps (`0.11.x`) still flow, so genuine fixes and any security patches arrive normally. Mirrors the existing ignore rules for the other deliberate pins.

## Note

This is independent of whether the Repl pilot itself ships. The packages are on `dev` either way, and Dependabot now targets `dev` (fixed in #409), so it would start proposing these on its next scheduled run regardless.

## Test plan

- [x] `dependabot.yml` parses; all nine ignore rules resolve as intended, both ecosystems still `target-branch: dev`
- [x] Config-only change - no build impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)