### PR TITLE
Bump version to 1.20.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
     website: "https://erikdarling.com"
 repository-code: "https://github.com/erikdarlingdata/PerformanceStudio"
 license: MIT
-version: "1.19.1"
-date-released: "2026-07-29"
+version: "1.20.0"
+date-released: "2026-08-21"
 keywords:
   - sql-server
   - execution-plan

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
     Tests and server/ projects are outside src/ and are unaffected.
   -->
   <PropertyGroup>
-    <Version>1.19.1</Version>
+    <Version>1.20.0</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
+++ b/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
@@ -7,5 +7,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Performance Studio for SSMS")]
 [assembly: AssemblyCopyright("Copyright Darling Data 2026")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("1.19.1.0")]
-[assembly: AssemblyFileVersion("1.19.1.0")]
+[assembly: AssemblyVersion("1.20.0.0")]
+[assembly: AssemblyFileVersion("1.20.0.0")]

--- a/src/PlanViewer.Ssms/source.extension.vsixmanifest
+++ b/src/PlanViewer.Ssms/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="PlanViewer.Ssms.64F79022-9D9A-4463-A1AE-4B19426A0CB1"
-              Version="1.19.1"
+              Version="1.20.0"
               Language="en-US"
               Publisher="Darling Data" />
     <DisplayName>Performance Studio for SSMS</DisplayName>


### PR DESCRIPTION
Version bump for v1.20.0. Merging this to `dev` publishes nothing — the release fires when `dev` is merged to `main`.

## Why minor, not patch

1.19.2 would understate it. #439 adds a `source` field to every warning in the JSON and MCP output and a new badge in the app and CLI, and #437 changes what an existing analysis rule concludes about a plan. Both are noticeable to a consumer, and one of them is output-shape.

## What ships

**User-facing**

- **#437** — Rule 12 no longer calls a conversion non-SARGable when it converts the *parameter* rather than the column. Plans carrying a parameter-side conversion on a scan lose that warning and report the scan's residual predicate instead. Verified against all 38 committed plans: **no other plan's verdict moves.**
- **#439** — SQL Server's own warnings are now told apart from ours: tagged `[SQL Server]` in the app and CLI, carried as `source` in JSON/MCP. Additive, but it changes the bytes of `analyze --compact` (`ExpectedCompactOutputSha256` was rolled deliberately).
- **#431** — Robot Advice no longer takes the app down on a deep plan.
- **#438** — `querystore` gets the same depth ceiling `analyze` got. It had been failing quietly on deep plans — one `ERROR` row in `summary.txt` per plan — for as long as `analyze` had been fine.
- **#443** — the macOS handle resolver no longer corrupts memory on Apple silicon.
- **#425** — Entra MFA works again (WAM parent window handle).

**Not user-facing, but relevant to anyone building from this tag**

- **#442** — the suite runs on Microsoft.Testing.Platform now (forced by `xunit.v3` 4.0.0 dropping VSTest on .NET 10).
- **#443** — `dotnet test` finishes on macOS for the first time: 307 tests, 305 passing, 13 seconds. It previously did not complete at all.

## Issues this closes on release

#430, #435, #436 — all three have been waiting on a release, and two have reporters who supplied a crash log and a repro script.

## Verification

- `dotnet build` clean (the 9 warnings are the pre-existing `MCP9005` obsolete-API uses in `McpSmokeTests.cs`).
- Full `dotnet test` on macOS ARM64: 307 total, 305 passed, 0 failed, 2 skipped.
- CI green on every constituent PR.
- Same four files the v1.19.1 bump touched, no more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
