### PR TITLE
Say which warnings are SQL Server's and which are ours (#436)

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.Properties.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.Properties.cs
@@ -818,9 +818,10 @@ public partial class PlanViewerControl : UserControl
                         : w.Severity == PlanWarningSeverity.Warning ? "#FFB347" : "#6BB5FF";
                     var warnPanel = new StackPanel { Margin = new Thickness(10, 2, 10, 2) };
                     var legacyTag = w.IsLegacy ? " [legacy]" : "";
+                    var sourceTag = WarningSourceTag(w);
                     var planWarnHeader = w.MaxBenefitPercent.HasValue
-                        ? $"\u26A0 {w.WarningType}{legacyTag} \u2014 up to {FormatBenefitPercent(w.MaxBenefitPercent.Value)}% benefit"
-                        : $"\u26A0 {w.WarningType}{legacyTag}";
+                        ? $"\u26A0 {w.WarningType}{sourceTag}{legacyTag} \u2014 up to {FormatBenefitPercent(w.MaxBenefitPercent.Value)}% benefit"
+                        : $"\u26A0 {w.WarningType}{sourceTag}{legacyTag}";
                     warnPanel.Children.Add(new TextBlock
                     {
                         Text = planWarnHeader,
@@ -901,9 +902,10 @@ public partial class PlanViewerControl : UserControl
                     : w.Severity == PlanWarningSeverity.Warning ? "#FFB347" : "#6BB5FF";
                 var warnPanel = new StackPanel { Margin = new Thickness(10, 2, 10, 2) };
                 var nodeLegacyTag = w.IsLegacy ? " [legacy]" : "";
+                var nodeSourceTag = WarningSourceTag(w);
                 var nodeWarnHeader = w.MaxBenefitPercent.HasValue
-                    ? $"\u26A0 {w.WarningType}{nodeLegacyTag} \u2014 up to {FormatBenefitPercent(w.MaxBenefitPercent.Value)}% benefit"
-                    : $"\u26A0 {w.WarningType}{nodeLegacyTag}";
+                    ? $"\u26A0 {w.WarningType}{nodeSourceTag}{nodeLegacyTag} \u2014 up to {FormatBenefitPercent(w.MaxBenefitPercent.Value)}% benefit"
+                    : $"\u26A0 {w.WarningType}{nodeSourceTag}{nodeLegacyTag}";
                 warnPanel.Children.Add(new TextBlock
                 {
                     Text = nodeWarnHeader,

--- a/src/PlanViewer.App/Controls/PlanViewerControl.Rendering.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.Rendering.cs
@@ -516,6 +516,14 @@ public partial class PlanViewerControl : UserControl
     private static string FormatBenefitPercent(double pct) =>
         pct >= 100 ? $"{pct:N0}" : $"{pct:N1}";
 
+    /// <summary>
+    /// #436: marks the warnings SQL Server itself wrote into the plan, so they are not read as one of
+    /// our inferences. Only the engine's are tagged — they are the minority, and a badge on every
+    /// warning would carry no information.
+    /// </summary>
+    private static string WarningSourceTag(PlanWarning warning) =>
+        warning.Source == PlanWarningSource.SqlServer ? " [SQL Server]" : "";
+
     private static bool HasSpillInPlanTree(PlanNode node)
     {
         foreach (var w in node.Warnings)

--- a/src/PlanViewer.Core/Models/PlanModels.cs
+++ b/src/PlanViewer.Core/Models/PlanModels.cs
@@ -376,6 +376,22 @@ public class PlanWarning
     public SpillDetail? SpillDetails { get; set; }
 
     /// <summary>
+    /// Who says so — SQL Server itself, or us (#436).
+    ///
+    /// <para>These two carry very different weight and a reader cannot tell them apart from the
+    /// message text. A warning SQL Server wrote into the plan's own &lt;Warnings&gt; element is a
+    /// statement of fact from the engine that executed the query: it spilled, it converted, it had no
+    /// statistics. One of our rules is an inference from plan shape, and inferences can be wrong about
+    /// a particular plan in a way the engine's own record cannot be.</para>
+    ///
+    /// <para>Defaults to <see cref="PlanWarningSource.PerformanceStudio"/> because the analyzer builds
+    /// the large majority of them. Everything the parser lifts out of the plan XML is stamped
+    /// <see cref="PlanWarningSource.SqlServer"/> in one place, at the single return of
+    /// ShowPlanParser.ParseWarningsFromElement, so a new engine warning cannot be added and forgotten.</para>
+    /// </summary>
+    public PlanWarningSource Source { get; set; } = PlanWarningSource.PerformanceStudio;
+
+    /// <summary>
     /// Maximum percentage of elapsed time that could be saved by addressing this finding.
     /// null = not quantifiable, 0 = calculated as negligible.
     /// </summary>
@@ -396,6 +412,16 @@ public class PlanWarning
 }
 
 public enum PlanWarningSeverity { Info, Warning, Critical }
+
+/// <summary>Where a <see cref="PlanWarning"/> came from. See <see cref="PlanWarning.Source"/>.</summary>
+public enum PlanWarningSource
+{
+    /// <summary>An inference of ours, from the shape of the plan.</summary>
+    PerformanceStudio,
+
+    /// <summary>Read out of the plan's own &lt;Warnings&gt; element — the engine's record, not ours.</summary>
+    SqlServer
+}
 
 public class MemoryGrantInfo
 {

--- a/src/PlanViewer.Core/Output/AnalysisResult.cs
+++ b/src/PlanViewer.Core/Output/AnalysisResult.cs
@@ -247,6 +247,15 @@ public class WarningResult
     /// </summary>
     [JsonPropertyName("is_legacy")]
     public bool IsLegacy { get; set; }
+
+    /// <summary>
+    /// "SqlServer" when the engine wrote this into the plan's own &lt;Warnings&gt; element, or
+    /// "PerformanceStudio" when it is one of our rules inferring it from plan shape (#436). Values
+    /// match <see cref="PlanViewer.Core.Models.PlanWarningSource"/>, spelled the same way
+    /// <see cref="Severity"/> spells its enum.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public string Source { get; set; } = "";
 }
 
 public class MissingIndexResult

--- a/src/PlanViewer.Core/Output/ResultMapper.cs
+++ b/src/PlanViewer.Core/Output/ResultMapper.cs
@@ -195,7 +195,8 @@ public static class ResultMapper
                 Message = w.Message,
                 MaxBenefitPercent = w.MaxBenefitPercent,
                 ActionableFix = w.ActionableFix,
-                IsLegacy = w.IsLegacy
+                IsLegacy = w.IsLegacy,
+                Source = w.Source.ToString()
             });
         }
 
@@ -304,7 +305,8 @@ public static class ResultMapper
                 NodeId = node.NodeId,
                 MaxBenefitPercent = w.MaxBenefitPercent,
                 ActionableFix = w.ActionableFix,
-                IsLegacy = w.IsLegacy
+                IsLegacy = w.IsLegacy,
+                Source = w.Source.ToString()
             });
         }
 

--- a/src/PlanViewer.Core/Output/TextFormatter.cs
+++ b/src/PlanViewer.Core/Output/TextFormatter.cs
@@ -193,7 +193,7 @@ public static class TextFormatter
                         ? $" (up to {(w.MaxBenefitPercent.Value >= 100 ? w.MaxBenefitPercent.Value.ToString("N0") : w.MaxBenefitPercent.Value.ToString("N1"))}% benefit)"
                         : "";
                     var legacyTag = w.IsLegacy ? " [legacy]" : "";
-                    writer.WriteLine($"  [{w.Severity}] {w.Type}{legacyTag}{benefitTag}: {EscapeNewlines(w.Message)}");
+                    writer.WriteLine($"  [{w.Severity}] {w.Type}{SourceTag(w.Source)}{legacyTag}{benefitTag}: {EscapeNewlines(w.Message)}");
                     if (!string.IsNullOrEmpty(w.ActionableFix))
                         writer.WriteLine($"    Fix: {EscapeNewlines(w.ActionableFix)}");
                 }
@@ -339,7 +339,7 @@ public static class TextFormatter
 
         // Split each message into "data | explanation" at the last sentence boundary
         // that starts with "The " (the harm assessment). Group by shared explanation.
-        var entries = new List<(string Severity, string Operator, string Data, string? Explanation, double? Benefit, bool IsLegacy)>();
+        var entries = new List<(string Severity, string Operator, string Data, string? Explanation, double? Benefit, bool IsLegacy, string Source)>();
         foreach (var w in sorted)
         {
             var msg = w.Message;
@@ -358,7 +358,7 @@ public static class TextFormatter
                 data = msg;
             }
 
-            entries.Add((w.Severity, w.Operator ?? "?", data, explanation, w.MaxBenefitPercent, w.IsLegacy));
+            entries.Add((w.Severity, w.Operator ?? "?", data, explanation, w.MaxBenefitPercent, w.IsLegacy, w.Source));
         }
 
         // Group entries that share the same severity, type, and explanation
@@ -380,7 +380,7 @@ public static class TextFormatter
                     var benefitTag = item.Benefit.HasValue
                         ? $" (up to {(item.Benefit.Value >= 100 ? item.Benefit.Value.ToString("N0") : item.Benefit.Value.ToString("N1"))}% benefit)"
                         : "";
-                    writer.WriteLine($"  [{item.Severity}] {item.Operator}{legacyTag}{benefitTag}: {EscapeNewlines(item.Data)}");
+                    writer.WriteLine($"  [{item.Severity}] {item.Operator}{SourceTag(item.Source)}{legacyTag}{benefitTag}: {EscapeNewlines(item.Data)}");
                 }
                 writer.WriteLine($"  -> {group.Key.Item2}");
             }
@@ -394,7 +394,7 @@ public static class TextFormatter
                     var benefitTag = item.Benefit.HasValue
                         ? $" (up to {(item.Benefit.Value >= 100 ? item.Benefit.Value.ToString("N0") : item.Benefit.Value.ToString("N1"))}% benefit)"
                         : "";
-                    writer.WriteLine($"  [{item.Severity}] {item.Operator}{legacyTag}{benefitTag}: {EscapeNewlines(full)}");
+                    writer.WriteLine($"  [{item.Severity}] {item.Operator}{SourceTag(item.Source)}{legacyTag}{benefitTag}: {EscapeNewlines(full)}");
                 }
             }
         }
@@ -420,6 +420,14 @@ public static class TextFormatter
     /// survive the top-level line split in AdviceContentBuilder.Build().
     /// CreateWarningBlock splits on U+001F to restore the internal structure.
     /// </summary>
+    /// <summary>
+    /// #436: marks the warnings SQL Server itself put in the plan, so they read differently from our
+    /// inferences. Only the engine's are tagged — they are the minority and the ones carrying extra
+    /// authority, and tagging all of them would just be noise on every line.
+    /// </summary>
+    private static string SourceTag(string? source) =>
+        source == nameof(PlanViewer.Core.Models.PlanWarningSource.SqlServer) ? " [SQL Server]" : "";
+
     private static string EscapeNewlines(string text) => text.Replace('\n', '\x1F');
 
     private static void CollectNodeTimings(

--- a/src/PlanViewer.Core/Services/ShowPlanParser.Warnings.cs
+++ b/src/PlanViewer.Core/Services/ShowPlanParser.Warnings.cs
@@ -332,6 +332,12 @@ public static partial class ShowPlanParser
             });
         }
 
+        /* #436: stamped here rather than on each of the constructions above, so that everything read
+           out of the plan's own <Warnings> element is marked as the engine's, including whatever gets
+           added to this method next. This is the only place parser warnings are built. */
+        foreach (var warning in result)
+            warning.Source = PlanWarningSource.SqlServer;
+
         return result;
     }
 }

--- a/tests/PlanViewer.Core.Tests/HistoricalCliContractTests.cs
+++ b/tests/PlanViewer.Core.Tests/HistoricalCliContractTests.cs
@@ -6,8 +6,13 @@ namespace PlanViewer.Core.Tests;
 
 public sealed class HistoricalCliContractTests
 {
+    /* Rolled for #436, which adds "source" to every warning in the JSON output so a consumer can tell
+       SQL Server's own warnings from Performance Studio's inferences. The change is additive — nothing
+       was removed or renamed, so a consumer reading fields by name is unaffected — but anything
+       diffing or hashing whole output sees different bytes, which is exactly what this constant is
+       here to make somebody decide on rather than discover. */
     private const string ExpectedCompactOutputSha256 =
-        "0c609fed8e250d9366eb9a6cd5eaf40b661ee30d7ba2546bd7726960592e9d87";
+        "06975e4e513eef23669c86bc2cfeec916f442461d605060bbd996bd44df13405";
 
     [Fact]
     public async Task AnalyzeCompact_PreservesHistoricalOutputBytes()

--- a/tests/PlanViewer.Core.Tests/WarningSourceTests.cs
+++ b/tests/PlanViewer.Core.Tests/WarningSourceTests.cs
@@ -1,0 +1,106 @@
+using System.IO;
+using System.Linq;
+using PlanViewer.Core.Models;
+using PlanViewer.Core.Output;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #436: a reader could not tell which warnings SQL Server itself raised and which ones we inferred,
+/// because both arrive as a <see cref="PlanWarning"/> with nothing but type, severity and message.
+///
+/// The distinction matters more than presentation. A warning the engine wrote into the plan's own
+/// &lt;Warnings&gt; element is a record of what happened when the query ran — it spilled, it converted,
+/// it had no statistics. One of our rules is an inference from plan shape, and an inference can be
+/// wrong about a particular plan in a way the engine's own record cannot be. #436 was itself an
+/// example: we claimed a conversion prevented a seek on a plan SQL Server had raised no conversion
+/// warning about at all.
+/// </summary>
+public class WarningSourceTests
+{
+    /// <summary>
+    /// One plan carrying both kinds. "Implicit Conversion" is lifted from the PlanAffectingConvert
+    /// element SQL Server wrote; "Non-SARGable Predicate" is Rule 12 reading the predicate text.
+    /// </summary>
+    [Fact]
+    public void TheTwoKindsAreToldApartOnAPlanCarryingBoth()
+    {
+        var plan = PlanTestHelper.LoadAndAnalyze("convert_implicit_plan.sqlplan");
+
+        Assert.All(
+            PlanTestHelper.WarningsOfType(plan, "Implicit Conversion"),
+            w => Assert.Equal(PlanWarningSource.SqlServer, w.Source));
+
+        Assert.All(
+            PlanTestHelper.WarningsOfType(plan, "Non-SARGable Predicate"),
+            w => Assert.Equal(PlanWarningSource.PerformanceStudio, w.Source));
+    }
+
+    /// <summary>
+    /// The stamp is applied once, at the single return of ParseWarningsFromElement, rather than at
+    /// each construction — so this asserts the property that arrangement buys: across every committed
+    /// plan, no warning type is ever produced as both kinds. A type appearing as both would mean a
+    /// construction site got missed or an analyzer rule started claiming the engine's authority.
+    /// </summary>
+    [Fact]
+    public void NoWarningTypeIsEverProducedAsBothKinds()
+    {
+        var plansDir = Path.Combine(AppContext.BaseDirectory, "Plans");
+        var confusions =
+            (from file in Directory.GetFiles(plansDir, "*.sqlplan")
+             let plan = PlanTestHelper.LoadAndAnalyze(Path.GetFileName(file))
+             from warning in PlanTestHelper.AllWarnings(plan)
+             group warning.Source by warning.WarningType into byType
+             where byType.Distinct().Count() > 1
+             select byType.Key).ToList();
+
+        Assert.True(confusions.Count == 0,
+            "These types are attributed to both SQL Server and us: " + string.Join(", ", confusions));
+    }
+
+    /// <summary>
+    /// Only the engine's warnings are tagged in rendered output. Tagging both would put a badge on
+    /// every line, which carries no information — our own advice is what a reader already expects
+    /// from a plan analyzer.
+    /// </summary>
+    [Fact]
+    public void OnlyTheEnginesWarningsAreTaggedInTextOutput()
+    {
+        var plan = PlanTestHelper.LoadAndAnalyze("convert_implicit_plan.sqlplan");
+        var result = ResultMapper.Map(plan, "convert_implicit_plan.sqlplan");
+
+        var writer = new StringWriter();
+        TextFormatter.WriteText(result, writer);
+        var text = writer.ToString();
+
+        var tagged = text.Split('\n').Where(l => l.Contains("[SQL Server]")).ToList();
+
+        Assert.NotEmpty(tagged);
+        Assert.All(tagged, line => Assert.Contains("Implicit Conversion", line));
+        Assert.DoesNotContain("Non-SARGable Predicate [SQL Server]", text);
+    }
+
+    /// <summary>The JSON and MCP consumers get it as a field rather than having to parse the tag out.</summary>
+    [Fact]
+    public void TheJsonOutputCarriesTheSource()
+    {
+        var plan = PlanTestHelper.LoadAndAnalyze("convert_implicit_plan.sqlplan");
+        var result = ResultMapper.Map(plan, "convert_implicit_plan.sqlplan");
+
+        var all = result.Statements
+            .SelectMany(s => s.Warnings.Concat(Flatten(s.OperatorTree)))
+            .ToList();
+
+        Assert.Contains(all, w => w.Type == "Implicit Conversion" && w.Source == nameof(PlanWarningSource.SqlServer));
+        Assert.Contains(all, w => w.Type == "Non-SARGable Predicate" && w.Source == nameof(PlanWarningSource.PerformanceStudio));
+        Assert.All(all, w => Assert.NotEqual("", w.Source));
+    }
+
+    private static System.Collections.Generic.IEnumerable<WarningResult> Flatten(OperatorResult? node)
+    {
+        if (node == null) yield break;
+        foreach (var w in node.Warnings) yield return w;
+        foreach (var child in node.Children)
+            foreach (var w in Flatten(child)) yield return w;
+    }
+}


### PR DESCRIPTION
The second half of #436 — telling SQL Server's warnings apart from ours. Independent of #436's rule fix; either can merge without the other.

## The problem

Both kinds arrive as a `PlanWarning` carrying nothing but type, severity and message, and both render identically. 14 warning constructions in `ShowPlanParser.Warnings.cs` are lifted straight out of the plan's own `<Warnings>` element; 47 across `PlanAnalyzer*.cs` are our rules reading plan shape. Nothing in the model or the output said which was which.

It isn't cosmetic. A warning SQL Server wrote into the plan is a record of what the engine did — it spilled, it converted, it had no statistics. One of our rules is an inference, and an inference can be wrong about a particular plan in a way the engine's own record cannot be.

The same issue supplies the example: we told this reporter a conversion prevented an index seek on a plan SQL Server had raised **no** conversion warning about. Being able to see "that line is ours, this line is the engine's" is what would have let him weigh the two himself.

## How it's attributed

`PlanWarning.Source` defaults to `PerformanceStudio`, and everything the parser produces is stamped `SqlServer` in **one** place — the single return of `ParseWarningsFromElement`, which every parser warning already funnels through.

Stamping the 14 construction sites individually would have been the same bug as the one in #430's original fix: a rule you have to remember at each site is a rule that eventually gets forgotten. A new engine warning added to that method is attributed correctly without anyone thinking about it.

## UX (left to me, so: what and why)

- **Only the engine's warnings are tagged**, as `[SQL Server]`, in both the GUI warnings panel and the CLI text output. Tagging both kinds would put a badge on every line and carry no information — our own advice is what a reader already expects from a plan analyzer, so the marked case should be the exception. Easy to invert if you disagree.
- The tag sits beside the existing `[legacy]` tag and is built the same way, since that badge already established the idiom.
- JSON and MCP consumers get a `source` field rather than having to parse a tag out of a string.

```
[Critical] Implicit Conversion [SQL Server] [legacy]: Seek Plan: CONVERT_IMPLICIT(nvarchar(40),[ub].[DisplayName],0)=[@d]
[Warning]  Index Scan on ... (up to 100% benefit): Implicit conversion (CONVERT_IMPLICIT) prevents an index seek...
```

## CLI output contract — flagged, not slipped in

Adding `source` to every warning changes the bytes of `analyze --compact`, so `HistoricalCliContractTests.ExpectedCompactOutputSha256` is rolled. The change is additive — nothing removed or renamed, so a consumer reading fields by name is unaffected — but anything hashing or diffing whole output sees a difference. That constant exists to make this a decision instead of a discovery, so it is called out rather than quietly updated.

The characterization baseline is untouched: it digests type, severity and message, none of which changed.

## Tests

New tests pin both kinds on one plan carrying both, that no warning type is ever produced as both kinds across every committed plan, that only the engine's are tagged in text output, and that the JSON field is populated. 65 tests, 0 failures. `dotnet build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
