### PR TITLE
Stop ShowError from crashing the app at launch (#471)

### DIFF
--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -512,6 +512,16 @@ public partial class MainWindow : Window
     // ── Recent Plans & Session Restore ────────────────────────────────────
 
 
+    /// <summary>
+    /// One modal for everything that goes wrong outside a file operation — a plan that is not
+    /// a plan, a clipboard with nothing in it, advice that could not be built.
+    ///
+    /// <para>Shown ownerless until this window is visible, for the same reason ShowFileError is.
+    /// Both the command-line open and the restore of the previous session's tabs run from the
+    /// constructor, so a plan file that fails XML validation at startup reaches here before there
+    /// is anything to be modal over, and ShowDialog against a window that has not been shown
+    /// throws rather than reporting the problem it was called about.</para>
+    /// </summary>
     private void ShowError(string message)
     {
         var dialog = new Window
@@ -538,7 +548,11 @@ public partial class MainWindow : Window
                 }
             }
         };
-        dialog.ShowDialog(this);
+
+        if (IsVisible)
+            dialog.ShowDialog(this);
+        else
+            dialog.Show();
     }
 
     private async Task CheckForUpdatesOnStartupAsync()

--- a/tests/PlanViewer.Core.Tests/ShowErrorBeforeVisibleTests.cs
+++ b/tests/PlanViewer.Core.Tests/ShowErrorBeforeVisibleTests.cs
@@ -1,0 +1,73 @@
+using System.IO;
+using PlanViewer.App;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #471: the same startup crash #459 cured in ShowFileError, still living in ShowError.
+///
+/// <para>Both the command-line open and the restore of the previous session's tabs run from
+/// the MainWindow constructor, before the window has been shown. A plan file that fails XML
+/// validation on that path reaches ShowError with nothing to be modal over, and ShowDialog
+/// against a window that has not been shown throws InvalidOperationException: "Cannot show
+/// window with non-visible owner" — so the app dies at launch instead of reporting the file
+/// it was called about.</para>
+///
+/// <para>These drive LoadPlanFile against a never-shown window, which is exactly the startup
+/// shape, and assert only that nothing escapes. What the dialog says is not the point; that
+/// it can be raised at all is.</para>
+/// </summary>
+public class ShowErrorBeforeVisibleTests
+{
+    [Fact]
+    public void AMalformedPlanFileIsReportedRatherThanThrownAtStartup()
+    {
+        HeadlessUi.Run(() =>
+        {
+            /* A .sql routed through LoadPlanFile is how this reproduced during #463's red run:
+               XDocument.Parse throws, ValidatePlanXml calls ShowError. */
+            var path = TempPlan("SELECT 1 AS not_a_plan;");
+            try
+            {
+                var window = new MainWindow();
+                Assert.False(window.IsVisible);
+
+                Assert.Null(Record.Exception(() => window.LoadPlanFile(path)));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    [Fact]
+    public void WellFormedXmlThatIsNotAPlanIsAlsoReportedRatherThanThrown()
+    {
+        HeadlessUi.Run(() =>
+        {
+            /* The other arm of ValidatePlanXml: parses cleanly, no ShowPlanXML anywhere in it.
+               A corrupt or truncated file can land on either arm, so both have to survive
+               being reported before the window exists. */
+            var path = TempPlan("<Nonsense><Inner/></Nonsense>");
+            try
+            {
+                var window = new MainWindow();
+                Assert.False(window.IsVisible);
+
+                Assert.Null(Record.Exception(() => window.LoadPlanFile(path)));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    private static string TempPlan(string text)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sqlplan");
+        File.WriteAllText(path, text);
+        return path;
+    }
+}


### PR DESCRIPTION
Closes #471.

`ShowError` ended with a bare `dialog.ShowDialog(this)`. Avalonia refuses that against an owner that has never been shown — `InvalidOperationException: Cannot show window with non-visible owner` — and both `LoadPlanFile(args[1])` and the session restore run from the `MainWindow` constructor, before the window is up. So a plan file that failed XML validation at startup, corrupt on disk or truncated by whatever sync client, killed the app on the way to telling you about it. The report was the crash.

`ShowFileError` was cured of exactly this in #459 and its doc comment spells the trap out. `ShowError` never got the same treatment, which is why it turned up again while testing #463's restore path. Same fix, same shape, and the doc comment goes with it so nobody tidies the guard away later thinking it is redundant:

```csharp
if (IsVisible)
    dialog.ShowDialog(this);
else
    dialog.Show();
```

### Proof

`ShowErrorBeforeVisibleTests` drives `LoadPlanFile` against a never-shown `MainWindow` and asserts nothing escapes. Both arms of `ValidatePlanXml` are covered, because a damaged file can land on either: XML that will not parse, and XML that parses fine but has no `ShowPlanXML` in it.

Red first, against the unguarded method — both tests, same exception:

```
Assert.Null() Failure: Value is not null
Actual: System.InvalidOperationException: Cannot show window with non-visible owner.
   at Avalonia.Controls.Window.EnsureParentStateBeforeShow(Window owner)
   at Avalonia.Controls.Window.ShowDialog(Window owner)
   at PlanViewer.App.MainWindow.ShowError(String message) in MainWindow.axaml.cs:line 541
   at PlanViewer.App.MainWindow.LoadPlanFile(String filePath) in MainWindow.FileOps.cs:line 351
Total: 2, Failed: 2
```

Green with the guard: `Total: 2, Failed: 0`.

Full suite: 353 total, 0 failed, 2 skipped — the 2 new tests on top of a 351/0/2 baseline, nothing else moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xj7HmCKrnsz2PWkRKT2Jx
