### PR TITLE
Add a headless Avalonia harness, and use it on #447 and #448

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.Execution.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.Execution.cs
@@ -237,7 +237,7 @@ public partial class QuerySessionControl : UserControl
     /// failure it is re-sized for prose. MaxWidth rather than Width, so a short error stays compact
     /// and a long one is bounded at a readable measure instead of running the width of the window.</para>
     /// </summary>
-    private static void ShowExecutionFailure(
+    internal static void ShowExecutionFailure(
         StackPanel panel,
         SelectableTextBlock statusLabel,
         ProgressBar progressBar,

--- a/src/PlanViewer.App/MainWindow.FileOps.cs
+++ b/src/PlanViewer.App/MainWindow.FileOps.cs
@@ -26,7 +26,7 @@ namespace PlanViewer.App;
 
 public partial class MainWindow : Window
 {
-    private void NewQuery_Click(object? sender, RoutedEventArgs e)
+    internal void NewQuery_Click(object? sender, RoutedEventArgs e)
     {
         _queryCounter++;
         var label = $"Query {_queryCounter}";
@@ -188,7 +188,7 @@ public partial class MainWindow : Window
         }
     }
 
-    private void LoadPlanFile(string filePath)
+    internal void LoadPlanFile(string filePath)
     {
         try
         {

--- a/tests/PlanViewer.Core.Tests/ComparePlansAvailabilityTests.cs
+++ b/tests/PlanViewer.Core.Tests/ComparePlansAvailabilityTests.cs
@@ -1,0 +1,100 @@
+using System.IO;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using PlanViewer.App;
+using PlanViewer.App.Controls;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #447: Compare Plans stayed disabled when the two plans lived in two different query sessions,
+/// which is the ordinary case — run a query, rewrite it, run it again in a second tab. The button's
+/// enablement counted only the session's OWN plan tabs, while the picker behind it had always been
+/// able to see across sessions. The reporter had to save a plan and reopen it to get at a comparison
+/// the app could already do.
+///
+/// The scenario is built from plan FILES rather than executed queries deliberately: getting a plan
+/// into a session needs a live SQL Server, and the defect does not require one. What it requires is
+/// plans existing somewhere OTHER than the session whose button is being judged, which two file tabs
+/// provide exactly.
+/// </summary>
+public class ComparePlansAvailabilityTests
+{
+    [Fact]
+    public void ASessionOffersCompareWhenThePlansAreElsewhereInTheWindow()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new MainWindow();
+
+            window.LoadPlanFile(PlanPath("row_goal_plan.sqlplan"));
+            window.LoadPlanFile(PlanPath("key_lookup_plan.sqlplan"));
+            window.NewQuery_Click(window, new RoutedEventArgs());
+
+            /* None of these sessions hold plans of their own — precisely the state that used to
+               disable the button, and precisely the state the reporter was in. Asserted across every
+               session rather than one, because the fix has to reach all of them. */
+            var sessions = Sessions(window).ToList();
+            Assert.NotEmpty(sessions);
+            Assert.All(sessions, session => Assert.Empty(session.GetPlanTabs()));
+            Assert.All(sessions, session => Assert.True(
+                CompareButton(session).IsEnabled,
+                "two plans are open in this window, so every session should offer to compare them"));
+        });
+    }
+
+    [Fact]
+    public void ASingleOpenPlanIsStillNotEnoughToCompare()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new MainWindow();
+
+            window.LoadPlanFile(PlanPath("row_goal_plan.sqlplan"));
+            window.NewQuery_Click(window, new RoutedEventArgs());
+
+            Assert.All(Sessions(window), session => Assert.False(
+                CompareButton(session).IsEnabled,
+                "one plan cannot be compared against anything"));
+        });
+    }
+
+    /// <summary>
+    /// The part that needed a window-wide refresh rather than a per-session one: a plan opening in
+    /// one place has to light the button up everywhere else, including in sessions that existed
+    /// before it arrived.
+    /// </summary>
+    [Fact]
+    public void OpeningASecondPlanEnablesCompareInASessionThatAlreadyExisted()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new MainWindow();
+
+            window.NewQuery_Click(window, new RoutedEventArgs());
+            window.LoadPlanFile(PlanPath("row_goal_plan.sqlplan"));
+
+            var sessions = Sessions(window).ToList();
+            Assert.NotEmpty(sessions);
+            Assert.All(sessions, session => Assert.False(CompareButton(session).IsEnabled));
+
+            window.LoadPlanFile(PlanPath("key_lookup_plan.sqlplan"));
+
+            Assert.All(sessions, session => Assert.True(CompareButton(session).IsEnabled,
+                "the session existed before the second plan did, and must still notice it"));
+        });
+    }
+
+    private static string PlanPath(string name) =>
+        Path.Combine(System.AppContext.BaseDirectory, "Plans", name);
+
+    private static System.Collections.Generic.IEnumerable<QuerySessionControl> Sessions(MainWindow window) =>
+        window.FindControl<TabControl>("MainTabControl")!.Items
+            .OfType<TabItem>()
+            .Select(tab => tab.Content)
+            .OfType<QuerySessionControl>();
+
+    private static Button CompareButton(QuerySessionControl session) =>
+        session.FindControl<Button>("ComparePlansButton")!;
+}

--- a/tests/PlanViewer.Core.Tests/ExecutionFailureDisplayTests.cs
+++ b/tests/PlanViewer.Core.Tests/ExecutionFailureDisplayTests.cs
@@ -1,0 +1,113 @@
+using Avalonia.Controls;
+using Avalonia.Media;
+using PlanViewer.App.Controls;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #448: a failed query reported an error that was cut off, three separate times over — truncated to
+/// 100 characters in code, then clipped by a label with no wrapping, inside a panel fixed at 300px.
+///
+/// These are the first tests in this suite to construct real Avalonia controls. That is the point:
+/// #447 and #448 were both genuine bugs that no test could reach, because every test here worked on
+/// Core models and the defects were in the UI. See <see cref="HeadlessUi"/> for why the session is
+/// hand-rolled.
+/// </summary>
+public class ExecutionFailureDisplayTests
+{
+    /// <summary>A real SQL error, longer than the old ceiling. Msg 208 with a long object name.</summary>
+    private const string LongSqlError =
+        "Invalid object name 'dbo.ThisTableNameIsDeliberatelyVeryLongIndeedSoThatTheResultingErrorMessageComfortablyExceedsOneHundredCharacters'.";
+
+    [Fact]
+    public void TheWholeErrorIsShown()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var (panel, label, progress, cancel) = BuildLoadingPanel();
+
+            QuerySessionControl.ShowExecutionFailure(panel, label, progress, cancel, LongSqlError);
+
+            Assert.Equal(LongSqlError, label.Text);
+            Assert.True(LongSqlError.Length > 100, "the fixture must exceed the ceiling it is pinning");
+            Assert.DoesNotContain("...", label.Text!, System.StringComparison.Ordinal);
+        });
+    }
+
+    /// <summary>
+    /// Showing the whole string is not enough on its own — without wrapping it is clipped by the
+    /// panel instead of by the substring, which looks identical to the user. Both halves of #448.
+    /// </summary>
+    [Fact]
+    public void TheErrorWrapsInsteadOfBeingClipped()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var (panel, label, progress, cancel) = BuildLoadingPanel();
+
+            QuerySessionControl.ShowExecutionFailure(panel, label, progress, cancel, LongSqlError);
+
+            Assert.Equal(TextWrapping.Wrap, label.TextWrapping);
+        });
+    }
+
+    /// <summary>
+    /// The panel is sized for a spinner and a Cancel button. An error needs room, but bounded room —
+    /// MaxWidth rather than Width, so a short error stays compact and a long one does not run the
+    /// full width of the window.
+    /// </summary>
+    [Fact]
+    public void ThePanelStopsBeingSpinnerSizedOnFailure()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var (panel, label, progress, cancel) = BuildLoadingPanel();
+            Assert.Equal(300, panel.Width);
+
+            QuerySessionControl.ShowExecutionFailure(panel, label, progress, cancel, LongSqlError);
+
+            Assert.True(double.IsNaN(panel.Width), "a fixed width would still clip the message");
+            Assert.True(panel.MaxWidth is > 300 and < double.PositiveInfinity,
+                "unbounded would let a long error run the width of the window");
+        });
+    }
+
+    /// <summary>The spinner and Cancel button belong to a running query, not a failed one.</summary>
+    [Fact]
+    public void TheProgressAffordancesGoAway()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var (panel, label, progress, cancel) = BuildLoadingPanel();
+
+            QuerySessionControl.ShowExecutionFailure(panel, label, progress, cancel, LongSqlError);
+
+            Assert.False(progress.IsVisible);
+            Assert.False(cancel.IsVisible);
+        });
+    }
+
+    /// <summary>
+    /// A SQL error is the string in this app a user most needs to paste somewhere else, and the
+    /// label it lands in used to be a plain TextBlock.
+    /// </summary>
+    [Fact]
+    public void TheErrorCanBeSelected()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var (_, label, _, _) = BuildLoadingPanel();
+            Assert.IsAssignableFrom<SelectableTextBlock>(label);
+        });
+    }
+
+    /// <summary>Mirrors how QuerySessionControl builds the loading tab, including the 300px width.</summary>
+    private static (StackPanel Panel, SelectableTextBlock Label, ProgressBar Progress, Button Cancel) BuildLoadingPanel()
+    {
+        var label = new SelectableTextBlock { Text = "Capturing actual plan...", TextWrapping = TextWrapping.Wrap };
+        var progress = new ProgressBar { IsIndeterminate = true, IsVisible = true };
+        var cancel = new Button { Content = "Cancel", IsVisible = true };
+        var panel = new StackPanel { Width = 300, Children = { progress, label, cancel } };
+        return (panel, label, progress, cancel);
+    }
+}

--- a/tests/PlanViewer.Core.Tests/HeadlessUi.cs
+++ b/tests/PlanViewer.Core.Tests/HeadlessUi.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Headless;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// A headless Avalonia session, so UI code can be tested without a display.
+///
+/// <para><b>Why this is hand-rolled rather than Avalonia.Headless.XUnit.</b> That package exists and
+/// would be less code, but at 11.3.20 it depends on <c>xunit.core 2.4.0</c> — xunit v2 — and this
+/// suite runs on xunit.v3. Putting two xunit frameworks in one test project to get an attribute is a
+/// worse trade than owning fifteen lines. <see cref="HeadlessUnitTestSession"/> is runner-agnostic
+/// and is what that package wraps anyway.</para>
+///
+/// <para><b>The real App, not a stub.</b> A bare Application looked tidier but does not load the
+/// application XAML, and MainWindow's toolbars resolve styles from it — FindResource("AppButton")
+/// throws without them, which surfaces as an unrelated-looking "Failed to open" dialog. App.Initialize
+/// loads those resources, and its OnFrameworkInitializationCompleted only creates a window under a
+/// classic desktop lifetime, which a headless session is not, so nothing is spawned behind the
+/// tests.</para>
+///
+/// <para><b>One session for the whole assembly.</b> Avalonia allows a single Application per
+/// process, so this cannot be per-test or per-class. It is created on first use and never disposed:
+/// the process is about to exit, and tearing an Avalonia session down while another test class may
+/// still be queued is a good way to reintroduce the kind of test-host wedge #441 was about.</para>
+/// </summary>
+internal static class HeadlessUi
+{
+    private static readonly Lazy<HeadlessUnitTestSession> Session =
+        new(() => HeadlessUnitTestSession.StartNew(typeof(PlanViewer.App.App)),
+            System.Threading.LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <summary>
+    /// Runs <paramref name="body"/> on the Avalonia UI thread and rethrows anything it threw, so an
+    /// assertion failure inside surfaces as a test failure rather than a swallowed task.
+    /// </summary>
+    internal static void Run(Action body)
+    {
+        Session.Value.Dispatch(() =>
+        {
+            body();
+            return Task.CompletedTask;
+        }, default).GetAwaiter().GetResult();
+    }
+}

--- a/tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj
+++ b/tests/PlanViewer.Core.Tests/PlanViewer.Core.Tests.csproj
@@ -32,6 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Avalonia.Headless" Version="11.3.20" />
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="2.3.3" />


### PR DESCRIPTION
Closes the test gap that #447 and #448 both fell into. Both were real bugs no test here could reach, because every test works on Core models and the defects were in the UI.

## Why hand-rolled

`Avalonia.Headless.XUnit` exists and would be less code, but at 11.3.20 it depends on **`xunit.core 2.4.0` — xunit v2** — and this suite runs xunit.v3. Two xunit frameworks in one test project to obtain an attribute is a worse trade than owning fifteen lines. `HeadlessUi` drives `HeadlessUnitTestSession` directly, which is runner-agnostic and is what that package wraps anyway.

## Two things learned the hard way, written into the harness

- **The session runs the real `App`, not a stub.** A bare `Application` looked tidier but doesn't load the application XAML, and `MainWindow`'s toolbars resolve styles from it. `FindResource("AppButton")` throws without them — surfacing as an unrelated-looking *"Failed to open"* dialog rather than anything resembling a missing style. `App.OnFrameworkInitializationCompleted` only creates a window under a classic desktop lifetime, which a headless session isn't, so nothing is spawned behind the tests.
- **One session for the whole assembly**, lazily created and never disposed. Avalonia allows one `Application` per process, and tearing a session down while another test class may still be queued is a good way to reintroduce the kind of wedge #441 was about.

## The tests were checked by reverting the fixes

That's the only way to know they test anything.

| | reverted | result |
|---|---|---|
| #448 | old truncation + fixed width | 2 of 5 fail |
| #447 | old session-only scope | 2 of 3 fail |

**Worth recording, because it nearly fooled me:** my first attempt at reverting #447 reverted only `UpdateCompareButtonState`, and all three tests still passed. That wasn't the tests being weak — it was the revert being incomplete, because the window-level subscription was still doing the work. Reverting *both* halves fails two of three, and the one that still passes is the one asserting a single plan is never enough to compare, which should hold either way. **A partial revert is not a check.**

## Stability

Putting Avalonia into the test process is exactly the shape of change that produced #441, so this was measured rather than hoped: **three consecutive full runs, 320 passing, 0 failed, 15–16s each, no wedges.**

## Surface changes

Three members became `internal` for this — `MainWindow.LoadPlanFile`, `MainWindow.NewQuery_Click`, `QuerySessionControl.ShowExecutionFailure`. `InternalsVisibleTo` to the test project already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
