### PR TITLE
Skip the AI review job on Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,9 +37,17 @@ jobs:
     # were each already reviewed on their own PR, so re-reviewing the whole
     # release adds nothing — and the diff is large enough that it reliably
     # exhausts the turn budget and fails, putting a red X on the release.
+    #
+    # Also skip Dependabot PRs. They fail twice over instead of getting a
+    # review: the action rejects non-human actors outright ("Workflow initiated
+    # by non-human actor: dependabot"), and a dependabot-triggered run draws
+    # from the DEPENDABOT secret store, not the Actions one, so the OAuth token
+    # is empty anyway. A version bump has nothing an AI review would catch that
+    # build-and-test doesn't; skipped is neutral, not a red X on every bump.
     if: |
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]' &&
       !(github.event.pull_request.head.ref == 'dev' && github.event.pull_request.base.ref == 'main')
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## What does this PR do?

Removes the standing red X from every Dependabot PR. The `review` check fails on them twice over instead of reviewing: `claude-code-action` rejects non-human actors outright (`Workflow initiated by non-human actor: dependabot (type: Bot)`), and a dependabot-triggered workflow draws from the **Dependabot** secret store rather than the Actions one, so `CLAUDE_CODE_OAUTH_TOKEN` arrives empty regardless (visible in the failing runs: `Secret source: Dependabot`, blank token env).

The fix is one more exclusion in the job's existing `if:` (same style and comment discipline as the draft/fork/release-PR skips): `github.actor != 'dependabot[bot]'`. Skipped reports neutral, not red, and satisfies branch checks. A dependency bump has nothing an AI review would catch that `build-and-test` doesn't.

Evidence: both open Dependabot PRs (#420, #422) pass `build-and-test` and `check-branches`; `review` is their only failure, dying at ~10s before doing any work. Failing run: https://github.com/erikdarlingdata/PerformanceStudio/actions/runs/30804813985/job/91657584068

The alternative — allow-listing the bot via `allowed_bots` — would also require duplicating the Anthropic token into the Dependabot secret store to get past the empty-secrets half, spending review tokens and secret exposure on lockfile bumps. Not worth it.

## How was this tested?

Workflow-condition change only; no compiled code touched. Verified the failure mode from both PRs' run logs (bot-actor rejection + empty Dependabot-scoped secrets), and that the existing `claude.yml` mention-responder already skips cleanly on these PRs. After merge, a rebase of #420/#422 picks up the fixed condition from dev and their `review` check reports skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)