### PR TITLE
Show the whole query error instead of the first 100 characters (#448)

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.Execution.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.Execution.cs
@@ -83,12 +83,17 @@ public partial class QuerySessionControl : UserControl
             Margin = new Avalonia.Thickness(0, 0, 0, 12)
         };
 
-        var statusLabel = new TextBlock
+        /* #448: SelectableTextBlock and wrapping, because this label doubles as the place a query
+           failure is reported. A SQL error is the one string in this app a user most needs to copy
+           somewhere else, and unwrapped it was being clipped by the panel. */
+        var statusLabel = new SelectableTextBlock
         {
             Text = $"Capturing {planType.ToLower()} plan...",
             FontSize = 14,
             Foreground = new SolidColorBrush(Color.Parse("#E4E6EB")),
-            HorizontalAlignment = HorizontalAlignment.Center
+            HorizontalAlignment = HorizontalAlignment.Center,
+            TextAlignment = Avalonia.Media.TextAlignment.Center,
+            TextWrapping = TextWrapping.Wrap
         };
 
         var cancelBtn = new Button
@@ -211,16 +216,42 @@ public partial class QuerySessionControl : UserControl
         }
         catch (SqlException ex)
         {
-            statusLabel.Text = ex.Message.Length > 100 ? ex.Message[..100] + "..." : ex.Message;
-            progressBar.IsVisible = false;
-            cancelBtn.IsVisible = false;
+            ShowExecutionFailure(loadingPanel, statusLabel, progressBar, cancelBtn, ex.Message);
         }
         catch (Exception ex)
         {
-            statusLabel.Text = ex.Message.Length > 100 ? ex.Message[..100] + "..." : ex.Message;
-            progressBar.IsVisible = false;
-            cancelBtn.IsVisible = false;
+            ShowExecutionFailure(loadingPanel, statusLabel, progressBar, cancelBtn, ex.Message);
         }
+    }
+
+    /// <summary>
+    /// Reports a query failure in the plan tab, in full (#448).
+    ///
+    /// <para>It used to be cut to 100 characters with an ellipsis, in a panel fixed at 300px wide
+    /// holding a non-wrapping label — three separate reasons the same message got clipped, and
+    /// between them a SQL error was routinely unreadable. 100 characters does not even reach the end
+    /// of "Msg 208, Level 16, State 1, Procedure X, Line N" before the sentence naming the actual
+    /// problem starts.</para>
+    ///
+    /// <para>The panel is sized for a spinner and a Cancel button, which is why it is narrow; on
+    /// failure it is re-sized for prose. MaxWidth rather than Width, so a short error stays compact
+    /// and a long one is bounded at a readable measure instead of running the width of the window.</para>
+    /// </summary>
+    private static void ShowExecutionFailure(
+        StackPanel panel,
+        SelectableTextBlock statusLabel,
+        ProgressBar progressBar,
+        Button cancelBtn,
+        string message)
+    {
+        panel.Width = double.NaN;
+        panel.MaxWidth = 640;
+
+        statusLabel.Text = message;
+        statusLabel.Foreground = new SolidColorBrush(Color.Parse("#E57373"));
+
+        progressBar.IsVisible = false;
+        cancelBtn.IsVisible = false;
     }
 
     private async void GetActualPlan_Click(object? sender, RoutedEventArgs e)
@@ -274,12 +305,15 @@ public partial class QuerySessionControl : UserControl
             Margin = new Avalonia.Thickness(0, 0, 0, 12)
         };
 
-        var statusLabel = new TextBlock
+        /* #448: see the note on the estimated-plan path — this label reports failures too. */
+        var statusLabel = new SelectableTextBlock
         {
             Text = "Capturing actual plan...",
             FontSize = 14,
             Foreground = new SolidColorBrush(Color.Parse("#E4E6EB")),
-            HorizontalAlignment = HorizontalAlignment.Center
+            HorizontalAlignment = HorizontalAlignment.Center,
+            TextAlignment = Avalonia.Media.TextAlignment.Center,
+            TextWrapping = TextWrapping.Wrap
         };
 
         var cancelBtn = new Button
@@ -385,15 +419,11 @@ public partial class QuerySessionControl : UserControl
         }
         catch (SqlException ex)
         {
-            statusLabel.Text = ex.Message.Length > 100 ? ex.Message[..100] + "..." : ex.Message;
-            progressBar.IsVisible = false;
-            cancelBtn.IsVisible = false;
+            ShowExecutionFailure(loadingPanel, statusLabel, progressBar, cancelBtn, ex.Message);
         }
         catch (Exception ex)
         {
-            statusLabel.Text = ex.Message.Length > 100 ? ex.Message[..100] + "..." : ex.Message;
-            progressBar.IsVisible = false;
-            cancelBtn.IsVisible = false;
+            ShowExecutionFailure(loadingPanel, statusLabel, progressBar, cancelBtn, ex.Message);
         }
         finally
         {


### PR DESCRIPTION
Fixes #448.

## Cut off three times, not once

- **`ex.Message[..100] + "..."`** at four sites in `Execution.cs`. A hundred characters doesn't even clear `Msg 208, Level 16, State 1, Server X, Line 1` before the sentence naming the actual problem starts — so the truncation reliably removed the only part worth reading.
- **`statusLabel` had no `TextWrapping`**, so it defaulted to `NoWrap` and clipped whatever survived.
- **`loadingPanel` is a fixed `Width = 300`**, sized for a spinner and a Cancel button, not prose.

Any one alone would cut a real SQL error. Together they made it close to useless, which matches the report.

## The fix

All four catch sites go through one helper instead of repeating the display logic — they were already identical and already wrong in the same way, which is what a copied line does over time.

The helper widens the panel on failure (`MaxWidth` rather than `Width`, so a short error stays compact and a long one is bounded at a readable measure instead of running the window), wraps, and colours it as an error.

The label is now a `SelectableTextBlock`. A SQL error is the one string in this app you most need to paste somewhere else, and it couldn't be selected.

## Verified against a real server

SQL Server 2025 in Docker. A query against a deliberately long object name produces a **191-character** error where the old path stopped mid-word:

```
Invalid object name 'dbo.ThisTableNameIsDeliberatelyVeryLongIndeedSoThatTheResulting…'.
```

## Flagged, not folded in

`QueryStore.cs:219` truncates at 80 characters before handing the text to a status bar that already does `TextTrimming="CharacterEllipsis"` — redundant and lossy, same family, but a different surface with no issue filed against it.

## No automated test

UI wiring, no headless Avalonia harness. Two bugs in one evening now sit in that gap, which is worth a decision about `Avalonia.Headless` rather than a hollow test asserting a string isn't truncated by code that no longer truncates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
