### PR TITLE
Warn about unsaved query changes, and mark modified tabs (#462)

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -37,6 +37,39 @@ public partial class QuerySessionControl : UserControl
     /// </summary>
     public string? SourceFilePath { get; set; }
 
+    /// <summary>
+    /// The editor text as of the last load or save. A new session starts empty, so a
+    /// never-saved scratch tab with anything typed into it is dirty too (#462).
+    /// </summary>
+    private string _savedText = "";
+
+    /// <summary>
+    /// Whether the editor holds work that is not on disk.
+    ///
+    /// <para>This compares text rather than latching a "was edited" bool on the first
+    /// keystroke, so typing something and typing it back out again leaves the session
+    /// clean — an undo to the original is not unsaved work, and prompting about it is
+    /// how a save prompt teaches people to dismiss save prompts.</para>
+    /// </summary>
+    public bool IsDirty => !string.Equals(QueryEditor.Text, _savedText, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Raised whenever the editor text changes or the session is marked clean. The tab
+    /// header subscribes to this to keep its modified marker honest; the session cannot
+    /// reach its own tab, and polling <see cref="IsDirty"/> per render would be worse.
+    /// </summary>
+    public event EventHandler? DirtyStateChanged;
+
+    /// <summary>
+    /// Declares the current text to be what is on disk. Called after a load and after a
+    /// successful save — not after a failed one, which must leave the session dirty.
+    /// </summary>
+    public void MarkClean()
+    {
+        _savedText = QueryEditor.Text;
+        DirtyStateChanged?.Invoke(this, EventArgs.Empty);
+    }
+
     private ServerConnection? _serverConnection;
     private string? _connectionString;
     private string? _selectedDatabase;
@@ -71,6 +104,10 @@ public partial class QuerySessionControl : UserControl
         // Code completion
         QueryEditor.TextArea.TextEntering += OnTextEntering;
         QueryEditor.TextArea.TextEntered += OnTextEntered;
+
+        // #462: every edit is a chance for the tab's modified marker to change, in both
+        // directions — an undo back to the saved text clears it again.
+        QueryEditor.TextChanged += (_, _) => DirtyStateChanged?.Invoke(this, EventArgs.Empty);
 
         // Focus the editor when the control is attached to the visual tree
         // Re-install TextMate if it was disposed on detach (tab switching disposes it)

--- a/src/PlanViewer.App/Dialogs/UnsavedChangesDialog.cs
+++ b/src/PlanViewer.App/Dialogs/UnsavedChangesDialog.cs
@@ -1,0 +1,102 @@
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+
+namespace PlanViewer.App.Dialogs;
+
+/// <summary>
+/// What the user said when asked about a query tab with unsaved changes.
+/// </summary>
+public enum UnsavedChangesChoice
+{
+    /// <summary>Write the query out, then close.</summary>
+    Save,
+
+    /// <summary>Close and lose the edit — an explicit answer, not a default.</summary>
+    DontSave,
+
+    /// <summary>Do not close anything.</summary>
+    Cancel
+}
+
+/// <summary>
+/// The Save / Don't Save / Cancel prompt for a modified query tab (#462).
+///
+/// <para>Separate from <see cref="ConfirmationDialog"/> rather than a parameter on it: this
+/// has three answers, and the third one has to be distinguishable from the second. A yes/no
+/// dialog collapses "don't save" and "cancel" into the same false, which is the one mistake
+/// this prompt cannot make — it is the difference between losing a tab and losing the app.</para>
+/// </summary>
+public static class UnsavedChangesDialog
+{
+    /// <summary>
+    /// Asks about one tab. Dismissing the window any other way — title-bar close, Escape —
+    /// is <see cref="UnsavedChangesChoice.Cancel"/>, because the safe answer to a question
+    /// nobody answered is to leave the work where it is.
+    /// </summary>
+    public static async Task<UnsavedChangesChoice> ShowAsync(Window owner, string tabLabel)
+    {
+        var choice = UnsavedChangesChoice.Cancel;
+
+        var messageText = new TextBlock
+        {
+            Text = $"Do you want to save the changes you made to {tabLabel}?\n\nYour changes will be lost if you don't save them.",
+            TextWrapping = TextWrapping.Wrap,
+            FontSize = 13,
+            Foreground = new SolidColorBrush(Color.Parse("#E4E6EB")),
+            Margin = new Avalonia.Thickness(0, 0, 0, 16)
+        };
+
+        var buttonPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right
+        };
+
+        var dialog = new Window
+        {
+            Title = "Unsaved Changes",
+            Width = 460,
+            Height = 220,
+            MinWidth = 460,
+            MinHeight = 220,
+            Icon = owner.Icon,
+            Background = new SolidColorBrush(Color.Parse("#1A1D23")),
+            Foreground = new SolidColorBrush(Color.Parse("#E4E6EB")),
+            WindowStartupLocation = WindowStartupLocation.CenterOwner
+        };
+
+        Button MakeButton(string caption, UnsavedChangesChoice answer)
+        {
+            var button = new Button
+            {
+                Content = caption,
+                Height = 32,
+                MinWidth = 96,
+                Padding = new Avalonia.Thickness(16, 0),
+                FontSize = 12,
+                Margin = new Avalonia.Thickness(8, 0, 0, 0),
+                HorizontalContentAlignment = HorizontalAlignment.Center,
+                VerticalContentAlignment = VerticalAlignment.Center,
+                Theme = (Avalonia.Styling.ControlTheme)owner.FindResource("AppButton")!
+            };
+            button.Click += (_, _) => { choice = answer; dialog.Close(); };
+            buttonPanel.Children.Add(button);
+            return button;
+        }
+
+        MakeButton("Save", UnsavedChangesChoice.Save);
+        MakeButton("Don't Save", UnsavedChangesChoice.DontSave);
+        MakeButton("Cancel", UnsavedChangesChoice.Cancel);
+
+        dialog.Content = new StackPanel
+        {
+            Margin = new Avalonia.Thickness(20),
+            Children = { messageText, buttonPanel }
+        };
+
+        await dialog.ShowDialog(owner);
+        return choice;
+    }
+}

--- a/src/PlanViewer.App/MainWindow.FileOps.cs
+++ b/src/PlanViewer.App/MainWindow.FileOps.cs
@@ -112,6 +112,17 @@ public partial class MainWindow : Window
         if (MainTabControl.SelectedItem is not TabItem { Content: QuerySessionControl session } tab)
             return;
 
+        await SaveQueryAsync(tab, session);
+    }
+
+    /// <summary>
+    /// Saves a named tab rather than whichever one is selected. The unsaved-changes prompt
+    /// (#462) walks every tab, so it needs to save one that is not the active one, and a
+    /// scratch tab answering Save arrives here to get a path.
+    /// </summary>
+    /// <returns>Whether the query reached disk. False also covers the user closing the picker.</returns>
+    private async Task<bool> SaveQueryAsync(TabItem tab, QuerySessionControl session)
+    {
         var existing = session.SourceFilePath;
 
         var options = new FilePickerSaveOptions
@@ -139,8 +150,7 @@ public partial class MainWindow : Window
         var file = await StorageProvider.SaveFilePickerAsync(options);
 
         var path = file?.TryGetLocalPath();
-        if (path != null)
-            SaveQueryToPath(tab, session, path);
+        return path != null && SaveQueryToPath(tab, session, path);
     }
 
     /// <summary>
@@ -153,6 +163,9 @@ public partial class MainWindow : Window
         {
             File.WriteAllText(path, session.QueryEditor.Text);
             session.SourceFilePath = path;
+            // Only a write that actually happened settles the dirty state; the catch below
+            // deliberately leaves the session modified so the work is still guarded.
+            session.MarkClean();
             SetTabLabel(tab, Path.GetFileName(path));
             return true;
         }
@@ -243,6 +256,8 @@ public partial class MainWindow : Window
             var session = new QuerySessionControl(_credentialService, _connectionStore);
             session.QueryEditor.Text = text;
             session.SourceFilePath = filePath;
+            // What was just loaded is what is on disk — the baseline every later edit is measured against.
+            session.MarkClean();
 
             var tab = CreateTab(fileName, session);
             MainTabControl.Items.Add(tab);

--- a/src/PlanViewer.App/MainWindow.Tabs.cs
+++ b/src/PlanViewer.App/MainWindow.Tabs.cs
@@ -48,7 +48,7 @@ public partial class MainWindow : Window
 
         var closeBtn = new Button
         {
-            Content = "\u2715",
+            Content = CloseGlyph,
             MinWidth = 22,
             MinHeight = 22,
             Width = 22,
@@ -75,13 +75,29 @@ public partial class MainWindow : Window
         closeBtn.Tag = tab;
         closeBtn.Click += CloseTab_Click;
 
+        /* #462: the modified marker. Only query sessions have a dirty state, and the button
+           has to re-decide on pointer-over as well as on edits, because hovering is what turns
+           the dot back into a close button. */
+        if (content is QuerySessionControl querySession)
+        {
+            void RefreshCloseGlyph() =>
+                closeBtn.Content = CloseButtonGlyph(querySession.IsDirty, closeBtn.IsPointerOver);
+
+            querySession.DirtyStateChanged += (_, _) => RefreshCloseGlyph();
+            closeBtn.PointerEntered += (_, _) => RefreshCloseGlyph();
+            closeBtn.PointerExited += (_, _) => RefreshCloseGlyph();
+
+            // A session can arrive already modified — re-docking a detached window builds a
+            // fresh tab around a session that has been edited since it left.
+            RefreshCloseGlyph();
+        }
+
         // Middle-click to close
         header.PointerPressed += (_, e) =>
         {
             if (e.GetCurrentPoint(null).Properties.PointerUpdateKind == PointerUpdateKind.MiddleButtonPressed)
             {
-                MainTabControl.Items.Remove(tab);
-                UpdateEmptyOverlay();
+                _ = TryCloseTabAsync(tab);
                 e.Handled = true;
             }
         };
@@ -118,10 +134,7 @@ public partial class MainWindow : Window
     private void CloseTab_Click(object? sender, RoutedEventArgs e)
     {
         if (sender is Button btn && btn.Tag is TabItem tab)
-        {
-            MainTabControl.Items.Remove(tab);
-            UpdateEmptyOverlay();
-        }
+            _ = TryCloseTabAsync(tab);
     }
 
     private void TabContextMenu_Click(object? sender, RoutedEventArgs e)
@@ -148,26 +161,16 @@ public partial class MainWindow : Window
 
             case "Close":
                 if (item.Tag is TabItem tab)
-                {
-                    MainTabControl.Items.Remove(tab);
-                    UpdateEmptyOverlay();
-                }
+                    _ = TryCloseTabAsync(tab);
                 break;
 
             case "Close Other Tabs":
                 if (item.Tag is TabItem keepTab)
-                {
-                    var others = MainTabControl.Items.Cast<TabItem>().Where(t => t != keepTab).ToList();
-                    foreach (var t in others)
-                        MainTabControl.Items.Remove(t);
-                    MainTabControl.SelectedItem = keepTab;
-                    UpdateEmptyOverlay();
-                }
+                    _ = CloseOtherTabsAsync(keepTab);
                 break;
 
             case "Close All Tabs":
-                MainTabControl.Items.Clear();
-                UpdateEmptyOverlay();
+                _ = CloseTabsAsync(MainTabControl.Items.Cast<TabItem>().ToList());
                 break;
 
             case "Detach to Window":

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -105,8 +105,7 @@ public partial class MainWindow : Window
                     case Key.W:
                         if (MainTabControl.SelectedItem is TabItem selected)
                         {
-                            MainTabControl.Items.Remove(selected);
-                            UpdateEmptyOverlay();
+                            _ = TryCloseTabAsync(selected);
                             e.Handled = true;
                         }
                         break;
@@ -257,6 +256,168 @@ public partial class MainWindow : Window
     private void UpdateEmptyOverlay()
     {
         EmptyOverlay.IsVisible = MainTabControl.Items.Count == 0;
+    }
+
+
+    // ── Unsaved query changes (#462) ──────────────────────────────────────
+
+    /// <summary>
+    /// Set once every tab has been asked about, so the second pass through
+    /// <see cref="OnClosing"/> does not ask the whole window again.
+    /// </summary>
+    private bool _closeConfirmed;
+
+    private const string CloseGlyph = "\u2715";   // ✕
+    private const string ModifiedGlyph = "\u25CF"; // ●
+
+    /// <summary>
+    /// What a tab's close button shows. Dirty tabs get a filled dot, but it reverts to the
+    /// × while the pointer is over the button — a marker you cannot click through is a tab
+    /// you cannot close, which is the trade VS Code makes and the one Josh asked for.
+    /// </summary>
+    internal static string CloseButtonGlyph(bool isDirty, bool isPointerOver) =>
+        isDirty && !isPointerOver ? ModifiedGlyph : CloseGlyph;
+
+    /// <summary>
+    /// Whether closing this tab would throw work away. Plan tabs are read-only, so only a
+    /// query session can ever answer yes.
+    /// </summary>
+    internal static bool HasUnsavedChanges(TabItem tab) =>
+        tab.Content is QuerySessionControl { IsDirty: true };
+
+    /// <summary>
+    /// Every tab that would lose work if the window closed right now, in tab order.
+    ///
+    /// <para>Deliberately not "the selected tab": the edit at risk is usually in the tab the
+    /// user is not looking at, which is the whole reason a window-close prompt exists.</para>
+    /// </summary>
+    internal List<TabItem> TabsWithUnsavedChanges() =>
+        MainTabControl.Items.OfType<TabItem>().Where(HasUnsavedChanges).ToList();
+
+    /// <summary>
+    /// What the close path does with an answer to the prompt.
+    /// </summary>
+    internal enum CloseAction
+    {
+        /// <summary>Proceed with the close.</summary>
+        Close,
+
+        /// <summary>Leave the tab, and the window, alone.</summary>
+        Cancel,
+
+        /// <summary>Overwrite the file the session came from, then close.</summary>
+        SaveInPlace,
+
+        /// <summary>Ask where to put it first, then close if it was actually written.</summary>
+        SaveAs
+    }
+
+    /// <summary>
+    /// Turns an answer into an action, split out from the dialog so the decision can be
+    /// tested without a window to click. A never-saved scratch tab has nowhere to write, so
+    /// its Save has to become a Save As rather than silently doing nothing.
+    /// </summary>
+    internal static CloseAction DecideClose(UnsavedChangesChoice choice, bool hasFile) => choice switch
+    {
+        UnsavedChangesChoice.Cancel => CloseAction.Cancel,
+        UnsavedChangesChoice.DontSave => CloseAction.Close,
+        _ => hasFile ? CloseAction.SaveInPlace : CloseAction.SaveAs
+    };
+
+    /// <summary>
+    /// Asks about a tab if it needs asking about. Returns whether the close may proceed —
+    /// false means the user cancelled, or a save they asked for failed.
+    /// </summary>
+    private async Task<bool> ConfirmCloseAsync(TabItem tab)
+    {
+        if (!HasUnsavedChanges(tab))
+            return true;
+
+        var session = (QuerySessionControl)tab.Content!;
+
+        MainTabControl.SelectedItem = tab; // show what is being asked about
+        var choice = await UnsavedChangesDialog.ShowAsync(this, GetTabLabel(tab));
+
+        return DecideClose(choice, session.SourceFilePath != null) switch
+        {
+            CloseAction.Cancel => false,
+            CloseAction.Close => true,
+            CloseAction.SaveInPlace => SaveQueryToPath(tab, session, session.SourceFilePath!),
+            _ => await SaveQueryAsync(tab, session)
+        };
+    }
+
+    /// <summary>
+    /// Closes one tab, asking first. Returns false when the close was refused, so callers
+    /// closing several tabs can stop rather than plough on past a Cancel.
+    /// </summary>
+    private async Task<bool> TryCloseTabAsync(TabItem tab)
+    {
+        if (!await ConfirmCloseAsync(tab))
+            return false;
+
+        MainTabControl.Items.Remove(tab);
+        UpdateEmptyOverlay();
+        return true;
+    }
+
+    /// <summary>
+    /// Closes a run of tabs. Cancelling any one of them abandons the rest: "close all tabs"
+    /// answered with Cancel means the user changed their mind about all of them, not about
+    /// that one.
+    /// </summary>
+    private async Task CloseTabsAsync(IEnumerable<TabItem> tabs)
+    {
+        foreach (var tab in tabs.ToList())
+        {
+            if (!await TryCloseTabAsync(tab))
+                return;
+        }
+    }
+
+    /// <summary>
+    /// Closes everything but one tab, then puts the survivor back in front — it may not have
+    /// been the selected tab, and <see cref="ConfirmCloseAsync"/> moves the selection around
+    /// to show what it is asking about.
+    /// </summary>
+    private async Task CloseOtherTabsAsync(TabItem keepTab)
+    {
+        await CloseTabsAsync(MainTabControl.Items.OfType<TabItem>().Where(t => t != keepTab));
+
+        if (MainTabControl.Items.Contains(keepTab))
+            MainTabControl.SelectedItem = keepTab;
+    }
+
+    /// <summary>
+    /// Holds the window open long enough to ask about every modified tab.
+    ///
+    /// <para>The prompt is async and Closing is not, so the first pass cancels the close
+    /// outright and re-issues it from <see cref="ConfirmWindowCloseAsync"/> once every tab
+    /// has answered. Anything that is not a query tab, and any window with nothing modified,
+    /// closes on the first pass without a detour.</para>
+    /// </summary>
+    protected override void OnClosing(WindowClosingEventArgs e)
+    {
+        if (!_closeConfirmed && TabsWithUnsavedChanges().Count > 0)
+        {
+            e.Cancel = true;
+            _ = ConfirmWindowCloseAsync();
+            return;
+        }
+
+        base.OnClosing(e);
+    }
+
+    private async Task ConfirmWindowCloseAsync()
+    {
+        foreach (var tab in MainTabControl.Items.OfType<TabItem>().ToList())
+        {
+            if (!await ConfirmCloseAsync(tab))
+                return; // one Cancel cancels the shutdown
+        }
+
+        _closeConfirmed = true;
+        Close();
     }
 
 

--- a/tests/PlanViewer.Core.Tests/UnsavedQueryChangesTests.cs
+++ b/tests/PlanViewer.Core.Tests/UnsavedQueryChangesTests.cs
@@ -1,0 +1,252 @@
+using System.IO;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using PlanViewer.App;
+using PlanViewer.App.Controls;
+using PlanViewer.App.Dialogs;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #462: a query session had no idea whether it had been edited. Open a .sql, change it, close
+/// the tab or the window, and the edit was gone with nothing asked and nothing marked.
+///
+/// The dirty flag is the whole feature — the close prompt and the modified marker are both
+/// consumers of it — so most of what is worth testing is the flag itself and the decision the
+/// prompt feeds. The dialog cannot be clicked headlessly, which is why the answer is a value
+/// (<see cref="UnsavedChangesChoice"/>) handed to <see cref="MainWindow.DecideClose"/> rather
+/// than something only the dialog knows. Same reasoning as OpenSaveQueryTests and the file
+/// picker: what the human chooses is untestable, everything downstream of the choice is not.
+/// </summary>
+public class UnsavedQueryChangesTests
+{
+    [Fact]
+    public void EditingAFileBackedQueryMakesItDirtyAndMarksTheTab()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                var tab = LastQueryTab(window);
+                var session = (QuerySessionControl)tab.Content!;
+
+                Assert.False(session.IsDirty, "a file just loaded is what is on disk");
+                Assert.Equal("\u2715", CloseButton(tab).Content);
+
+                session.QueryEditor.Text = "SELECT 2; -- unsaved work";
+
+                Assert.True(session.IsDirty);
+                Assert.True(MainWindow.HasUnsavedChanges(tab));
+                Assert.Equal("\u25CF", CloseButton(tab).Content);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    [Fact]
+    public void TypingBackToTheOriginalTextClearsTheDirtyState()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                var tab = LastQueryTab(window);
+                var session = (QuerySessionControl)tab.Content!;
+
+                session.QueryEditor.Text = "SELECT 2;";
+                Assert.True(session.IsDirty);
+
+                /* The point of comparing text rather than latching a bool on the first keystroke:
+                   an undo back to the file's contents is not unsaved work, and being asked about it
+                   is what teaches people to click through save prompts without reading them. */
+                session.QueryEditor.Text = "SELECT 1;";
+
+                Assert.False(session.IsDirty);
+                Assert.Equal("\u2715", CloseButton(tab).Content);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    [Fact]
+    public void AScratchTabWithTypedContentIsDirtyAndItsSaveGoesThroughSaveAs()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new MainWindow();
+            window.NewQuery_Click(window, new RoutedEventArgs());
+
+            var tab = LastQueryTab(window);
+            var session = (QuerySessionControl)tab.Content!;
+
+            Assert.False(session.IsDirty, "an empty new query has nothing to lose");
+
+            session.QueryEditor.Text = "SELECT 'never saved';";
+
+            Assert.True(session.IsDirty);
+            Assert.Null(session.SourceFilePath);
+            Assert.Equal("\u25CF", CloseButton(tab).Content);
+
+            /* Nowhere to write it, so Save has to become Save As. Saving "in place" over a null
+               path is the one outcome that would throw away the query it was trying to rescue. */
+            Assert.Equal(
+                MainWindow.CloseAction.SaveAs,
+                MainWindow.DecideClose(UnsavedChangesChoice.Save, hasFile: false));
+        });
+    }
+
+    [Fact]
+    public void ASuccessfulSaveSettlesTheTabAndAFailedOneDoesNot()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var opened = TempSql("SELECT 1;");
+            var savedAs = Path.Combine(Path.GetTempPath(), $"saved_{Path.GetRandomFileName()}.sql");
+            /* A directory that does not exist, so File.WriteAllText throws. */
+            var unwritable = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), "nope.sql");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(opened);
+
+                var tab = LastQueryTab(window);
+                var session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 2 AS edited;";
+
+                Assert.False(window.SaveQueryToPath(tab, session, unwritable));
+                Assert.True(session.IsDirty, "a save that threw has not saved anything");
+                Assert.Equal("\u25CF", CloseButton(tab).Content);
+
+                Assert.True(window.SaveQueryToPath(tab, session, savedAs));
+                Assert.False(session.IsDirty);
+                Assert.Equal("\u2715", CloseButton(tab).Content);
+            }
+            finally
+            {
+                File.Delete(opened);
+                if (File.Exists(savedAs))
+                    File.Delete(savedAs);
+            }
+        });
+    }
+
+    [Fact]
+    public void TheModifiedMarkerGivesWayToTheCloseButtonUnderThePointer()
+    {
+        /* Josh's ask, and the reason the marker is a swap rather than an extra glyph: a dot you
+           cannot click is a tab you cannot close. */
+        Assert.Equal("\u25CF", MainWindow.CloseButtonGlyph(isDirty: true, isPointerOver: false));
+        Assert.Equal("\u2715", MainWindow.CloseButtonGlyph(isDirty: true, isPointerOver: true));
+        Assert.Equal("\u2715", MainWindow.CloseButtonGlyph(isDirty: false, isPointerOver: false));
+        Assert.Equal("\u2715", MainWindow.CloseButtonGlyph(isDirty: false, isPointerOver: true));
+    }
+
+    [Fact]
+    public void ClosingTheWindowAsksAboutEveryTabNotJustTheSelectedOne()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var first = TempSql("SELECT 1;");
+            var second = TempSql("SELECT 2;");
+            var third = TempSql("SELECT 3;");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(first);
+                window.LoadSqlFile(second);
+                window.LoadSqlFile(third);
+
+                var tabs = QueryTabs(window).ToList();
+                var firstTab = tabs[^3];
+                var secondTab = tabs[^2];
+                var thirdTab = tabs[^1];
+
+                Edit(firstTab, "SELECT 1; -- edited");
+                Edit(secondTab, "SELECT 2; -- edited");
+
+                /* The tab in front is the clean one. The edits at risk are behind it, which is the
+                   ordinary case and exactly what a window-close prompt is for. */
+                window.MainTabControl.SelectedItem = thirdTab;
+
+                Assert.Equal(
+                    new[] { firstTab, secondTab },
+                    window.TabsWithUnsavedChanges());
+            }
+            finally
+            {
+                File.Delete(first);
+                File.Delete(second);
+                File.Delete(third);
+            }
+        });
+    }
+
+    [Fact]
+    public void PlanTabsAreNeverDirty()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new MainWindow();
+            window.LoadPlanFile(Path.Combine("Plans", "row_goal_plan.sqlplan"));
+
+            /* Plans are read-only. Nothing about opening one should make the app ask whether to
+               save it, and the restored-on-startup query tab must not be dragged in either. */
+            Assert.Empty(window.TabsWithUnsavedChanges());
+        });
+    }
+
+    [Fact]
+    public void CancelRefusesTheCloseAndDontSaveGoesThroughWithIt()
+    {
+        Assert.Equal(
+            MainWindow.CloseAction.Cancel,
+            MainWindow.DecideClose(UnsavedChangesChoice.Cancel, hasFile: true));
+        Assert.Equal(
+            MainWindow.CloseAction.Cancel,
+            MainWindow.DecideClose(UnsavedChangesChoice.Cancel, hasFile: false));
+
+        Assert.Equal(
+            MainWindow.CloseAction.Close,
+            MainWindow.DecideClose(UnsavedChangesChoice.DontSave, hasFile: true));
+        Assert.Equal(
+            MainWindow.CloseAction.Close,
+            MainWindow.DecideClose(UnsavedChangesChoice.DontSave, hasFile: false));
+
+        Assert.Equal(
+            MainWindow.CloseAction.SaveInPlace,
+            MainWindow.DecideClose(UnsavedChangesChoice.Save, hasFile: true));
+    }
+
+    private static void Edit(TabItem tab, string text) =>
+        ((QuerySessionControl)tab.Content!).QueryEditor.Text = text;
+
+    private static string TempSql(string text)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+        File.WriteAllText(path, text);
+        return path;
+    }
+
+    private static System.Collections.Generic.IEnumerable<TabItem> QueryTabs(MainWindow window) =>
+        window.MainTabControl.Items.OfType<TabItem>().Where(t => t.Content is QuerySessionControl);
+
+    private static TabItem LastQueryTab(MainWindow window) => QueryTabs(window).Last();
+
+    private static Button CloseButton(TabItem tab) =>
+        ((StackPanel)tab.Header!).Children.OfType<Button>().Single();
+}


### PR DESCRIPTION
Closes #462.

## What was actually wrong

A query session knew where it came from and nothing about what was in it. #459 gave `QuerySessionControl` a `SourceFilePath`; it never gave it any notion of content. So there was no dirty state for anything to consult — not the close button, not the tab header, not `Window.Closing` — and every close path was free to drop the editor on the floor.

Headless repro against `ea71288`: open a `.sql`, edit it, then do exactly what `CloseTab_Click` did.

```
REPRO close glyph after edit: '✕'
REPRO tab count after close: 1
REPRO file on disk still: 'SELECT 1;'
```

Nothing marked, nothing asked, edit gone.

## The missing piece

The dirty flag is the whole feature. The prompt and the marker are both consumers of it, which is why they were both missing at once.

`QuerySessionControl` now keeps `_savedText` — the editor text as of the last load or save — and `IsDirty` compares against it. Deliberately not a "was edited" bool latched on the first keystroke: typing something and typing it back out is not unsaved work, and a prompt that fires on it is how a save prompt teaches people to dismiss save prompts. `MarkClean()` is called after a load and after a save that actually wrote, so a save that threw leaves the session guarded.

`DirtyStateChanged` exists because the session cannot reach its own tab. The header subscribes and swaps the close button's glyph.

Every path that discarded a tab now goes through `TryCloseTabAsync`:

| Path | Before | After |
|---|---|---|
| Tab's `×` button | `Items.Remove` | prompt, then remove |
| Middle-click header | `Items.Remove` | prompt, then remove |
| Context menu → Close | `Items.Remove` | prompt, then remove |
| Context menu → Close Other Tabs | remove loop | prompt each; Cancel abandons the rest |
| Context menu → Close All Tabs | `Items.Clear()` | prompt each; Cancel abandons the rest |
| Ctrl+W | `Items.Remove` | prompt, then remove |
| Window close | nothing | walks **every** tab, Cancel anywhere cancels the shutdown |

The window-close case is the one that has to walk everything. The edit at risk is almost always in the tab you are *not* looking at — that is the entire reason the prompt exists — so `TabsWithUnsavedChanges()` is over `MainTabControl.Items`, not `SelectedItem`. `OnClosing` cancels the first pass, asks, and re-issues the close, because the prompt is async and `Closing` is not.

Two things the prompt gets right that a yes/no dialog cannot:

- **Three answers, not two.** `ConfirmationDialog` collapses "don't save" and "cancel" into the same `false`. That is the one mistake this prompt cannot make: it is the difference between losing a tab and losing the app. Hence a separate `UnsavedChangesDialog` returning `Save` / `DontSave` / `Cancel`, with anything else — title bar, Escape — meaning Cancel.
- **A scratch tab's Save is a Save As.** A never-saved tab with typed content is dirty, and it has nowhere to write. `DecideClose(Save, hasFile: false)` returns `SaveAs`; saving it "in place" over a null path would destroy the query it was trying to rescue. `SaveQueryAsync` gained a `(tab, session)` overload returning `bool`, so the prompt can save a tab that is not the selected one and can tell a written file from a dismissed picker.

The marker is a swap, not an addition: `●` while dirty, back to `✕` under the pointer. A dot you cannot click is a tab you cannot close.

## What this deliberately does not do

- **Detached windows.** Closing a torn-off query window still discards without asking. `DetachedWindowHelper` is shared with plan and Query Store content and is outside this change; #462 is about tab close and window close.
- **macOS app termination.** Cmd+Q / Dock → Quit may not route through `Window.Closing` on every platform. Not chased here.
- **Plan tabs.** Read-only, as the issue says. `HasUnsavedChanges` only ever answers yes for a `QuerySessionControl`, and there is a test pinning that so a future "any tab can be dirty" refactor has to argue with something.
- **Autosave, or recovering the text after a Don't Save.** Don't Save means don't save.
- **Session restore.** `SaveOpenPlans` / `RestoreOpenPlans` untouched.

## Red-then-green

Every new test was written against the fix, then proven red by reverting the specific line it covers, then green again. Each mutation reddens exactly the tests it should and no others.

| Mutation of the fix | Tests that went red |
|---|---|
| `IsDirty => false` (the pre-fix state) | 5: dirty, retype, scratch tab, save/failed-save, window walk |
| Bare `_everEdited` bool instead of a text compare | `TypingBackToTheOriginalTextClearsTheDirtyState` |
| `MarkClean()` dropped from `LoadSqlFile` | 3: dirty, retype, window walk |
| `MarkClean()` dropped from `SaveQueryToPath` | `ASuccessfulSaveSettlesTheTabAndAFailedOneDoesNot` |
| `MarkClean()` moved *before* the write | `ASuccessfulSaveSettlesTheTabAndAFailedOneDoesNot` |
| `DecideClose` always returns `SaveInPlace` | `AScratchTabWithTypedContentIsDirtyAndItsSaveGoesThroughSaveAs` |
| `DontSave` mapped to `Cancel` (the yes/no trap) | `CancelRefusesTheCloseAndDontSaveGoesThroughWithIt` |
| Glyph ignores pointer-over | `TheModifiedMarkerGivesWayToTheCloseButtonUnderThePointer` |
| `TabsWithUnsavedChanges` returns only the selected tab | `ClosingTheWindowAsksAboutEveryTabNotJustTheSelectedOne` |
| `HasUnsavedChanges` also claims plan tabs | `PlanTabsAreNeverDirty` |
| Header never subscribes to `DirtyStateChanged` | 3 marker assertions |

## Tests

`335 passed / 0 failed / 2 skipped` → `343 passed / 0 failed / 2 skipped`. Run with the in-process runner (`dotnet test` reports zero tests under SDK 10.0.302 here — pre-existing, unrelated to this change).

What is covered by tests: the dirty flag in both directions, the load and save baselines including the failed-save case, the scratch-tab Save As routing, the glyph swap, the every-tab walk, and the full `DecideClose` mapping.

What rests on manual reasoning: showing the dialog and clicking one of its three buttons, and the pointer actually entering the close button. Neither is answerable headlessly, which is why the decision each one feeds is a plain value in a testable method rather than something only the dialog knows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xj7HmCKrnsz2PWkRKT2Jx
