### PR TITLE
Give the WAM broker a parent window handle so Entra MFA works (#425)

### DIFF
--- a/src/PlanViewer.App/App.axaml.cs
+++ b/src/PlanViewer.App/App.axaml.cs
@@ -6,6 +6,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Avalonia.Platform;
 using Avalonia.Platform.Storage;
+using Avalonia.Threading;
 using System.Linq;
 using System.Threading.Tasks;
 using PlanViewer.App.Services;
@@ -70,8 +71,29 @@ public partial class App : Application
     /// <para>Resolved per call rather than captured once: a window's platform handle is not valid until the
     /// window has been sourced, so a handle read at startup can be zero even though a real window exists a
     /// moment later.</para>
+    ///
+    /// <para>Marshaled to the UI thread: MSAL invokes this from whatever thread SqlClient's token acquisition
+    /// happens to run on, and <c>desktop.Windows</c> is a UI-thread-owned collection that the UI thread can
+    /// mutate (a dialog opening or closing) mid-enumeration. Blocking on <see cref="Dispatcher.UIThread"/> is
+    /// safe here because no connection path blocks the UI thread on auth — every open in the app is async. If
+    /// the dispatcher can't deliver anyway (shutdown timing), Zero degrades to MSAL's normal no-handle
+    /// failure instead of throwing from inside the auth callback.</para>
     /// </summary>
     private static IntPtr ActiveWindowHandle()
+    {
+        try
+        {
+            return Dispatcher.UIThread.CheckAccess()
+                ? ActiveWindowHandleOnUIThread()
+                : Dispatcher.UIThread.Invoke(ActiveWindowHandleOnUIThread);
+        }
+        catch
+        {
+            return IntPtr.Zero;
+        }
+    }
+
+    private static IntPtr ActiveWindowHandleOnUIThread()
     {
         if (Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop)
             return IntPtr.Zero;

--- a/src/PlanViewer.App/App.axaml.cs
+++ b/src/PlanViewer.App/App.axaml.cs
@@ -9,6 +9,7 @@ using Avalonia.Platform.Storage;
 using System.Linq;
 using System.Threading.Tasks;
 using PlanViewer.App.Services;
+using PlanViewer.Core.Services;
 
 namespace PlanViewer.App;
 
@@ -30,6 +31,13 @@ public partial class App : Application
             desktop.MainWindow = new MainWindow();
         }
 
+        // Entra MFA needs a parent window handle for the WAM broker, or the prompt never
+        // appears and the connection fails with 0xwindow_handle_required (issue #425).
+        // Registered once here because SqlAuthenticationProvider is process-wide, so this
+        // covers every connection Studio opens without touching each call site. No-op off
+        // Windows, where interactive auth uses the browser and needs no handle.
+        EntraInteractiveAuth.Register(ActiveWindowHandle);
+
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
             var iconPath = System.IO.Path.Combine(AppContext.BaseDirectory, "EDD.icns");
@@ -48,6 +56,29 @@ public partial class App : Application
         Task.Run(FileAssociationService.RegisterForCurrentExecutable);
 
         base.OnFrameworkInitializationCompleted();
+    }
+
+    /// <summary>
+    /// The window that should own an Entra MFA prompt, resolved at the moment MSAL asks (issue #425).
+    ///
+    /// <para>Prefers whichever window is currently active over the main window, because a connection is
+    /// usually triggered from the connection dialog — parenting the account picker to the main window behind
+    /// it would let the picker appear behind the dialog the user is looking at. Falls back to the main window,
+    /// then to <see cref="IntPtr.Zero"/>, which MSAL treats the same as no handle: the prompt fails rather
+    /// than the app crashing, which is the right way round for an auth path.</para>
+    ///
+    /// <para>Resolved per call rather than captured once: a window's platform handle is not valid until the
+    /// window has been sourced, so a handle read at startup can be zero even though a real window exists a
+    /// moment later.</para>
+    /// </summary>
+    private static IntPtr ActiveWindowHandle()
+    {
+        if (Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop)
+            return IntPtr.Zero;
+
+        var window = desktop.Windows.FirstOrDefault(w => w.IsActive) ?? desktop.MainWindow;
+
+        return window?.TryGetPlatformHandle()?.Handle ?? IntPtr.Zero;
     }
 
     /// <summary>

--- a/src/PlanViewer.Cli/Commands/CliConnectionResolver.cs
+++ b/src/PlanViewer.Cli/Commands/CliConnectionResolver.cs
@@ -43,6 +43,26 @@ public static class CliConnectionResolver
             throw new InvalidOperationException("No credentials configured");
         }
 
+        /* Interactive Entra auth goes through the Windows WAM broker, which needs a parent window handle to
+           own its account picker (issue #425). A CLI has no window to give it, so the connection would fail
+           deep inside MSAL with "0xwindow_handle_required" — a message that tells the user nothing about
+           what to do. Say it here instead, up front, and name the modes that actually work headless.
+
+           Deliberately not silently substituting another auth mode: picking a different identity than the
+           one the operator asked for is worse than refusing. Whether the CLI should grow device-code flow is
+           the open question on #425, not something to guess at from here. */
+        if (authType == AuthenticationTypes.EntraMFA && !EntraInteractiveAuth.IsSupported)
+        {
+            Console.Error.WriteLine(
+                "Interactive Microsoft Entra MFA (--auth entra) needs a desktop window for the Windows " +
+                "account picker, so it cannot run from the CLI.");
+            Console.Error.WriteLine(
+                "Use the Studio app for interactive sign-in, or a non-interactive identity here: " +
+                "--auth sql with a stored credential, or a service principal / managed identity.");
+            Environment.ExitCode = 1;
+            throw new InvalidOperationException("Interactive Entra authentication is not available headless");
+        }
+
         return new ServerConnection
         {
             Id = server,

--- a/src/PlanViewer.Core/Services/EntraInteractiveAuth.cs
+++ b/src/PlanViewer.Core/Services/EntraInteractiveAuth.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.Data.SqlClient;
 
 namespace PlanViewer.Core.Services;
@@ -76,4 +75,17 @@ public static class EntraInteractiveAuth
     /// a clear message instead of letting MSAL produce that error.
     /// </summary>
     public static bool IsSupported => _registered || !OperatingSystem.IsWindows();
+
+    /* Test-only escape hatch for the one-way registration flag. Registration is deliberately irreversible
+       in production — SqlAuthenticationProvider offers no unregister — so a test that needs to observe the
+       never-registered state (the CLI refusal path) resets the flag rather than the provider. The provider
+       itself may stay registered with SqlClient; nothing in the test process opens interactive connections,
+       so that is inert. */
+    internal static void ResetRegistrationForTests()
+    {
+        lock (Gate)
+        {
+            _registered = false;
+        }
+    }
 }

--- a/src/PlanViewer.Core/Services/EntraInteractiveAuth.cs
+++ b/src/PlanViewer.Core/Services/EntraInteractiveAuth.cs
@@ -1,0 +1,79 @@
+using System;
+using Microsoft.Data.SqlClient;
+
+namespace PlanViewer.Core.Services;
+
+/// <summary>
+/// Makes <c>Authentication=ActiveDirectoryInteractive</c> (Microsoft Entra MFA) work on Windows by giving
+/// MSAL a parent window handle.
+///
+/// <para>Why this has to exist: current <c>Microsoft.Data.SqlClient</c> routes interactive Entra auth through
+/// the Windows <b>WAM broker</b>, and WAM requires the calling application to supply the HWND that will own
+/// the account picker. An application that never supplies one does not get a prompt — it gets
+/// <c>0xwindow_handle_required</c> / "A window handle must be configured" and the connection fails outright.
+/// Studio set the authentication mode but never registered a provider, so Entra MFA was broken for every
+/// Windows user rather than for some particular tenant (issue #425, reported via PerformanceMonitor#2184;
+/// Studio 1.4.3 worked because it predates WAM being the default and fell back to a browser).</para>
+///
+/// <para>Registration is process-wide. <see cref="SqlAuthenticationProvider.SetProvider"/> installs against
+/// the authentication METHOD, not against a connection, so one call at startup covers every
+/// <c>SqlConnection</c> the process opens — which is what we want here, because Studio opens connections from
+/// several unrelated places (the connection dialog, the query session control, the schema service) and
+/// threading a handle through all of them would be a change every future call site could forget to make.</para>
+/// </summary>
+public static class EntraInteractiveAuth
+{
+    private static readonly object Gate = new();
+    private static bool _registered;
+
+    /// <summary>
+    /// Registers the interactive-auth provider, resolving the parent window through
+    /// <paramref name="parentWindowHandleProvider"/> at the moment MSAL asks for it.
+    ///
+    /// <para>The handle is fetched per prompt rather than captured once, deliberately: a window's platform
+    /// handle is not valid until the window has been sourced, and the right parent is whichever window is
+    /// actually in front when the user triggers a connection — not necessarily the one that existed at
+    /// startup.</para>
+    ///
+    /// <para>Windows only. WAM does not exist on macOS or Linux, where interactive auth already works through
+    /// the system browser and needs no handle at all, so registering a handle-supplying provider there would
+    /// add a failure mode to platforms that currently work. Returns false when it did not register, so a
+    /// caller can tell "not applicable" from "done" without duplicating the OS check.</para>
+    /// </summary>
+    /// <param name="parentWindowHandleProvider">
+    /// Returns the owning window handle, or <see cref="IntPtr.Zero"/> when no window is available yet.
+    /// </param>
+    /// <returns>True if the provider was registered by this call; false if not applicable or already done.</returns>
+    public static bool Register(Func<IntPtr> parentWindowHandleProvider)
+    {
+        ArgumentNullException.ThrowIfNull(parentWindowHandleProvider);
+
+        if (!OperatingSystem.IsWindows())
+            return false;
+
+        lock (Gate)
+        {
+            if (_registered)
+                return false;
+
+            var provider = new ActiveDirectoryAuthenticationProvider();
+
+            /* Func<object> rather than Func<IntPtr> is MSAL's shape — it takes an Android Activity on
+               mobile and an HWND on Windows. Boxing the IntPtr is the intended usage. */
+            provider.SetParentActivityOrWindowFunc(() => parentWindowHandleProvider());
+
+            SqlAuthenticationProvider.SetProvider(SqlAuthenticationMethod.ActiveDirectoryInteractive, provider);
+
+            _registered = true;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Whether interactive Entra auth is expected to work in this process: either a provider has been
+    /// registered, or we are not on Windows and therefore never needed one. False means a prompt would fail
+    /// with <c>0xwindow_handle_required</c> — which is the case a windowless host (the CLI) should surface as
+    /// a clear message instead of letting MSAL produce that error.
+    /// </summary>
+    public static bool IsSupported => _registered || !OperatingSystem.IsWindows();
+}

--- a/tests/PlanViewer.Core.Tests/CliConnectionResolverTests.cs
+++ b/tests/PlanViewer.Core.Tests/CliConnectionResolverTests.cs
@@ -1,0 +1,48 @@
+using PlanViewer.Cli.Commands;
+using PlanViewer.Core.Interfaces;
+using PlanViewer.Core.Services;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// Issue #425: the CLI accepts --auth entra but has no window to hand the WAM broker, so
+/// <see cref="CliConnectionResolver.BuildServerConnection"/> must refuse up front with actionable guidance
+/// instead of letting MSAL fail with 0xwindow_handle_required. This pins that refusal.
+///
+/// <para>Shares a collection with <see cref="EntraInteractiveAuthTests"/> because both read or flip the
+/// process-wide registration state behind <see cref="EntraInteractiveAuth.IsSupported"/>; running them in
+/// parallel would let that state change between this test's skip check and its assertion.</para>
+/// </summary>
+[Collection("EntraInteractiveAuth process-wide state")]
+public class CliConnectionResolverTests
+{
+    [Fact]
+    public void BuildServerConnection_RefusesInteractiveEntraWhereItCannotWork()
+    {
+        /* Only reachable on Windows: off Windows IsSupported is permanently true (browser auth works
+           headless there) and the CLI correctly does not refuse. */
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "the refusal only exists where WAM does");
+
+        /* Registration state is process-wide and one-way, and the registration tests may have run earlier
+           in this process; reset the flag so this test observes the state the real CLI process is always
+           in — nothing ever registered. The shared collection keeps the registration tests from running
+           concurrently and re-flipping it mid-test. */
+        EntraInteractiveAuth.ResetRegistrationForTests();
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            CliConnectionResolver.BuildServerConnection("srv", "entra", trustCert: false, new NoCredentials()));
+
+        Assert.Contains("headless", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /* Minimal stand-in: the resolver only asks whether a credential exists, and the entra refusal must fire
+       before credentials ever matter. */
+    private sealed class NoCredentials : ICredentialService
+    {
+        public bool SaveCredential(string serverId, string username, string password) => false;
+        public (string Username, string Password)? GetCredential(string serverId) => null;
+        public bool DeleteCredential(string serverId) => false;
+        public bool CredentialExists(string serverId) => false;
+        public bool UpdateCredential(string serverId, string username, string password) => false;
+    }
+}

--- a/tests/PlanViewer.Core.Tests/EntraInteractiveAuthTests.cs
+++ b/tests/PlanViewer.Core.Tests/EntraInteractiveAuthTests.cs
@@ -1,0 +1,59 @@
+using System;
+using PlanViewer.Core.Services;
+using Xunit;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// Issue #425: interactive Entra auth needs a parent window handle on Windows, because SqlClient routes it
+/// through the WAM broker. These pin the parts that are verifiable without a tenant — the OS gating and the
+/// contract the windowless CLI depends on. Whether the picker actually authenticates can only be established
+/// against a real Entra tenant, which is what the reporter offered to do.
+/// </summary>
+public class EntraInteractiveAuthTests
+{
+    [Fact]
+    public void Register_RejectsANullHandleProvider()
+    {
+        /* The whole point of the type is supplying a handle; accepting null would register a provider that
+           fails at prompt time instead of at wiring time, which is the harder bug to find. */
+        Assert.Throws<ArgumentNullException>(() => EntraInteractiveAuth.Register(null!));
+    }
+
+    [Fact]
+    public void OffWindows_RegistrationIsSkippedButInteractiveAuthIsStillConsideredSupported()
+    {
+        /* macOS and Linux have no WAM broker: interactive auth goes through the system browser and needs no
+           handle, so registering a handle-supplying provider there would add a failure mode to the platforms
+           that currently work. Register must decline, and IsSupported must still be TRUE — otherwise the CLI
+           guard would refuse `--auth entra` on exactly the platforms where it is fine. */
+        Assert.SkipWhen(OperatingSystem.IsWindows(), "Windows has WAM; this pins the non-Windows contract.");
+
+        var called = false;
+        var registered = EntraInteractiveAuth.Register(() => { called = true; return IntPtr.Zero; });
+
+        Assert.False(registered, "off Windows there is nothing to register");
+        Assert.False(called, "the handle provider must not even be consulted off Windows");
+        Assert.True(EntraInteractiveAuth.IsSupported,
+            "browser-based interactive auth works off Windows, so the CLI must not refuse it there");
+    }
+
+    [Fact]
+    public void OnWindows_RegistersOnceAndIsIdempotent()
+    {
+        /* SqlAuthenticationProvider.SetProvider is process-wide, so a second registration would silently
+           replace the first — and with several entry points able to call this (the app today, the SSMS
+           extension later) "first one wins, later ones are no-ops" is the contract worth pinning. */
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "WAM registration only happens on Windows.");
+
+        var first = EntraInteractiveAuth.Register(() => IntPtr.Zero);
+        var second = EntraInteractiveAuth.Register(() => new IntPtr(1234));
+
+        Assert.False(second, "a second Register must be a no-op rather than replacing the provider");
+        Assert.True(EntraInteractiveAuth.IsSupported);
+
+        /* first is only true when this test observed the very first registration in the process; another test
+           or the host may legitimately have gotten there first, so it is not asserted either way. */
+        _ = first;
+    }
+}

--- a/tests/PlanViewer.Core.Tests/EntraInteractiveAuthTests.cs
+++ b/tests/PlanViewer.Core.Tests/EntraInteractiveAuthTests.cs
@@ -1,6 +1,4 @@
-using System;
 using PlanViewer.Core.Services;
-using Xunit;
 
 namespace PlanViewer.Core.Tests;
 
@@ -9,7 +7,11 @@ namespace PlanViewer.Core.Tests;
 /// through the WAM broker. These pin the parts that are verifiable without a tenant — the OS gating and the
 /// contract the windowless CLI depends on. Whether the picker actually authenticates can only be established
 /// against a real Entra tenant, which is what the reporter offered to do.
+///
+/// <para>Shares a collection with <see cref="CliConnectionResolverTests"/>: registration here flips the
+/// process-wide state that the CLI refusal test keys off, so the two classes must not run in parallel.</para>
 /// </summary>
+[Collection("EntraInteractiveAuth process-wide state")]
 public class EntraInteractiveAuthTests
 {
     [Fact]


### PR DESCRIPTION
## What does this PR do?

Closes #425.

Microsoft Entra MFA could not work in Studio on Windows **at all**. Current `Microsoft.Data.SqlClient` (7.0.2 here) routes `Authentication=ActiveDirectoryInteractive` through the Windows **WAM broker**, and WAM requires the application to supply the HWND that will own its account picker. `ServerConnection.BuildConnectionString` set the authentication mode but nothing in the repo ever registered an auth provider, so users got

```
Error code 0xwindow_handle_required
Failed to acquire access token for ActiveDirectoryInteractive: A window handle must be configured.
```

instead of a prompt. Not tenant-specific — broken for every Windows user on a current build. 1.4.3 worked because it predates WAM being the default and fell back to a browser.

Reported by @joshdbe (via erikdarlingdata/PerformanceMonitor#2184), whose observation that **1.4.3 works and 1.19.1 doesn't** is what turned a vague auth error into a specific dependency behaviour change. Studio goes first because it's the tool he actually uses; the Lite half follows.

## The three decisions worth reviewing

**Registered once at startup, not per connection.** `SqlAuthenticationProvider.SetProvider` installs against the authentication *method*, not a connection, so one call covers every `SqlConnection` the process opens. Studio opens them from at least three unrelated places — the connection dialog, the query session control, and `SchemaQueryService` — and threading a handle through all of them would be a change every future call site could forget to make.

**Windows-only.** WAM doesn't exist on macOS or Linux, where interactive auth already works through the system browser and needs no handle. Registering a handle-supplying provider unconditionally would add a failure mode to the platforms Avalonia exists to serve. `Register` returns `false` when it declines, so callers can distinguish "not applicable" from "done".

**Handle resolved per prompt, preferring the active window.** Two reasons it isn't captured at startup: a window's platform handle isn't valid until the window has been sourced, and the right parent is whichever window is actually in front. Connections are usually triggered from the connection dialog, so parenting the picker to the main window behind it would let the picker appear *behind* the dialog the user is looking at. Falls back to main window, then `IntPtr.Zero` — which MSAL treats as no handle, so the prompt fails rather than the app crashing.

## The CLI

`planview` accepts `--auth entra` and has no window to give, so it would have failed deep inside MSAL with a message that tells the operator nothing. It now refuses up front and names the modes that work headless.

Deliberately **not** silently substituting another auth mode — connecting as a different identity than the one asked for is worse than refusing. Whether the CLI should grow device-code flow is left as the open question on #425 rather than guessed at here.

## How was this tested?

**Honestly: partially, and the important half isn't done yet.**

- The SqlClient API surface is validated by compilation rather than from memory — `ActiveDirectoryAuthenticationProvider`, `SetParentActivityOrWindowFunc` and `SqlAuthenticationProvider.SetProvider` all exist and bind on 7.0.2.
- Full solution builds with zero errors and zero new warnings.
- Three unit tests, covering what's provable without a tenant: a null handle provider is rejected at wiring time rather than at prompt time; the non-Windows contract (`Register` declines, the provider is never even consulted, and `IsSupported` stays **true** so the CLI guard doesn't refuse `entra` on platforms where it works); and idempotent registration, which matters because `SetProvider` is process-wide and a second call would otherwise silently replace the first once the SSMS extension wires in.
- Ran green locally: 2 passed, 1 skipped (the Windows-only pin, correctly skipped on macOS).

**What is NOT verified:** that the picker actually authenticates against a real tenant. I can only demonstrate a prompt appears; @joshdbe has offered to test against his Entra-MFA-on-Azure-VM environment and I'm not claiming this fixed until he does.

Note on the local suite: the full `PlanViewer.Core.Tests` run can't be used as a gate on macOS ARM64 — it wedges in a CoreCLR GC-suspension livelock (.NET 10.0.8), unrelated to this change. CI's `--blame-hang` watchdog is the regression gate here. Three orphaned test hosts from that hang were burning ~108% CPU each and have been cleaned up.

## Follow-ups deliberately not in scope

- **CLI device-code flow** vs. staying documented-unsupported — the open question on #425.
- **SSMS extension** — verified moot (2026-08-12): the extension opens no connections at all. It extracts the plan from SSMS and hands it to the App via named pipe or process launch, so the App's own registration covers every Entra prompt. There is no wiring point.
- **Lite** (erikdarlingdata/PerformanceMonitor#2184) — same missing registration, WPF's `WindowInteropHelper` instead of Avalonia's.


## Update after review (28be5ed)

The revived review gate (#428) produced two findings on this diff, both taken:

- **`ActiveWindowHandle` is now marshaled through `Dispatcher.UIThread`** (fast path when already on it), catching to `IntPtr.Zero` so a dispatcher failure degrades to MSAL's normal no-handle error. Verified the deadlock precondition first: no connection path blocks the UI thread on auth — every open in the app is async — so the blocking Invoke is safe.
- **The CLI refusal is now pinned by a real `BuildServerConnection` test.** The reviewer's static-state warning was the observed behavior: the registration tests run first in-process, so a skip-if-contaminated guard would have skipped on exactly the platform where the branch is reachable. The test instead resets the one-way flag via an internal test-only hook, and both test classes share a collection so the process-wide state can't flip mid-test.

Suite is now 292 tests: 291 pass, 1 skip (the off-Windows contract pin, correctly skipped on Windows).

