### PR TITLE
Watchdog the macOS test-host hang from outside the process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,4 @@ jobs:
         run: dotnet build PlanViewer.sln -c Release --no-restore
 
       - name: Run tests
-        run: dotnet test tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj -c Release --no-build --verbosity normal
+        run: dotnet test tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj -c Release --no-build --verbosity normal --blame-hang --blame-hang-timeout 5m --blame-hang-dump-type none

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,7 +65,7 @@ jobs:
           dotnet restore tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj
 
       - name: Run tests
-        run: dotnet test tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj -c Release --verbosity normal
+        run: dotnet test tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj -c Release --verbosity normal --blame-hang --blame-hang-timeout 5m --blame-hang-dump-type none
 
       - name: Publish App (all platforms)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           dotnet restore
           dotnet build -c Release
-          dotnet test tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj -c Release --no-build --verbosity normal
+          dotnet test tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj -c Release --no-build --verbosity normal --blame-hang --blame-hang-timeout 5m --blame-hang-dump-type none
 
       - name: Publish App (all platforms)
         run: |

--- a/tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj
+++ b/tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj
@@ -7,6 +7,13 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+
+    <!-- Applies the hang watchdog to a bare `dotnet test` with no flags to remember. The CI
+         workflows additionally pass the blame-hang options for the sequence file; this property is
+         what covers LOCAL runs, which is where the macOS ARM64 GC-suspension livelock actually
+         burned cores twice. See hang-watchdog.runsettings for why nothing inside the test host can
+         ever self-terminate. -->
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)/hang-watchdog.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/PlanViewer.Core.Tests/hang-watchdog.runsettings
+++ b/tests/PlanViewer.Core.Tests/hang-watchdog.runsettings
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Out-of-process watchdog for the macOS ARM64 test-host hang.
+
+  PlanViewer.Core.Tests can wedge in a CoreCLR GC-suspension livelock on macOS ARM64 (.NET 10.0.8):
+  a GC suspension interrupts a thread inside libunwind where CheckActivationSafePoint can never reach
+  a safe point, so the runtime re-sends activations forever and the mach-exception thread churns a
+  full core. Observed twice, with three hosts at ~108% CPU each, outliving the run that started them.
+
+  The important property: NOTHING INSIDE THE TEST HOST CAN STOP THIS. xUnit timeouts and in-test
+  CancelAfter cannot fire, because the execution engine itself is suspended; that is what the
+  livelock is. dotnet-stack and EventPipe hang for the same reason. Only an external process can
+  intervene, and TestSessionTimeout is enforced by vstest.console, which is a separate process from
+  the host it is watching.
+
+  Wired through RunSettingsFilePath in the .csproj rather than a settings flag on the command line, on purpose, so a
+  plain `dotnet test` picks it up. The two times this burned cores it was a bare local run: a fix
+  that only lives in the CI workflow files protects the machine that was never at risk and leaves
+  the laptop unprotected.
+
+  15 minutes is far above any real runtime here (individual tests are milliseconds and the whole
+  suite is normally well under a minute), so this only ever fires on a genuine wedge. It is a
+  backstop, not a performance budget: if a legitimate test ever approaches it, raise it rather than
+  trimming the test to fit.
+-->
+<RunSettings>
+  <RunConfiguration>
+    <TestSessionTimeout>900000</TestSessionTimeout>
+  </RunConfiguration>
+</RunSettings>


### PR DESCRIPTION
## What does this PR do?

Stops `PlanViewer.Core.Tests` from spinning a full core indefinitely when it wedges on macOS ARM64.

It happened **twice unprompted today**: three test hosts at ~108% CPU each, one wedged 22 minutes and still going when sampled. It was noticed because the laptop got hot, which is not a monitoring strategy.

## Why nothing in the test host can fix this

This is a CoreCLR **GC-suspension livelock** (.NET 10.0.8, macOS ARM64), not a slow or hanging test. From a 1 ms `sample` of a wedged host:

- `GCToEEInterface::SuspendEE` → `ThreadSuspend::SuspendEE` in **all 2451 samples** — the runtime is trying to suspend for GC and never completes.
- The victim thread was interrupted where `CheckActivationSafePoint` can never succeed, so the runtime re-sends activations forever.
- The mach-exception thread churns `thread_get_state` / `thread_set_state`, which is what burns the core.

So **xUnit timeouts and in-test `CancelAfter` cannot fire** — the execution engine itself is suspended; that *is* the livelock. `dotnet-stack` and EventPipe hang for the same reason. Only an out-of-process watchdog works, and both mechanisms below are enforced by `vstest.console`, which is a separate process from the host it watches.

## Two layers, and the second is the one that matters

1. **The three CI invocations** (`ci`, `nightly`, `release`) pass the blame-hang options, which produce a sequence file naming the test that wedged.
2. **`RunSettingsFilePath` in the test csproj** points at `hang-watchdog.runsettings`, giving a bare `dotnet test` a `TestSessionTimeout` backstop with no flags to remember.

Layer 2 is the important one: **both incidents were plain local runs.** A fix living only in the workflow files would protect the machine that was never at risk and leave the laptop unprotected — which is precisely how this recurred after being root-caused the first time.

15 minutes is far above any real runtime here (individual tests are milliseconds; the suite is normally well under a minute), so it only fires on a genuine wedge. It's a backstop, not a performance budget.

## How was this tested?

A silently-ignored runsettings looks exactly like a working one, so I verified the mechanism rather than the file's existence:

- Temporarily set `TestSessionTimeout` to `1`, ran a **bare** `dotnet test` with no flags, and got `Aborting test run: test run timeout of 1 milliseconds exceeded` / `Test Run Aborted.` Then restored it to 900000. That proves `RunSettingsFilePath` is honored on a flagless invocation, which is the whole claim.
- On a normal run the blame collector reports itself active: `Data collector 'Blame' message: All tests finished running, Sequence file will not be generated.`
- Tests pass (2 passed, 1 skipped — the skip is a Windows-only pin), and zero test hosts survived any run.

Both XML files validated as well-formed, after the toolchain caught me twice writing `--` inside an XML comment (illegal), once in the csproj and once in the runsettings.

## Not in scope

The upstream bug itself. Evidence for a future dotnet/runtime report is preserved outside the session scratchpad at `~/Documents/dotnet-hang-evidence` (sample, gzip, and a README explaining the signature); related to dotnet/runtime#66759 on Apple thread-suspension limits. This PR just makes the symptom self-terminating instead of open-ended.
