### PR TITLE
Stop autohiding scrollbars (#464)

### DIFF
--- a/src/PlanViewer.App/App.axaml
+++ b/src/PlanViewer.App/App.axaml
@@ -14,6 +14,27 @@
         <FluentTheme />
         <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
         <StyleInclude Source="avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml"/>
+
+        <!-- Fluent defaults AllowAutoHide to true, which collapses a scrollbar to a
+             sliver until it is hovered. That is a bad trade on a horizontal bar under
+             a wide grid or a long query: the thing you need to grab is a couple of
+             pixels tall until after you have found it. Full size everywhere. -->
+        <Style Selector="ScrollViewer">
+            <Setter Property="AllowAutoHide" Value="False"/>
+        </Style>
+
+        <Style Selector="ScrollBar">
+            <Setter Property="AllowAutoHide" Value="False"/>
+        </Style>
+
+        <!-- DataGrid does not scroll through a ScrollViewer, and the ScrollBar rule above
+             cannot reach its bars either: it assigns AllowAutoHide to them in code, and a
+             local value outranks any style. There is no DataGrid.AllowAutoHide to set, but
+             the value it pushes down is the ATTACHED ScrollViewer property read off itself,
+             so setting that here is what reaches the grids. -->
+        <Style Selector="DataGrid">
+            <Setter Property="ScrollViewer.AllowAutoHide" Value="False"/>
+        </Style>
     </Application.Styles>
 
     <Application.Resources>

--- a/tests/PlanViewer.Core.Tests/ScrollBarVisibilityTests.cs
+++ b/tests/PlanViewer.Core.Tests/ScrollBarVisibilityTests.cs
@@ -1,0 +1,70 @@
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.VisualTree;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #464: every scrollbar in the app collapsed to a sliver until hovered, because Fluent defaults
+/// <c>AllowAutoHide</c> to true and nothing ever set it otherwise. The reporter's complaint was
+/// about a horizontal bar, which is where it hurts most — the thing you need to grab is a couple
+/// of pixels tall until after you have found it.
+///
+/// <para>Two selectors are needed, not one, and that is the whole reason this test exists. A
+/// <see cref="ScrollViewer"/> rule alone looks like it covers the app and does not: DataGrid does
+/// not scroll through a ScrollViewer, its template hosts PART_HorizontalScrollbar and
+/// PART_VerticalScrollbar as bare <see cref="ScrollBar"/>s. A style that compiles is not a style
+/// that matches, so both are asserted against controls that have actually been styled rather than
+/// against the App.axaml text.</para>
+/// </summary>
+public class ScrollBarVisibilityTests
+{
+    [Fact]
+    public void AScrollViewerDoesNotAutoHideItsBars()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var scrollViewer = new ScrollViewer { Content = new TextBlock { Text = "x" } };
+            Show(scrollViewer);
+
+            Assert.False(
+                scrollViewer.AllowAutoHide,
+                "the app-wide ScrollViewer style should have turned auto-hide off");
+        });
+    }
+
+    [Fact]
+    public void ADataGridsOwnScrollBarsDoNotAutoHideEither()
+    {
+        HeadlessUi.Run(() =>
+        {
+            /* The grid needs columns and rows before its template puts scrollbars in the tree,
+               so this is a real grid rather than an empty one. */
+            var grid = new DataGrid
+            {
+                ItemsSource = Enumerable.Range(0, 50).Select(i => new { Value = i }).ToList()
+            };
+            Show(grid);
+
+            var bars = grid.GetVisualDescendants().OfType<ScrollBar>().ToList();
+
+            Assert.NotEmpty(bars);
+            Assert.All(bars, bar => Assert.False(
+                bar.AllowAutoHide,
+                "a DataGrid's scrollbars are bare ScrollBars and need their own rule"));
+        });
+    }
+
+    /// <summary>
+    /// Puts a control in a window and forces a layout pass, so styles are applied and templated
+    /// children exist. Nothing is asserted before this runs — an unstyled control reports the
+    /// Fluent default and would pass for the wrong reason.
+    /// </summary>
+    private static void Show(Control content)
+    {
+        var window = new Window { Content = content, Width = 400, Height = 300 };
+        window.Show();
+        window.UpdateLayout();
+    }
+}


### PR DESCRIPTION
Fixes #464.

`AllowAutoHide` was never set anywhere, so every scrollbar inherited Fluent's default of `true` and collapsed to a sliver until hovered. Worst on a horizontal bar, which is what @joshdbe reported: the thing you need to grab is a couple of pixels tall until after you have found it.

## It takes three selectors, not one

A `ScrollViewer` rule looks like it covers the app. It does not, and I would have shipped it believing otherwise if the test had not failed:

| Selector | Reaches |
|---|---|
| `ScrollViewer` | the query editor, plan panes, anything scrolling normally |
| `ScrollBar` | bars that are not inside a ScrollViewer |
| `DataGrid` (attached `ScrollViewer.AllowAutoHide`) | the grids |

DataGrid does not scroll through a `ScrollViewer` — its template hosts `PART_HorizontalScrollbar` and `PART_VerticalScrollbar` as bare `ScrollBar`s. The `ScrollBar` rule does not reach those either, because DataGrid **assigns** `AllowAutoHide` to them in code and a local value outranks any style.

There is no `DataGrid.AllowAutoHide` to set instead — `AVLN2000: Unable to resolve suitable regular or attached property AllowAutoHide on type Avalonia.Controls.DataGrid`. What DataGrid pushes down is the *attached* `ScrollViewer.AllowAutoHide` read off itself, so setting that on the grid is what actually lands. That is the one that matters here, since a wide grid is where a horizontal bar shows up most.

## Tests

`ScrollBarVisibilityTests`, two tests, asserting against controls that have been through a real layout pass rather than against the App.axaml text — an unstyled control reports the Fluent default and would pass for the wrong reason.

Both proved red first. With the setters stripped, both fail with `AllowAutoHide = True`; the DataGrid one also failed against the ScrollViewer-and-ScrollBar-only version, which is how the third selector was found.

Full suite: 335 passed, 0 failed, 2 skipped.

Not made a setting. A scrollbar you cannot hit is not a preference worth preserving.
