### PR TITLE
Offer Compare Plans across query sessions, not just within one (#447)

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.Plans.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.Plans.cs
@@ -220,7 +220,30 @@ public partial class QuerySessionControl : UserControl
         }
     }
 
+    /// <summary>
+    /// #447: asks the window, not this session. Comparing the plan from one query against the plan
+    /// from another is the ordinary case, and counting only this session's own tabs left the button
+    /// disabled in both — the reporter had to save a plan and reopen it to get at a comparison the
+    /// app could already do.
+    /// </summary>
     private void UpdateCompareButtonState()
+    {
+        if (TopLevel.GetTopLevel(this) is MainWindow owner)
+        {
+            /* Refreshes every session, not just this one: a plan appearing here can be the second
+               plan that makes Compare available over THERE. */
+            owner.RefreshComparePlanAvailability();
+            return;
+        }
+
+        /* No owning window — the control is being hosted somewhere else or is not attached yet.
+           Fall back to what this session can see rather than leaving the button in a stale state. */
+        SetCompareAvailability(CountOwnPlans() >= 2);
+    }
+
+    internal void SetCompareAvailability(bool enabled) => ComparePlansButton.IsEnabled = enabled;
+
+    private int CountOwnPlans()
     {
         int planCount = 0;
         foreach (var item in SubTabControl.Items)
@@ -228,7 +251,7 @@ public partial class QuerySessionControl : UserControl
             if (item is TabItem t && t.Content is PlanViewerControl v && v.CurrentPlan != null)
                 planCount++;
         }
-        ComparePlansButton.IsEnabled = planCount >= 2;
+        return planCount;
     }
 
     private static string GetTabLabel(TabItem tab)
@@ -242,10 +265,19 @@ public partial class QuerySessionControl : UserControl
 
     private void ComparePlans_Click(object? sender, RoutedEventArgs e)
     {
+        /* #447: hand off to the window's picker, which lists plans from every session and labels
+           them "Query 1 > Plan". This session's own picker cannot see the other query's plan, which
+           is the whole complaint. */
+        if (TopLevel.GetTopLevel(this) is MainWindow owner)
+        {
+            owner.ShowCompareDialog();
+            return;
+        }
+
         var planTabs = GetPlanTabs().ToList();
         if (planTabs.Count < 2)
         {
-            SetStatus("Need at least 2 plan tabs to compare");
+            SetStatus("Need at least 2 plans open to compare");
             return;
         }
 

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml
@@ -61,7 +61,7 @@
                             Click="ComparePlans_Click"
                             Height="28" Padding="8,0" FontSize="12" IsEnabled="False"
                             Theme="{StaticResource AppButton}"
-                            ToolTip.Tip="Compare two plan tabs"/>
+                            ToolTip.Tip="Compare any two plans open in this window"/>
                     <TextBlock Text="|" VerticalAlignment="Center"
                                Foreground="{DynamicResource ForegroundBrush}" Margin="2,0"/>
                     <Button x:Name="QueryStoreButton" Content="&#x1F4CA; Query Store"

--- a/src/PlanViewer.App/MainWindow.PlanViewer.cs
+++ b/src/PlanViewer.App/MainWindow.PlanViewer.cs
@@ -220,7 +220,7 @@ public partial class MainWindow : Window
         AdviceWindowHelper.Show(this, title, content, analysis, sourceViewer);
     }
 
-    private void ShowCompareDialog()
+    internal void ShowCompareDialog()
     {
         var planTabs = CollectAllPlanTabs();
         if (planTabs.Count < 2)

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
 using System.IO.Pipes;
 using System.Linq;
@@ -73,6 +74,14 @@ public partial class MainWindow : Window
 
         // Track tab changes to update empty overlay
         MainTabControl.SelectionChanged += (_, _) => UpdateEmptyOverlay();
+
+        /* #447: one subscription rather than a call at each of the sixteen places that add or
+           remove a tab. Compare Plans depends on how many plans exist across the WHOLE window, so
+           opening or closing any tab can change whether it is available in every OTHER tab, and a
+           refresh that has to be remembered at sixteen call sites is one that gets forgotten at the
+           seventeenth. */
+        if (MainTabControl.Items is INotifyCollectionChanged tabs)
+            tabs.CollectionChanged += (_, _) => RefreshComparePlanAvailability();
 
         // Global hotkeys via tunnel routing so they fire before AvaloniaEdit consumes them
         AddHandler(KeyDownEvent, (_, e) =>
@@ -277,7 +286,26 @@ public partial class MainWindow : Window
 #pragma warning restore CS0618
 
 
-    private List<(string label, PlanViewerControl viewer)> CollectAllPlanTabs()
+    /// <summary>
+    /// Re-decides whether Compare Plans is offered, for every query session in the window (#447).
+    ///
+    /// <para>The button used to be enabled from a session's OWN plan count, so two queries in two
+    /// separate sessions — one plan each — left it disabled in both, even though comparing them is
+    /// exactly what it is for. The plans were always reachable: <see cref="CollectAllPlanTabs"/>
+    /// spans sessions and is what the file-mode Compare button has always used, which is why saving
+    /// a plan and reopening it worked around this.</para>
+    /// </summary>
+    internal void RefreshComparePlanAvailability()
+    {
+        var comparable = CollectAllPlanTabs().Count >= 2;
+        foreach (var item in MainTabControl.Items)
+        {
+            if (item is TabItem { Content: QuerySessionControl session })
+                session.SetCompareAvailability(comparable);
+        }
+    }
+
+    internal List<(string label, PlanViewerControl viewer)> CollectAllPlanTabs()
     {
         var entries = new List<(string label, PlanViewerControl viewer)>();
 


### PR DESCRIPTION
Fixes #447.

## The bug

`QuerySessionControl.UpdateCompareButtonState()` counted plans in the session's **own** sub-tabs:

```csharp
foreach (var item in SubTabControl.Items)   // ← this session only
    ...
ComparePlansButton.IsEnabled = planCount >= 2;
```

Two queries in two separate sessions means one plan each, so the button stayed disabled in both — which is exactly the comparison it exists for.

## Why the workaround worked

The plans were always reachable. `MainWindow.CollectAllPlanTabs()` spans sessions and labels them `Query 1 > Plan`, and the file-mode Compare button has always used it. Saving a plan and reopening it gave joshdbe a *file* tab, whose button looks at the window-wide collection. Only the session button was looking at the wrong one — in both its enablement and its own narrower picker.

## The fix

The session button asks the window for both, and hands off to the window's picker rather than keeping a second one that can't see past its own session.

Refresh is **one subscription** to `MainTabControl.Items` collection-changed, not a call added at each of the 16 places that add or remove a tab. That matters more here than usual: a plan appearing in one session changes whether Compare is available in *every other* session, so a forgotten call site leaves a stale button somewhere the author never looked.

Kept a fallback to the session's own count for when there's no owning `MainWindow` — control not yet attached, or hosted elsewhere — so the button is never stale rather than throwing.

Tooltip updated; it said "Compare two plan tabs" and now means something wider.

## Verifying without a SQL Server

Worth recording, because two sessions holding real plans otherwise need a live connection: **open two `.sqlplan` files, then New Query.** The session's Compare button is enabled and its picker lists both file plans. On `dev` it stays disabled — the session has no plans of its own and `IsEnabled="False"` is the XAML default.

## No automated test

UI wiring, and the repo has no headless Avalonia harness — a test that would have caught this needs two constructed sessions and a window. A test on the arithmetic would be hollow: `count >= 2` was never the broken part, the **scope** was.

314 tests unchanged, since nothing here touches Core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
