### PR TITLE
Restore query tabs on restart, and let Copy Path see them (#463)

### DIFF
--- a/src/PlanViewer.App/Dialogs/SettingsWindow.axaml.cs
+++ b/src/PlanViewer.App/Dialogs/SettingsWindow.axaml.cs
@@ -639,7 +639,7 @@ internal partial class SettingsWindow : Window
 		var fresh = new AppSettings
 		{
 			RecentPlans = _settings.RecentPlans,
-			OpenPlans = _settings.OpenPlans,
+			OpenTabs = _settings.OpenTabs,
 			AccuracyRatioDivergenceLimit = _settings.AccuracyRatioDivergenceLimit
 		};
 		_settings = fresh;

--- a/src/PlanViewer.App/MainWindow.FileOps.cs
+++ b/src/PlanViewer.App/MainWindow.FileOps.cs
@@ -384,11 +384,16 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
-    /// Saves the file paths of all currently open file-based plan tabs.
+    /// The file behind every open tab that has one, in tab order. Plans and queries both,
+    /// since <see cref="GetTabFilePath"/> answers for either shape.
     /// </summary>
-    private void SaveOpenPlans()
+    /// <remarks>
+    /// Separate from <see cref="SaveOpenPlans"/> so a test can assert what would be persisted
+    /// without writing over the user's real settings file.
+    /// </remarks>
+    internal List<string> CollectOpenTabPaths()
     {
-        _appSettings.OpenPlans.Clear();
+        var paths = new List<string>();
 
         foreach (var item in MainTabControl.Items)
         {
@@ -396,31 +401,46 @@ public partial class MainWindow : Window
 
             var path = GetTabFilePath(tab);
             if (!string.IsNullOrEmpty(path))
-                _appSettings.OpenPlans.Add(path);
+                paths.Add(path);
         }
+
+        return paths;
+    }
+
+    /// <summary>
+    /// Saves the file paths of all currently open file-based tabs, plans and queries alike.
+    /// </summary>
+    private void SaveOpenPlans()
+    {
+        _appSettings.OpenTabs.Clear();
+        _appSettings.OpenTabs.AddRange(CollectOpenTabPaths());
 
         AppSettingsService.Save(_appSettings);
     }
 
     /// <summary>
-    /// Restores plan tabs from the previous session. Skips files that no longer exist.
+    /// Restores the tabs from the previous session. Skips files that no longer exist.
     /// Falls back to a new query tab if nothing was restored.
+    ///
+    /// <para>The saved list holds queries as well as plans, so it routes on extension the
+    /// same way an ordinary file open does. Sending a .sql file to LoadPlanFile would greet
+    /// the user with "the XML is not valid" where their query used to be.</para>
     /// </summary>
     private void RestoreOpenPlans()
     {
         var restored = false;
 
-        foreach (var path in _appSettings.OpenPlans)
+        foreach (var path in _appSettings.OpenTabs)
         {
             if (File.Exists(path))
             {
-                LoadPlanFile(path);
+                OpenFileByExtension(path);
                 restored = true;
             }
         }
 
-        // Clear the open plans list now that we've restored
-        _appSettings.OpenPlans.Clear();
+        // Clear the restored list now that its tabs are back on screen
+        _appSettings.OpenTabs.Clear();
         AppSettingsService.Save(_appSettings);
 
         if (!restored)

--- a/src/PlanViewer.App/MainWindow.Tabs.cs
+++ b/src/PlanViewer.App/MainWindow.Tabs.cs
@@ -187,6 +187,15 @@ public partial class MainWindow : Window
             text.Text = label;
     }
 
+    /// <summary>
+    /// The file a tab was opened from, or null when nothing on disk is behind it
+    /// (a pasted plan, a scratch query, a Query Store tab).
+    ///
+    /// <para>Every tab shape that can carry a path has to be recognised here, because this one
+    /// method answers two questions: what <see cref="SaveOpenPlans"/> writes down for the next
+    /// session, and whether <b>Copy Path</b> appears on the tab's context menu. A shape it does
+    /// not know about loses both without saying anything.</para>
+    /// </summary>
     private static string? GetTabFilePath(TabItem tab)
     {
         // Plans opened from file are wrapped in a DockPanel with the viewer as the last child
@@ -198,6 +207,11 @@ public partial class MainWindow : Window
                     return v.SourceFilePath;
             }
         }
+
+        // Queries are the session control itself, with no wrapper around it
+        if (tab.Content is QuerySessionControl session)
+            return session.SourceFilePath;
+
         return null;
     }
 

--- a/src/PlanViewer.App/Services/AppSettingsService.cs
+++ b/src/PlanViewer.App/Services/AppSettingsService.cs
@@ -69,6 +69,11 @@ internal sealed class AppSettingsService
                 settings = JsonSerializer.Deserialize<AppSettings>(json, JsonOptions) ?? new AppSettings();
             }
 
+            // Settings written before the open-tab list held queries use the old key.
+            // Ahead of MigrateFormatSettings, which can Save mid-load and would otherwise
+            // write the old key straight back out.
+            MigrateOpenTabs(settings);
+
             // Migrate legacy format settings file into unified settings
             MigrateFormatSettings(settings);
 
@@ -115,6 +120,23 @@ internal sealed class AppSettingsService
         {
             // Best-effort persistence — don't crash the app
         }
+    }
+
+    /// <summary>
+    /// Moves an "open_plans" list written by an older version onto <see cref="AppSettings.OpenTabs"/>,
+    /// so upgrading does not cost the user the tabs they had open. Only fills an empty OpenTabs:
+    /// if both keys are somehow present, the current one wins.
+    /// </summary>
+    /// <remarks>
+    /// Nothing is written here. The old key disappears from disk on the next ordinary save, which
+    /// happens on the first restore, so a downgrade before that point still finds its list.
+    /// </remarks>
+    internal static void MigrateOpenTabs(AppSettings settings)
+    {
+        if (settings.LegacyOpenPlans is { Count: > 0 } legacy && settings.OpenTabs.Count == 0)
+            settings.OpenTabs = legacy;
+
+        settings.LegacyOpenPlans = null;
     }
 
     /// <summary>
@@ -214,8 +236,20 @@ internal sealed class AppSettings
     [JsonPropertyName("recent_plans")]
     public List<string> RecentPlans { get; set; } = new();
 
+    /// <summary>
+    /// Paths of the tabs that were open when the app last closed, reopened on the next start.
+    /// Holds queries as well as plans, which is why it is no longer named for plans.
+    /// </summary>
+    [JsonPropertyName("open_tabs")]
+    public List<string> OpenTabs { get; set; } = new();
+
+    /// <summary>
+    /// What <see cref="OpenTabs"/> was called before it held queries too. Read on load so an
+    /// upgrade does not throw away the tabs the previous version wrote down, then nulled —
+    /// nulls are not serialized, so the old key drops out of the file on the next save.
+    /// </summary>
     [JsonPropertyName("open_plans")]
-    public List<string> OpenPlans { get; set; } = new();
+    public List<string>? LegacyOpenPlans { get; set; }
 
     /// <summary>
     /// Divergence limit for accuracy ratio coloring on plan links. Default 10.

--- a/tests/PlanViewer.Core.Tests/RestoreQueryTabsTests.cs
+++ b/tests/PlanViewer.Core.Tests/RestoreQueryTabsTests.cs
@@ -1,0 +1,240 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using PlanViewer.App;
+using PlanViewer.App.Controls;
+using PlanViewer.App.Services;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #463: plan tabs came back after a restart and query tabs did not, even when the query had been
+/// opened from a file and its path was sitting right there on the session. The saved-tab list was
+/// built from GetTabFilePath, which knew how to look inside a plan tab and nothing else, so a query
+/// tab was invisible to it — nothing was written down, so nothing could be restored.
+///
+/// The same blind spot hid <b>Copy Path</b> on the tab context menu, which is shown only when
+/// GetTabFilePath answers, and so had never once appeared on a query tab. Both halves are covered
+/// here because they are one defect, and the menu half is the easier one to fix by accident and
+/// never actually check.
+///
+/// These drive LoadSqlFile and the MainWindow constructor rather than the menu handlers, for the
+/// same reason <see cref="OpenSaveQueryTests"/> does: a file picker cannot be answered headlessly.
+/// </summary>
+public class RestoreQueryTabsTests
+{
+    [Fact]
+    public void AQueryOpenedFromAFileIsWrittenDownForTheNextSession()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1 AS restored;");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                Assert.Contains(path, window.CollectOpenTabPaths());
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The deliberate edge of the fix. A never-saved scratch buffer has no path, so there is
+    /// nothing to write down and it does not come back — persisting unsaved text is #462's job,
+    /// not this one's.
+    /// </summary>
+    [Fact]
+    public void AScratchQueryHasNoFileAndIsNotWrittenDown()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new MainWindow();
+            window.NewQuery_Click(window, new RoutedEventArgs());
+
+            var session = Sessions(window).Last();
+            Assert.Null(session.SourceFilePath);
+            Assert.Empty(window.CollectOpenTabPaths());
+        });
+    }
+
+    [Fact]
+    public void AQueryFileComesBackAsAQueryTabOnTheNextStart()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1 AS came_back;");
+            try
+            {
+                Seed(path);
+
+                var window = new MainWindow();
+
+                var session = Sessions(window).SingleOrDefault(s => s.SourceFilePath == path);
+                Assert.NotNull(session);
+                Assert.Equal("SELECT 1 AS came_back;", session!.QueryEditor.Text);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The saved list now holds both kinds of file, so restore routes on extension. This is the
+    /// half that would break if that routing sent everything to LoadSqlFile instead.
+    /// </summary>
+    [Fact]
+    public void APlanFileStillComesBackAsAPlanTab()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = Path.Combine(System.AppContext.BaseDirectory, "Plans", "row_goal_plan.sqlplan");
+            Seed(path);
+
+            var window = new MainWindow();
+
+            Assert.Contains(path, window.CollectOpenTabPaths());
+            Assert.Contains(Viewers(window), v => v.SourceFilePath == path);
+        });
+    }
+
+    [Fact]
+    public void CopyPathIsOfferedOnAQueryTabAndCopiesTheFile()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1 AS copied;");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                var tab = window.MainTabControl.Items
+                    .OfType<TabItem>()
+                    .Last(t => t.Content is QuerySessionControl);
+
+                var copyPath = ContextMenuItem(tab, "Copy Path");
+                Assert.True(copyPath.IsVisible,
+                    "the query came from a file, so there is a path to copy");
+
+                copyPath.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
+
+                Assert.Equal(path, Pump(ClipboardHelper.TryGetTextAsync(window)));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// A scratch tab has no path, so the menu item stays hidden — the gate still gates.
+    /// </summary>
+    [Fact]
+    public void CopyPathStaysHiddenOnAQueryTabWithNoFile()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new MainWindow();
+            window.NewQuery_Click(window, new RoutedEventArgs());
+
+            var tab = window.MainTabControl.Items
+                .OfType<TabItem>()
+                .Last(t => t.Content is QuerySessionControl);
+
+            Assert.False(ContextMenuItem(tab, "Copy Path").IsVisible);
+        });
+    }
+
+    /// <summary>
+    /// The list outgrew the name "open_plans" once it started holding queries. Renaming the key
+    /// is free for a new install and expensive for an existing one, so the old key is still read.
+    /// </summary>
+    [Fact]
+    public void TabsRecordedUnderTheOldSettingsKeyAreStillRestored()
+    {
+        var settings = JsonSerializer.Deserialize<AppSettings>(
+            """{"open_plans":["/tmp/one.sqlplan","/tmp/two.sql"]}""")!;
+
+        AppSettingsService.MigrateOpenTabs(settings);
+
+        Assert.Equal(new[] { "/tmp/one.sqlplan", "/tmp/two.sql" }, settings.OpenTabs);
+        Assert.Null(settings.LegacyOpenPlans);
+    }
+
+    /// <summary>
+    /// Both keys present means a downgrade wrote the old one after the new one already existed.
+    /// The current key is the one that reflects the last session.
+    /// </summary>
+    [Fact]
+    public void TheCurrentSettingsKeyWinsOverTheOldOne()
+    {
+        var settings = JsonSerializer.Deserialize<AppSettings>(
+            """{"open_plans":["/tmp/stale.sqlplan"],"open_tabs":["/tmp/current.sql"]}""")!;
+
+        AppSettingsService.MigrateOpenTabs(settings);
+
+        Assert.Equal(new[] { "/tmp/current.sql" }, settings.OpenTabs);
+        Assert.Null(settings.LegacyOpenPlans);
+    }
+
+    /// <summary>
+    /// Puts one path where the next MainWindow will look for the previous session's tabs.
+    /// Load returns the process-wide cached instance, which is the same object the window reads,
+    /// and restore clears it again on the way out — so this does not leak into other tests.
+    /// </summary>
+    private static void Seed(string path)
+    {
+        var settings = AppSettingsService.Load();
+        settings.OpenTabs.Clear();
+        settings.OpenTabs.Add(path);
+    }
+
+    private static MenuItem ContextMenuItem(TabItem tab, string header) =>
+        ((StackPanel)tab.Header!).ContextMenu!.Items
+            .OfType<MenuItem>()
+            .Single(i => (i.Header as string) == header);
+
+    /// <summary>
+    /// Drains the UI queue until the clipboard call finishes. Copy Path starts its write and
+    /// does not await it, so the read that follows can be a dispatcher turn early. Fails rather
+    /// than hangs if the headless clipboard never answers.
+    /// </summary>
+    private static T Pump<T>(Task<T> task)
+    {
+        for (var i = 0; i < 100 && !task.IsCompleted; i++)
+            Dispatcher.UIThread.RunJobs();
+
+        Assert.True(task.IsCompleted, "the clipboard call never completed");
+        return task.GetAwaiter().GetResult();
+    }
+
+    private static string TempSql(string text)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+        File.WriteAllText(path, text);
+        return path;
+    }
+
+    private static IEnumerable<QuerySessionControl> Sessions(MainWindow window) =>
+        window.MainTabControl.Items.OfType<TabItem>().Select(t => t.Content).OfType<QuerySessionControl>();
+
+    private static IEnumerable<PlanViewerControl> Viewers(MainWindow window) =>
+        window.MainTabControl.Items.OfType<TabItem>()
+            .Select(t => t.Content)
+            .OfType<DockPanel>()
+            .SelectMany(d => d.Children)
+            .OfType<PlanViewerControl>();
+}


### PR DESCRIPTION
Closes #463. Reported by @joshdbe in #458.

## What was wrong

Close the app with a plan open and it comes back. Close it with a query open — a query you opened from a `.sql` file, whose path the app has known since #459 — and it is gone.

`GetTabFilePath` understood exactly one tab shape:

```csharp
if (tab.Content is DockPanel dp)
{
    foreach (var child in dp.Children)
        if (child is PlanViewerControl v)
            return v.SourceFilePath;
}
return null;
```

A plan tab is a `DockPanel` wrapping a `PlanViewerControl`. A query tab is a `QuerySessionControl` with nothing around it, and it carries a perfectly good `SourceFilePath`. It was never asked. `SaveOpenPlans` builds its list from this method, so it recorded nothing for query tabs and `RestoreOpenPlans` had nothing to restore.

Evidence, with only the `QuerySessionControl` branch removed and everything else in this PR left in place:

```
AQueryOpenedFromAFileIsWrittenDownForTheNextSession [FAIL]
  Assert.Contains() Failure: Item not found in collection
  Collection: []
  Not found:  "/var/folders/.../k5j2vtoq.sql"
```

An empty collection, with a query tab open that came from a file.

## Copy Path, same cause

`Copy Path` on the tab context menu is gated on `GetTabFilePath(tab) != null`, so it has never once appeared on a query tab. That is the same defect, not a second one, and it un-hides with the same three lines. It is also the half that is easy to fix by accident and never actually check, so there is a test that clicks the menu item and reads the path back off the clipboard rather than just asserting `IsVisible`.

## Restore has to route now

The saved list holds `.sql` paths as well as plans, so restore goes through the existing `OpenFileByExtension` instead of assuming `LoadPlanFile`. Sending a query file to `LoadPlanFile` fails XML validation and puts up an error box where the user's query should have been — and at startup, before the main window is visible, that error box is worse than it sounds:

```
AQueryFileComesBackAsAQueryTabOnTheNextStart [FAIL]
  System.InvalidOperationException : Cannot show window with non-visible owner.
     at Avalonia.Controls.Window.EnsureParentStateBeforeShow(Window owner)
```

That is the failure with the routing reverted and everything else in place. `ShowFileError` has a guard for exactly this; `ShowError`, which `LoadPlanFile` uses, does not. Not fixed here — out of scope, and it lives in a file I am staying out of — but worth knowing it is there.

## The setting

`open_plans` is renamed to `open_tabs` now that it holds both kinds of file. An existing settings file is not silently emptied: the old key deserializes into a migration-only property that is merged into `OpenTabs` on load and then nulled. Nulls are not serialized, so the old key disappears from disk on the first ordinary save rather than lingering. If both keys somehow exist, the current one wins.

`SaveOpenPlans` and `RestoreOpenPlans` keep their names — renaming them means editing `MainWindow.axaml.cs`, which another PR is in the middle of.

## What this deliberately does not do

- **Scratch tabs.** A query tab that was never saved has no path, so there is nothing to write down and it does not come back. Persisting unsaved buffers is #462. There is a test pinning that boundary so it does not get closed by accident.
- **Copy Path on a tab that acquires a file later.** The menu item's visibility is decided once, when the tab is built. Save a scratch query and `Copy Path` stays hidden on that tab until the next restart. Fixing that means recomputing on menu open, inside the tab-header construction another PR currently owns. Follow-up.

## Testing

335 passed / 0 failed / 2 skipped before, 343 / 0 / 2 after. Eight new tests, three of them proved red first by reverting one piece of the fix at a time:

| Reverted | Goes red |
| --- | --- |
| the `QuerySessionControl` branch in `GetTabFilePath` | `AQueryOpenedFromAFileIsWrittenDownForTheNextSession`, `CopyPathIsOfferedOnAQueryTabAndCopiesTheFile` |
| `OpenFileByExtension` back to `LoadPlanFile` in restore | `AQueryFileComesBackAsAQueryTabOnTheNextStart` |
| the legacy-key migration | `TabsRecordedUnderTheOldSettingsKeyAreStillRestored`, `TheCurrentSettingsKeyWinsOverTheOldOne` |

The other three — a scratch tab records nothing, `Copy Path` stays hidden with no file, a plan still restores as a plan — pass either way by design. They pin the edges, they do not prove the fix.

The migration was also checked against a real settings file rather than only in a unit test: an `appsettings.json` was hand-edited back to the pre-#463 shape — one plan path under `open_plans`, no `open_tabs` — and the suite run against it. Afterwards the file has `open_tabs` and no `open_plans`, and the plan named only under the old key is at the head of `recent_plans`, which nothing but `LoadPlanFile` puts it there. The old list was read, opened, and retired.

`dotnet test` still reports "Zero tests ran" under SDK 10.0.302; that is the pre-existing runner integration problem, not this change. Counts above are from the test executable directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xj7HmCKrnsz2PWkRKT2Jx
