### PR TITLE
Stop cutting Query Store errors before the status bar can trim them

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.Editor.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.Editor.cs
@@ -315,6 +315,11 @@ public partial class QuerySessionControl : UserControl
 
         StatusText.Text = text;
 
+        /* The bar is one line and trims with an ellipsis, so a long message - an error, usually -
+           is readable only on hover. Setting the tip to the same text costs nothing when it fits and
+           is the difference between a truncated error and a recoverable one when it does not. */
+        ToolTip.SetTip(StatusText, string.IsNullOrEmpty(text) ? null : text);
+
         if (autoClear && !string.IsNullOrEmpty(text))
         {
             var cts = new CancellationTokenSource();

--- a/src/PlanViewer.App/Controls/QuerySessionControl.QueryStore.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.QueryStore.cs
@@ -216,7 +216,12 @@ public partial class QuerySessionControl : UserControl
         }
         catch (Exception ex)
         {
-            SetStatus(ex.Message.Length > 80 ? ex.Message[..80] + "..." : ex.Message, autoClear: false);
+            /* Was cut to 80 characters here before being handed to a status bar that already does
+               TextTrimming="CharacterEllipsis". The trimming is the bar's job and it does it against
+               the actual available width; doing it again in code just threw away text the control
+               would have kept, and with it the tooltip that now carries the full message. Same
+               family as #448. */
+            SetStatus(ex.Message, autoClear: false);
             return;
         }
 


### PR DESCRIPTION
Same family as #448, different surface — the loose end I flagged when that merged.

`QueryStore.cs` cut the message to 80 characters and appended an ellipsis before handing it to `StatusText`, which already has `TextTrimming="CharacterEllipsis"`. The trimming is the control's job and it does it against the actual available width; doing it again in code threw away text the control would otherwise have kept.

It also cost the only way to recover the rest. The bar is one line, so a long message is readable on hover or not at all — `SetStatus` now sets the tip to the full text. That costs nothing when the message fits, and is the difference between a truncated error and a recoverable one when it doesn't. It applies to every status rather than just this one, because every status goes through the same bar under the same one-line constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)