### PR TITLE
Give querystore the depth ceiling that analyze got (#430)

### DIFF
--- a/src/PlanViewer.Cli/Commands/AnalyzeCommand.cs
+++ b/src/PlanViewer.Cli/Commands/AnalyzeCommand.cs
@@ -11,21 +11,12 @@ namespace PlanViewer.Cli.Commands;
 
 public static class AnalyzeCommand
 {
-    /* #430: MaxDepth on both, because the default ceiling of 64 is roughly 30 nested operators and
-       `analyze --json` on a large plan hit it. The CLI surfaces this as a non-zero exit rather than a
-       crash, but a plan too deep to print is the same defect wearing a different coat. */
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        WriteIndented = true,
-        MaxDepth = AnalysisJson.MaxDepth,
-        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
-    };
+    /* #430: the depth ceiling and the null handling both live on AnalysisJson now. They used to be
+       built here, which is how the identical pair in QueryStoreCommand got missed when #430 was
+       fixed — see AnalysisJson.IndentedWithoutNulls. */
+    private static readonly JsonSerializerOptions JsonOptions = AnalysisJson.IndentedWithoutNulls;
 
-    private static readonly JsonSerializerOptions CompactJsonOptions = new()
-    {
-        MaxDepth = AnalysisJson.MaxDepth,
-        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
-    };
+    private static readonly JsonSerializerOptions CompactJsonOptions = AnalysisJson.CompactWithoutNulls;
 
     public static Command Create(ICredentialService? credentialService = null)
     {

--- a/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
+++ b/src/PlanViewer.Cli/Commands/QueryStoreCommand.cs
@@ -10,16 +10,12 @@ namespace PlanViewer.Cli.Commands;
 
 public static class QueryStoreCommand
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        WriteIndented = true,
-        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
-    };
+    /* #430: these two were built inline and never got the depth ceiling, so `querystore` still
+       failed on a plan deeper than ~30 operators long after the crash was "fixed" — one ERROR row
+       in summary.txt per deep plan, which is quieter than the crash and no more correct. */
+    private static readonly JsonSerializerOptions JsonOptions = AnalysisJson.IndentedWithoutNulls;
 
-    private static readonly JsonSerializerOptions CompactJsonOptions = new()
-    {
-        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
-    };
+    private static readonly JsonSerializerOptions CompactJsonOptions = AnalysisJson.CompactWithoutNulls;
 
     public static Command Create(ICredentialService? credentialService = null)
     {

--- a/src/PlanViewer.Core/Output/AnalysisJson.cs
+++ b/src/PlanViewer.Core/Output/AnalysisJson.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace PlanViewer.Core.Output;
 
@@ -43,5 +44,30 @@ public static class AnalysisJson
     {
         WriteIndented = true,
         MaxDepth = MaxDepth,
+    };
+
+    /// <summary>
+    /// What the CLI writes analysis files with — same as <see cref="Indented"/> plus dropping nulls,
+    /// which is what keeps `analyze --json` output readable.
+    ///
+    /// <para>These live here rather than on the commands because the commands each built their own
+    /// copy, and that is precisely how <c>querystore</c> was left behind when #430 was fixed: the
+    /// depth ceiling was made a shared constant, but the OPTIONS were still duplicated, so adding
+    /// <c>MaxDepth</c> to the two sets in AnalyzeCommand silently did nothing for the identical pair
+    /// in QueryStoreCommand. A shared constant only helps the call sites that remember to reference
+    /// it. Sharing the options instead is what makes the next command unable to get it wrong.</para>
+    /// </summary>
+    public static readonly JsonSerializerOptions IndentedWithoutNulls = new()
+    {
+        WriteIndented = true,
+        MaxDepth = MaxDepth,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>The unindented counterpart to <see cref="IndentedWithoutNulls"/>, for --compact.</summary>
+    public static readonly JsonSerializerOptions CompactWithoutNulls = new()
+    {
+        MaxDepth = MaxDepth,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
 }

--- a/tests/PlanViewer.Core.Tests/AnalysisJsonDepthTests.cs
+++ b/tests/PlanViewer.Core.Tests/AnalysisJsonDepthTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text.Json;
 using PlanViewer.Core.Output;
 
@@ -67,6 +68,39 @@ public class AnalysisJsonDepthTests
     {
         Assert.Throws<JsonException>(() =>
             JsonSerializer.Serialize(WithOperatorChain(AnalysisJson.MaxDepth + 10), AnalysisJson.Indented));
+    }
+
+    /// <summary>
+    /// The miss that #430's original fix left behind, and the reason the OPTIONS are shared and not
+    /// just the constant.
+    ///
+    /// <para>Every CLI command that writes an analysis built its own JsonSerializerOptions. Making
+    /// MaxDepth a shared constant only fixed the sets that were edited to reference it — AnalyzeCommand's
+    /// two — while the identical pair in QueryStoreCommand kept the default ceiling of 64 and kept
+    /// failing on any plan deeper than ~30 operators. It failed quietly there: the per-plan catch turns
+    /// it into one "ERROR" row in summary.txt instead of an analysis, which is exactly the kind of
+    /// wrong-but-not-loud result nobody files a bug about.</para>
+    ///
+    /// <para>So this walks the options rather than trusting the call sites, and a new command that
+    /// rolls its own will fail here rather than in someone's Query Store sweep.</para>
+    /// </summary>
+    [Fact]
+    public void EveryCliCommandWritesAnalysesWithTheCeiling()
+    {
+        var offenders =
+            (from type in typeof(PlanViewer.Cli.Commands.AnalyzeCommand).Assembly.GetTypes()
+             where type.Name.EndsWith("Command", System.StringComparison.Ordinal)
+             from field in type.GetFields(System.Reflection.BindingFlags.NonPublic
+                                        | System.Reflection.BindingFlags.Public
+                                        | System.Reflection.BindingFlags.Static)
+             where field.FieldType == typeof(JsonSerializerOptions)
+             let options = (JsonSerializerOptions?)field.GetValue(null)
+             where options is not null && options.MaxDepth != AnalysisJson.MaxDepth
+             select $"{type.Name}.{field.Name} (MaxDepth {options.MaxDepth})").ToList();
+
+        Assert.True(offenders.Count == 0,
+            "These write an analysis with the default depth ceiling and will fail on a deep plan: "
+            + string.Join(", ", offenders));
     }
 
     /// <summary>


### PR DESCRIPTION
Completes #430. The crash fix in #431 was right; its enumeration of call sites was one file short.

## What was missed

#431 made the depth ceiling a shared constant and referenced it from every serializer it found: both Robot Advice entry points, the MCP tool options, and AnalyzeCommand's two option sets. `QueryStoreCommand` builds its **own** `JsonOptions` and `CompactJsonOptions`, identical in shape to AnalyzeCommand's, and neither ever got `MaxDepth`.

So `planview querystore` has kept failing on any plan deeper than roughly 30 operators for as long as `analyze` has been fine.

## Why nobody reported it

It fails quietly. The per-plan `try`/`catch` in the sweep loop turns the `JsonException` into one `ERROR: ...` row in `summary.txt` and moves on to the next plan — so a sweep over a few hundred Query Store plans silently analyzes all but the deep ones. Query Store batch analysis is exactly where the deep plans are.

## Why the fix isn't just two more `MaxDepth =` lines

A shared constant only helps the call sites that remember to reference it, and the *options* were still duplicated per command. Editing AnalyzeCommand's two sets did nothing for the identical pair one file over, and nothing anywhere said they were supposed to match.

The options now live on `AnalysisJson` next to the constant — `IndentedWithoutNulls` and `CompactWithoutNulls` — and both commands point at them. There is no longer a copy to forget.

Values are unchanged for `analyze`: same `WriteIndented`, same `JsonIgnoreCondition.WhenWritingNull`, same ceiling. Only `querystore` behaviour changes, and only from "fails on deep plans" to "doesn't".

## Test

It walks the options rather than trusting the call sites, since trusting them is what went wrong: every static `JsonSerializerOptions` on a `*Command` type in `PlanViewer.Cli` must carry the ceiling.

Verified by reverting just the QueryStoreCommand hunk, at which point it fails naming both offenders:

```
These write an analysis with the default depth ceiling and will fail on a deep plan:
QueryStoreCommand.JsonOptions (MaxDepth 0), QueryStoreCommand.CompactJsonOptions (MaxDepth 0)
```

A new command that rolls its own now fails here rather than in someone's Query Store sweep.

82 tests across `AnalysisJsonDepthTests` and the CLI/analysis classes, 0 failures. `dotnet build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
