### PR TITLE
Bump version to 1.19.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
     website: "https://erikdarling.com"
 repository-code: "https://github.com/erikdarlingdata/PerformanceStudio"
 license: MIT
-version: "1.19.0"
-date-released: "2026-07-25"
+version: "1.19.1"
+date-released: "2026-07-29"
 keywords:
   - sql-server
   - execution-plan

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
     Tests and server/ projects are outside src/ and are unaffected.
   -->
   <PropertyGroup>
-    <Version>1.19.0</Version>
+    <Version>1.19.1</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
+++ b/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
@@ -7,5 +7,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Performance Studio for SSMS")]
 [assembly: AssemblyCopyright("Copyright Darling Data 2026")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("1.19.0.0")]
-[assembly: AssemblyFileVersion("1.19.0.0")]
+[assembly: AssemblyVersion("1.19.1.0")]
+[assembly: AssemblyFileVersion("1.19.1.0")]

--- a/src/PlanViewer.Ssms/source.extension.vsixmanifest
+++ b/src/PlanViewer.Ssms/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="PlanViewer.Ssms.64F79022-9D9A-4463-A1AE-4B19426A0CB1"
-              Version="1.19.0"
+              Version="1.19.1"
               Language="en-US"
               Publisher="Darling Data" />
     <DisplayName>Performance Studio for SSMS</DisplayName>


### PR DESCRIPTION
Bumps all four version sources to 1.19.1 ahead of the `dev` -> `main` release merge.

- `src/Directory.Build.props`
- `src/PlanViewer.Ssms/source.extension.vsixmanifest`
- `src/PlanViewer.Ssms/Properties/AssemblyInfo.cs`
- `CITATION.cff`

Verified: clean Release build (0 warnings), 288/288 tests, release-auditor gate passed, no stale `1.19.0` strings remaining.

**1.19.1 contents:** clipboard crash hardening (#416) — every clipboard path (copy/paste in grids, editors, plan viewer, advice windows) now survives a busy Windows clipboard instead of crashing — plus the release-PR review skip (#414, workflow-only).

No server/PlanShare changes in this release, so no manual deploy needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)