### PR TITLE
Bump version to 1.21.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ authors:
     website: "https://erikdarling.com"
 repository-code: "https://github.com/erikdarlingdata/PerformanceStudio"
 license: MIT
-version: "1.20.0"
+version: "1.21.0"
 date-released: "2026-08-21"
 keywords:
   - sql-server

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
     Tests and server/ projects are outside src/ and are unaffected.
   -->
   <PropertyGroup>
-    <Version>1.20.0</Version>
+    <Version>1.21.0</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
+++ b/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
@@ -7,5 +7,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Performance Studio for SSMS")]
 [assembly: AssemblyCopyright("Copyright Darling Data 2026")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("1.20.0.0")]
-[assembly: AssemblyFileVersion("1.20.0.0")]
+[assembly: AssemblyVersion("1.21.0.0")]
+[assembly: AssemblyFileVersion("1.21.0.0")]

--- a/src/PlanViewer.Ssms/source.extension.vsixmanifest
+++ b/src/PlanViewer.Ssms/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="PlanViewer.Ssms.64F79022-9D9A-4463-A1AE-4B19426A0CB1"
-              Version="1.20.0"
+              Version="1.21.0"
               Language="en-US"
               Publisher="Darling Data" />
     <DisplayName>Performance Studio for SSMS</DisplayName>


### PR DESCRIPTION
Version bump for v1.21.0. Merging this to `dev` publishes nothing — the release fires when `dev` is merged to `main`.

**Minor, not patch**, on the same reasoning as 1.20.0: #440 adds `origin_node_ids` to every warning in the JSON and MCP output, and an output-shape change isn't a patch even when it's additive.

## What ships

All three were reported by users of 1.20.0 in the two days since it went out.

- **#440** — warnings record which operator produced them, and link to it. The ones that genuinely have no operator behind them (`High Compile CPU` happened before a row was read) deliberately have none, because a wrong link is worse than no link. The statement panel also gained an **Operator Warnings** index.
- **#447** — Compare Plans works across query sessions. Two queries in two tabs is the ordinary case, and the button was disabled for it even though the picker behind it could always see both.
- **#448** — a failed query shows its whole error. It was cut three times over: truncated to 100 characters, clipped by a non-wrapping label, inside a panel fixed at 300px. It's also selectable now.

Not user-facing: Query Store errors are no longer cut to 80 characters before reaching a status bar that already trims, and the bar carries the full text as a tooltip.

## The suite can test the UI now

#447 and #448 were both real bugs nothing here could reach. This release also carries a headless Avalonia harness and eight tests over those two defects — each checked by reverting the fix rather than assumed.

## Verification

320 passing, 0 failed, across three consecutive full runs. `dotnet build` clean (the 9 warnings are the pre-existing `MCP9005` obsolete-API uses in `McpSmokeTests.cs`). Same four files the previous bumps touched, no more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)