### PR TITLE
Sync claude-code-review.yml to main so the review gate validates again

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,9 +37,17 @@ jobs:
     # were each already reviewed on their own PR, so re-reviewing the whole
     # release adds nothing — and the diff is large enough that it reliably
     # exhausts the turn budget and fails, putting a red X on the release.
+    #
+    # Also skip Dependabot PRs. They fail twice over instead of getting a
+    # review: the action rejects non-human actors outright ("Workflow initiated
+    # by non-human actor: dependabot"), and a dependabot-triggered run draws
+    # from the DEPENDABOT secret store, not the Actions one, so the OAuth token
+    # is empty anyway. A version bump has nothing an AI review would catch that
+    # build-and-test doesn't; skipped is neutral, not a red X on every bump.
     if: |
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]' &&
       !(github.event.pull_request.head.ref == 'dev' && github.event.pull_request.base.ref == 'main')
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## What does this PR do?

Fixes #428.

Cherry-picks 6decaf8 from dev onto main so `.github/workflows/claude-code-review.yml` is byte-identical on the default branch again. `claude-code-action` validates the running workflow file against the default-branch copy and silently skips with `conclusion=success` on any mismatch, so this 8-line drift (the Dependabot skip from #423) disabled the review gate on every PR since 2026-08-03.

Direct push to main is blocked by repository rules, hence this PR. The review check on this PR will itself skip by design (it modifies the workflow file). Verification that the gate is live again happens separately: re-run the review on #426 and confirm the log shows a real review (token spend, no validation warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)