### PR TITLE
Stop Robot Advice from crashing the app on a deep plan (#430)

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.Advice.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.Advice.cs
@@ -49,7 +49,21 @@ public partial class QuerySessionControl : UserControl
         var analysis = GetCurrentAnalysis();
         if (analysis == null) { SetStatus("No plan to analyze", autoClear: false); return; }
 
-        var json = JsonSerializer.Serialize(analysis, new JsonSerializerOptions { WriteIndented = true });
+        string json;
+        try
+        {
+            json = JsonSerializer.Serialize(analysis, AnalysisJson.Indented);
+        }
+        catch (Exception ex) when (ex is JsonException or NotSupportedException)
+        {
+            /* #430: Avalonia does not guard click handlers, so anything thrown on this path takes the
+               process down with no dialog and nothing logged. AnalysisJson's depth ceiling makes this
+               unreachable for any plan seen in the field — this catch is here so that "unreachable" is
+               not the only thing standing between a deep plan and a silent crash. */
+            SetStatus($"Could not build robot advice for this plan: {ex.Message}", autoClear: false);
+            return;
+        }
+
         ShowAdviceWindow("Advice for Robots", json);
     }
 

--- a/src/PlanViewer.App/MainWindow.PlanViewer.cs
+++ b/src/PlanViewer.App/MainWindow.PlanViewer.cs
@@ -63,7 +63,20 @@ public partial class MainWindow : Window
         {
             if (viewer.CurrentPlan == null) return;
             var analysis = ResultMapper.Map(viewer.CurrentPlan, "file", viewer.Metadata);
-            var json = JsonSerializer.Serialize(analysis, new JsonSerializerOptions { WriteIndented = true });
+            string json;
+            try
+            {
+                json = JsonSerializer.Serialize(analysis, AnalysisJson.Indented);
+            }
+            catch (Exception ex) when (ex is JsonException or NotSupportedException)
+            {
+                /* #430: the same unguarded-click-handler crash as QuerySessionControl's Robot Advice
+                   button — this entry point builds the payload independently, so it needed the same
+                   depth ceiling and the same guard. */
+                ShowError($"Could not build robot advice for this plan: {ex.Message}");
+                return;
+            }
+
             ShowAdviceWindow("Advice for Robots", json);
         };
 

--- a/src/PlanViewer.App/Mcp/McpHelpers.cs
+++ b/src/PlanViewer.App/Mcp/McpHelpers.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text.Json;
+using PlanViewer.Core.Output;
 
 namespace PlanViewer.App.Mcp;
 
@@ -7,7 +8,14 @@ internal static class McpHelpers
 {
     public const int MaxTop = 100;
 
-    public static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+    /* #430: MaxDepth, because several of these tools return an analysis carrying an OperatorTree and the
+       default ceiling of 64 is roughly 30 nested operators. Unlike the UI buttons an MCP tool failing here
+       does not crash the process, but it does return an error where the caller expected a plan. */
+    public static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        MaxDepth = AnalysisJson.MaxDepth,
+    };
 
     public static string? Truncate(string? value, int maxLength)
     {

--- a/src/PlanViewer.Cli/Commands/AnalyzeCommand.cs
+++ b/src/PlanViewer.Cli/Commands/AnalyzeCommand.cs
@@ -11,14 +11,19 @@ namespace PlanViewer.Cli.Commands;
 
 public static class AnalyzeCommand
 {
+    /* #430: MaxDepth on both, because the default ceiling of 64 is roughly 30 nested operators and
+       `analyze --json` on a large plan hit it. The CLI surfaces this as a non-zero exit rather than a
+       crash, but a plan too deep to print is the same defect wearing a different coat. */
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = true,
+        MaxDepth = AnalysisJson.MaxDepth,
         DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
     };
 
     private static readonly JsonSerializerOptions CompactJsonOptions = new()
     {
+        MaxDepth = AnalysisJson.MaxDepth,
         DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
     };
 

--- a/src/PlanViewer.Core/Output/AnalysisJson.cs
+++ b/src/PlanViewer.Core/Output/AnalysisJson.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+
+namespace PlanViewer.Core.Output;
+
+/// <summary>
+/// How deep a serializer must be willing to go to write an <see cref="AnalysisResult"/>, in ONE place
+/// because every writer of this object needs the same answer and none of them can tell when they got it
+/// wrong.
+///
+/// <para><b>Why this exists (#430).</b> <see cref="System.Text.Json"/> defaults <c>MaxDepth</c> to 64 and
+/// throws when a graph exceeds it. <see cref="OperatorResult.Children"/> nests once per operator, and each
+/// level costs two JSON levels (the object, then the array), so a plan roughly 30 operators deep exhausts
+/// the default. Clicking "Advice for Robots" on a large plan therefore threw a <c>JsonException</c> out of
+/// an Avalonia click handler, which Avalonia does not guard, and the process died with no dialog and no
+/// log entry the user could act on.</para>
+///
+/// <para><b>Why raising it is safe here, which is the part worth checking before copying this.</b> The
+/// exception message reads "A possible object cycle was detected. This can either be due to a cycle or if
+/// the object depth is larger than the maximum allowed depth of 64", and those two causes want opposite
+/// fixes: raising the limit on a genuine cycle just moves the crash. The serialized graph is
+/// <see cref="OperatorResult"/>, which has <c>Children</c> and no parent link, so it is a tree and the
+/// depth reading is the right one. Note that the INTERNAL model this is mapped from,
+/// <c>PlanViewer.Core.Models.PlanNode</c>, DOES carry a <c>Parent</c> back-reference that the parser
+/// populates — so if anything ever serializes <c>PlanNode</c> directly, that is a real cycle and needs
+/// <c>[JsonIgnore]</c> on <c>Parent</c> rather than a bigger number.</para>
+///
+/// <para><b>The number is headroom, not a guarantee</b>, and it is deliberately paired with a caller-side
+/// guard. 1024 covers about 500 nested operators against the ~30 that used to fail, which is far past any
+/// plan seen in the field; a plan deeper than that now surfaces as a message instead of terminating the
+/// process, because a serialization limit should never be able to take the app down.</para>
+/// </summary>
+public static class AnalysisJson
+{
+    /// <summary>Depth ceiling for every serializer that writes an <see cref="AnalysisResult"/>.</summary>
+    public const int MaxDepth = 1024;
+
+    /// <summary>
+    /// The indented options the UI writes advice with. Matches what the call sites built inline before
+    /// #430 — <c>WriteIndented</c> only — so the emitted JSON is unchanged apart from no longer failing
+    /// partway down a deep tree.
+    /// </summary>
+    public static readonly JsonSerializerOptions Indented = new()
+    {
+        WriteIndented = true,
+        MaxDepth = MaxDepth,
+    };
+}

--- a/tests/PlanViewer.Core.Tests/AnalysisJsonDepthTests.cs
+++ b/tests/PlanViewer.Core.Tests/AnalysisJsonDepthTests.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using PlanViewer.Core.Output;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #430: "Robot Advice" crashed the app on a large plan.
+///
+/// System.Text.Json defaults MaxDepth to 64 and throws past it. An operator tree nests once per
+/// operator and each level costs two JSON levels (the object, then the Children array), so a plan
+/// roughly 30 operators deep exhausts the default. The throw came out of an Avalonia click handler,
+/// which Avalonia does not guard, so the process died with no dialog and nothing actionable logged.
+///
+/// The reported stack named the cause precisely: the path was
+/// $.Statements.OperatorTree.Children.Children...(30 deep)...NodeId — thirty CONSECUTIVE Children.
+/// That matters, because the exception message offers two causes ("either be due to a cycle or if the
+/// object depth is larger than the maximum allowed depth of 64") and they want opposite fixes. A
+/// consecutive descent is depth. A cycle would have alternated, and raising the ceiling on a cycle
+/// only moves the crash.
+/// </summary>
+public class AnalysisJsonDepthTests
+{
+    /// <summary>An analysis whose statement carries a single chain of nested operators.</summary>
+    private static AnalysisResult WithOperatorChain(int operators)
+    {
+        var node = new OperatorResult { PhysicalOp = "Leaf" };
+        for (var i = 1; i < operators; i++)
+            node = new OperatorResult { PhysicalOp = "Nested", Children = { node } };
+
+        return new AnalysisResult { Statements = { new StatementResult { OperatorTree = node } } };
+    }
+
+    /// <summary>
+    /// The defect, reproduced against the options the call sites used to build inline. Without this the
+    /// fix below is unfalsifiable — a passing serialize proves nothing if nothing ever failed.
+    /// </summary>
+    [Fact]
+    public void TheOldInlineOptionsFailOnADeepPlan()
+    {
+        var exception = Assert.Throws<JsonException>(() =>
+            JsonSerializer.Serialize(WithOperatorChain(60), new JsonSerializerOptions { WriteIndented = true }));
+
+        Assert.Contains("depth", exception.Message, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>The fix: the shared options carry the plan that used to crash the app.</summary>
+    [Theory]
+    [InlineData(60)]
+    [InlineData(200)]
+    [InlineData(400)]
+    public void TheSharedOptionsCarryADeepPlan(int operators)
+    {
+        var json = JsonSerializer.Serialize(WithOperatorChain(operators), AnalysisJson.Indented);
+
+        Assert.Contains("\"Leaf\"", json, System.StringComparison.Ordinal);
+        /* Every level actually made it out, rather than the serializer stopping quietly partway. */
+        Assert.Equal(operators - 1, System.Text.RegularExpressions.Regex.Matches(json, "\"Nested\"").Count);
+    }
+
+    /// <summary>
+    /// The ceiling is headroom, not a guarantee — which is exactly why the two UI call sites also catch.
+    /// A plan past it must still fail as an exception the caller can turn into a message, not as
+    /// silently truncated JSON that reads like a complete plan.
+    /// </summary>
+    [Fact]
+    public void PastTheCeilingItStillThrowsRatherThanTruncating()
+    {
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Serialize(WithOperatorChain(AnalysisJson.MaxDepth + 10), AnalysisJson.Indented));
+    }
+
+    /// <summary>
+    /// Pins the headroom itself. 1024 is about 500 nested operators against the ~30 that used to fail;
+    /// a future edit dropping it back toward the default would re-open #430 for large plans only, which
+    /// is the shape of bug that reaches users rather than tests.
+    /// </summary>
+    [Fact]
+    public void TheCeilingIsFarAboveAnyRealPlan()
+    {
+        Assert.Equal(1024, AnalysisJson.MaxDepth);
+        Assert.Equal(AnalysisJson.MaxDepth, AnalysisJson.Indented.MaxDepth);
+        Assert.True(AnalysisJson.Indented.WriteIndented, "advice output is read by people as well as models");
+    }
+}


### PR DESCRIPTION
Fixes #430.

## What does this PR do?

`System.Text.Json` defaults `MaxDepth` to 64 and throws past it. An operator tree nests once per operator and each level costs two JSON levels (the object, then the `Children` array), so a plan roughly **30 operators deep** exhausts the default. The throw came out of an Avalonia click handler, which Avalonia does not guard — so the process died with no dialog and nothing the user could act on.

The reporter's stack named the cause precisely:

```
System.Text.Json.JsonException: A possible object cycle was detected. This can either be due to a
cycle or if the object depth is larger than the maximum allowed depth of 64.
Path: $.Statements.OperatorTree.Children.Children...(30 deep)...NodeId
   at PlanViewer.App.Controls.QuerySessionControl.RobotAdvice_Click
```

**Thirty consecutive `Children`, and that distinction decides the fix.** The message offers two causes and they want opposite remedies — raising the ceiling on a genuine cycle just moves the crash. The serialized type is `OperatorResult`, which has `Children` and no parent link, so it is a tree and the depth reading is the right one.

Worth recording for whoever hits this next: the **internal** model it is mapped from, `PlanViewer.Core.Models.PlanNode`, *does* carry a `Parent` back-reference that the parser populates (`ShowPlanParser.RelOp.cs:140`). Serializing that type directly would be a real cycle needing `[JsonIgnore]`, not a bigger number. Nothing does today, and the new file says so.

**Four places serialize this object and none of them could tell when they got it wrong**, so the ceiling is now one shared constant:

| site | consequence before |
|---|---|
| `QuerySessionControl.RobotAdvice_Click` | **process crash** (the reported bug) |
| `MainWindow.PlanViewer.cs` robot advice | **process crash** — a second entry point that builds the payload independently |
| `McpHelpers.JsonOptions` | MCP tool returns an error where the caller expected a plan |
| `AnalyzeCommand` JSON + compact options | `analyze --json` fails on a large plan |

1024 is about 500 nested operators against the ~30 that used to fail. It is deliberately paired with a caller-side `catch` at both UI sites: a serialization limit should never be able to take the app down, so the headroom is not the only thing standing between a deep plan and a crash.

## Which component(s) does this affect?

- [x] Desktop App (PlanViewer.App)
- [x] Core Library (PlanViewer.Core)
- [x] CLI Tool (PlanViewer.Cli)
- [ ] SSMS Extension (PlanViewer.Ssms)
- [x] Tests
- [ ] Documentation

## How was this tested?

`AnalysisJsonDepthTests` (6 cases), including a **reproduction** — a 60-operator chain that throws on the options the call sites used to build inline and serializes on the shared ones. Without that case the fix would be unfalsifiable: a passing serialize proves nothing if nothing ever failed. It also asserts every level actually made it into the output rather than the serializer stopping quietly partway, and that a tree past the ceiling still *throws* rather than emitting truncated JSON that reads like a complete plan.

- 137/137 in `PlanViewer.Core.Tests`, macOS (arm64)
- `PlanViewer.App` and `PlanViewer.Cli` build with **zero warnings**

Synthetic depth chains rather than a plan file — the reporter's plan was too large to anonymize, and depth is the whole variable, so constructing it directly tests the boundary precisely at 64 and at the new ceiling.

**One note on the local run.** The full suite reports all 137 passing in 54 ms and then the test host livelocks on shutdown at ~100% CPU; `dotnet test` prints `Catastrophic failure: Test process crashed with exit code 143`, which is the `SIGTERM` I sent it. A 3-second `sample` shows `SuspendEE`, `inject_activation`, `CheckActivationSafePoint` and `thread_get_state`/`thread_set_state` churn inside nested `_sigtramp` — the known CoreCLR GC-suspension livelock on macOS ARM64, unrelated to this change (`sample` itself hangs until the host is killed, since it needs the same thread suspension). Mentioning it because it makes a green local run look like a crash, and because #427's watchdog is the thing that catches it.

## Checklist

- [x] I have read the contributing guide
- [x] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] All tests pass (`dotnet test`)
- [x] I have not introduced any hardcoded credentials or server names

🤖 Generated with [Claude Code](https://claude.com/claude-code)