### PR TITLE
Give queries their own Open and Save in the File menu (#458)

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -32,6 +32,11 @@ public partial class QuerySessionControl : UserControl
     private readonly ICredentialService _credentialService;
     private readonly ConnectionStore _connectionStore;
 
+    /// <summary>
+    /// Full path on disk when the query was loaded from, or last saved to, a file.
+    /// </summary>
+    public string? SourceFilePath { get; set; }
+
     private ServerConnection? _serverConnection;
     private string? _connectionString;
     private string? _selectedDatabase;

--- a/src/PlanViewer.App/MainWindow.FileOps.cs
+++ b/src/PlanViewer.App/MainWindow.FileOps.cs
@@ -72,6 +72,97 @@ public partial class MainWindow : Window
         }
     }
 
+    private async void OpenQuery_Click(object? sender, RoutedEventArgs e)
+    {
+        var files = await StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Open Query",
+            AllowMultiple = true,
+            FileTypeFilter = new[]
+            {
+                new FilePickerFileType("SQL Scripts")
+                {
+                    Patterns = new[] { "*.sql" }
+                },
+                FilePickerFileTypes.All
+            }
+        });
+
+        foreach (var file in files)
+        {
+            var path = file.TryGetLocalPath();
+            if (path != null)
+                LoadSqlFile(path);
+        }
+    }
+
+    private async void SaveQuery_Click(object? sender, RoutedEventArgs e)
+    {
+        await SaveQueryAsync();
+    }
+
+    /// <summary>
+    /// Writes the active query tab's text to disk. Always prompts, but defaults to the
+    /// file the query came from so saving back over it is the path of least resistance.
+    /// Silently does nothing when the active tab is a plan rather than a query - the menu
+    /// item is reachable from anywhere and there is nothing to save.
+    /// </summary>
+    private async Task SaveQueryAsync()
+    {
+        if (MainTabControl.SelectedItem is not TabItem { Content: QuerySessionControl session } tab)
+            return;
+
+        var existing = session.SourceFilePath;
+
+        var options = new FilePickerSaveOptions
+        {
+            Title = "Save Query",
+            SuggestedFileName = existing != null ? Path.GetFileName(existing) : "Query.sql",
+            DefaultExtension = "sql",
+            FileTypeChoices = new[]
+            {
+                new FilePickerFileType("SQL Scripts")
+                {
+                    Patterns = new[] { "*.sql" }
+                },
+                FilePickerFileTypes.All
+            }
+        };
+
+        if (existing != null)
+        {
+            var directory = Path.GetDirectoryName(existing);
+            if (!string.IsNullOrEmpty(directory))
+                options.SuggestedStartLocation = await StorageProvider.TryGetFolderFromPathAsync(directory);
+        }
+
+        var file = await StorageProvider.SaveFilePickerAsync(options);
+
+        var path = file?.TryGetLocalPath();
+        if (path != null)
+            SaveQueryToPath(tab, session, path);
+    }
+
+    /// <summary>
+    /// The half of saving that does not need a human: write the text, remember where it went,
+    /// and retitle the tab to match. Split out from the picker so it can be tested.
+    /// </summary>
+    internal bool SaveQueryToPath(TabItem tab, QuerySessionControl session, string path)
+    {
+        try
+        {
+            File.WriteAllText(path, session.QueryEditor.Text);
+            session.SourceFilePath = path;
+            SetTabLabel(tab, Path.GetFileName(path));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            ShowFileError("Error Saving File", $"Failed to save: {Path.GetFileName(path)}", ex.Message);
+            return false;
+        }
+    }
+
     private async void PasteXml_Click(object? sender, RoutedEventArgs e)
     {
         await PasteXmlAsync();
@@ -141,7 +232,7 @@ public partial class MainWindow : Window
             LoadPlanFile(filePath);
     }
 
-    private void LoadSqlFile(string filePath)
+    internal void LoadSqlFile(string filePath)
     {
         try
         {
@@ -151,6 +242,7 @@ public partial class MainWindow : Window
             _queryCounter++;
             var session = new QuerySessionControl(_credentialService, _connectionStore);
             session.QueryEditor.Text = text;
+            session.SourceFilePath = filePath;
 
             var tab = CreateTab(fileName, session);
             MainTabControl.Items.Add(tab);
@@ -159,33 +251,52 @@ public partial class MainWindow : Window
         }
         catch (Exception ex)
         {
-            var dialog = new Window
+            ShowFileError("Error Opening File", $"Failed to open: {Path.GetFileName(filePath)}", ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// One modal for every file operation that can fail, so opening and saving report
+    /// trouble the same way.
+    ///
+    /// <para>Shown ownerless until this window is visible. Both the command-line open and the
+    /// restore of the previous session's tabs run from the constructor, so a file that is
+    /// missing or unreadable at startup reaches here before there is anything to be modal
+    /// over, and ShowDialog against a window that has not been shown throws rather than
+    /// reporting the problem it was called about.</para>
+    /// </summary>
+    private void ShowFileError(string title, string headline, string detail)
+    {
+        var dialog = new Window
+        {
+            Title = title,
+            Width = 450,
+            Height = 200,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            Content = new StackPanel
             {
-                Title = "Error Opening File",
-                Width = 450,
-                Height = 200,
-                WindowStartupLocation = WindowStartupLocation.CenterOwner,
-                Content = new StackPanel
+                Margin = new Avalonia.Thickness(20),
+                Children =
                 {
-                    Margin = new Avalonia.Thickness(20),
-                    Children =
+                    new TextBlock
                     {
-                        new TextBlock
-                        {
-                            Text = $"Failed to open: {Path.GetFileName(filePath)}",
-                            FontWeight = FontWeight.Bold,
-                            Margin = new Avalonia.Thickness(0, 0, 0, 10)
-                        },
-                        new TextBlock
-                        {
-                            Text = ex.Message,
-                            TextWrapping = TextWrapping.Wrap
-                        }
+                        Text = headline,
+                        FontWeight = FontWeight.Bold,
+                        Margin = new Avalonia.Thickness(0, 0, 0, 10)
+                    },
+                    new TextBlock
+                    {
+                        Text = detail,
+                        TextWrapping = TextWrapping.Wrap
                     }
                 }
-            };
+            }
+        };
+
+        if (IsVisible)
             dialog.ShowDialog(this);
-        }
+        else
+            dialog.Show();
     }
 
     internal void LoadPlanFile(string filePath)

--- a/src/PlanViewer.App/MainWindow.Tabs.cs
+++ b/src/PlanViewer.App/MainWindow.Tabs.cs
@@ -177,6 +177,16 @@ public partial class MainWindow : Window
         }
     }
 
+    /// <summary>
+    /// Retitles a tab. The header is a StackPanel whose first child carries the text,
+    /// which is also what StartRename edits.
+    /// </summary>
+    private static void SetTabLabel(TabItem tab, string label)
+    {
+        if (tab.Header is StackPanel header && header.Children.Count > 0 && header.Children[0] is TextBlock text)
+            text.Text = label;
+    }
+
     private static string? GetTabFilePath(TabItem tab)
     {
         // Plans opened from file are wrapped in a DockPanel with the viewer as the last child

--- a/src/PlanViewer.App/MainWindow.axaml
+++ b/src/PlanViewer.App/MainWindow.axaml
@@ -16,6 +16,11 @@
             <MenuItem Header="_File">
                 <MenuItem Header="New _Query" Click="NewQuery_Click"
                           InputGesture="Ctrl+N"/>
+                <MenuItem Header="Open Q_uery..." Click="OpenQuery_Click"
+                          InputGesture="Ctrl+Shift+O"/>
+                <MenuItem Header="_Save Query..." Click="SaveQuery_Click"
+                          InputGesture="Ctrl+S"/>
+                <Separator/>
                 <MenuItem Header="_Open .sqlplan..." Click="OpenFile_Click"
                           InputGesture="Ctrl+O"/>
                 <MenuItem Header="_Paste Plan XML" Click="PasteXml_Click"

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -98,6 +98,10 @@ public partial class MainWindow : Window
                         OpenFile_Click(this, new RoutedEventArgs());
                         e.Handled = true;
                         break;
+                    case Key.S:
+                        _ = SaveQueryAsync();
+                        e.Handled = true;
+                        break;
                     case Key.W:
                         if (MainTabControl.SelectedItem is TabItem selected)
                         {
@@ -123,6 +127,11 @@ public partial class MainWindow : Window
                         }
                         break;
                 }
+            }
+            else if (e.KeyModifiers == (KeyModifiers.Control | KeyModifiers.Shift) && e.Key == Key.O)
+            {
+                OpenQuery_Click(this, new RoutedEventArgs());
+                e.Handled = true;
             }
             else if (e.KeyModifiers == (KeyModifiers.Control | KeyModifiers.Shift) && e.Key == Key.Tab)
             {

--- a/tests/PlanViewer.Core.Tests/OpenSaveQueryTests.cs
+++ b/tests/PlanViewer.Core.Tests/OpenSaveQueryTests.cs
@@ -1,0 +1,151 @@
+using System.IO;
+using System.Linq;
+using Avalonia.Controls;
+using PlanViewer.App;
+using PlanViewer.App.Controls;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #458: a user asked for File > Open Query, not knowing the app already opened .sql files —
+/// the menu item was labelled "Open .sqlplan..." and said nothing about queries. The feature
+/// that shipped is the pair of menu items, and what has to keep working underneath is that a
+/// .sql file lands in a query session and can be written back out again.
+///
+/// These drive LoadSqlFile and SaveQueryToPath rather than the Click handlers, because the
+/// handlers exist to raise a file picker and a picker cannot be answered headlessly. The
+/// picker chooses a path; everything after that choice is what these cover.
+/// </summary>
+public class OpenSaveQueryTests
+{
+    [Fact]
+    public void OpeningASqlFileFillsAQuerySessionAndRemembersWhereItCameFrom()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1 AS opened;");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                var tab = QueryTabs(window).Last();
+                var session = (QuerySessionControl)tab.Content!;
+
+                Assert.Equal("SELECT 1 AS opened;", session.QueryEditor.Text);
+                Assert.Equal(path, session.SourceFilePath);
+                Assert.Equal(Path.GetFileName(path), TabLabel(tab));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    [Fact]
+    public void SavingWritesTheEditorTextAndRetitlesTheTab()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var opened = TempSql("SELECT 1;");
+            var savedAs = Path.Combine(Path.GetTempPath(), $"renamed_{Path.GetFileName(opened)}");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(opened);
+
+                var tab = QueryTabs(window).Last();
+                var session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 2 AS edited;";
+
+                Assert.True(window.SaveQueryToPath(tab, session, savedAs));
+
+                Assert.Equal("SELECT 2 AS edited;", File.ReadAllText(savedAs));
+                /* Save-as retargets the session: a second save has to land on the new file,
+                   not silently keep overwriting the one it was opened from. */
+                Assert.Equal(savedAs, session.SourceFilePath);
+                Assert.Equal(Path.GetFileName(savedAs), TabLabel(tab));
+                Assert.Equal("SELECT 1;", File.ReadAllText(opened));
+            }
+            finally
+            {
+                File.Delete(opened);
+                if (File.Exists(savedAs))
+                    File.Delete(savedAs);
+            }
+        });
+    }
+
+    [Fact]
+    public void ANewQuerySessionHasNoFileUntilItIsSaved()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var savedAs = Path.Combine(Path.GetTempPath(), $"fresh_{Path.GetRandomFileName()}.sql");
+            try
+            {
+                var window = new MainWindow();
+                window.NewQuery_Click(window, new Avalonia.Interactivity.RoutedEventArgs());
+
+                var tab = QueryTabs(window).Last();
+                var session = (QuerySessionControl)tab.Content!;
+
+                /* Nothing to default the Save picker to, which is why it suggests Query.sql. */
+                Assert.Null(session.SourceFilePath);
+
+                session.QueryEditor.Text = "SELECT 3;";
+                Assert.True(window.SaveQueryToPath(tab, session, savedAs));
+                Assert.Equal(savedAs, session.SourceFilePath);
+            }
+            finally
+            {
+                if (File.Exists(savedAs))
+                    File.Delete(savedAs);
+            }
+        });
+    }
+
+    [Fact]
+    public void AFailedSaveLeavesTheSessionPointingAtItsOriginalFile()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var opened = TempSql("SELECT 1;");
+            /* A directory that does not exist: File.WriteAllText throws, and the session must not
+               come away believing it now lives somewhere it was never written. */
+            var unwritable = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), "nope.sql");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(opened);
+
+                var tab = QueryTabs(window).Last();
+                var session = (QuerySessionControl)tab.Content!;
+
+                Assert.False(window.SaveQueryToPath(tab, session, unwritable));
+                Assert.Equal(opened, session.SourceFilePath);
+                Assert.Equal(Path.GetFileName(opened), TabLabel(tab));
+            }
+            finally
+            {
+                File.Delete(opened);
+            }
+        });
+    }
+
+    private static string TempSql(string text)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+        File.WriteAllText(path, text);
+        return path;
+    }
+
+    private static System.Collections.Generic.IEnumerable<TabItem> QueryTabs(MainWindow window) =>
+        window.MainTabControl.Items.OfType<TabItem>().Where(t => t.Content is QuerySessionControl);
+
+    private static string? TabLabel(TabItem tab) =>
+        tab.Header is StackPanel header && header.Children.Count > 0 && header.Children[0] is TextBlock text
+            ? text.Text
+            : null;
+}


### PR DESCRIPTION
Closes #458.

## What was actually wrong

The app has opened `.sql` files since v0.7.0. The picker behind **Open .sqlplan...** carries a SQL Scripts filter, `OpenFileByExtension` routes `.sql` to `LoadSqlFile`, and drag-and-drop accepts it via `_supportedExtensions`. None of that is visible from the menu, so @joshdbe asked for a feature that already shipped.

He was right that something was missing — it was missing from the menu, which is the only place he could have looked.

## What this adds

**Open Query...** and **Save Query...** under **New Query**, where someone looking for query operations is already looking. `Ctrl+Shift+O` and `Ctrl+S`.

Saving always prompts, but defaults to the file the query came from and starts the picker in that folder, so writing back over it is the path of least resistance and Save As is the same gesture. `QuerySessionControl` gains `SourceFilePath`, matching the property `PlanViewerControl` already has, which is what makes that default possible and what lets the tab retitle itself when a query is saved somewhere new.

`Open .sqlplan...` keeps its label and `Ctrl+O`. It still accepts `.sql` — no reason to take that away from anyone who found it.

## A startup crash, found while testing

`ShowFileError` was `ShowDialog(this)` unconditionally. Both the command-line open and the restore of the previous session's tabs run from the **MainWindow constructor**, before the window is visible, so a file that is missing or corrupt at startup reached that dialog with nothing to be modal over and threw `InvalidOperationException: Cannot show window with non-visible owner` — an unhandled exception at launch instead of the error message it was called to show.

It's now shown ownerless until the window is up. This is pre-existing and unrelated to the feature; I only found it because `AFailedSaveLeavesTheSessionPointingAtItsOriginalFile` drives a failing write and got the crash instead of the assertion.

## Tests

Four in `OpenSaveQueryTests`, on the headless harness. They drive `LoadSqlFile` and `SaveQueryToPath` rather than the Click handlers, because a file picker can't be answered headlessly — the picker chooses a path, and everything after that choice is what these cover.

- a `.sql` file lands in a query session with its text, path, and tab title
- saving writes the edited text, retargets the session, retitles the tab, and leaves the original file alone
- a new session has no path until it's saved
- **a failed save leaves the session pointing at its original file** — the one that caught the crash above

333 passing, 0 failed, full solution builds with 0 warnings.

## Still open

There's no dirty-state tracking, so nothing warns you about unsaved changes when closing a tab. Deliberately out of scope. Worth its own issue if we want it.
