### PR TITLE
Ask whether there is a path to copy when the menu opens (#472)

### DIFF
--- a/src/PlanViewer.App/MainWindow.Tabs.cs
+++ b/src/PlanViewer.App/MainWindow.Tabs.cs
@@ -105,8 +105,8 @@ public partial class MainWindow : Window
         // Right-click context menu
         var copyPathItem = new MenuItem { Header = "Copy Path", Tag = tab };
         // Only visible when tab content has a file path
-        var filePath = GetTabFilePath(tab);
-        copyPathItem.IsVisible = filePath != null;
+        void RefreshCopyPathVisibility() => copyPathItem.IsVisible = GetTabFilePath(tab) != null;
+        RefreshCopyPathVisibility();
 
         var contextMenu = new ContextMenu
         {
@@ -122,6 +122,12 @@ public partial class MainWindow : Window
                 new MenuItem { Header = "Close All Tabs" }
             }
         };
+
+        /* #472: whether there is a path to copy is not a fact about the tab's birth. A scratch
+           query gains one the moment it is saved, and a tab can lose one. The menu is only
+           consulted when it opens, so that is when the question gets asked — the call above is
+           just the answer for a menu nobody has opened yet. */
+        contextMenu.Opening += (_, _) => RefreshCopyPathVisibility();
 
         foreach (var item in contextMenu.Items.OfType<MenuItem>())
             item.Click += TabContextMenu_Click;

--- a/tests/PlanViewer.Core.Tests/CopyPathVisibilityTests.cs
+++ b/tests/PlanViewer.Core.Tests/CopyPathVisibilityTests.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using PlanViewer.App;
+using PlanViewer.App.Controls;
+using PlanViewer.App.Services;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #472: <b>Copy Path</b> answered the question "is there a path to copy?" once, while the tab was
+/// being built, and never again. Open a scratch query and save it — the session gains a
+/// SourceFilePath, the tab is retitled after the file, and the menu item is still hidden, because
+/// it was told there was nothing to copy back when that was true. Only a restart, which rebuilds
+/// the tab, put it right.
+///
+/// The fix asks on <see cref="ContextMenu.Opening"/>, the one moment the menu is actually consulted,
+/// so these drive that event rather than reading the flag straight after construction — reading it
+/// cold is what the old code got right and is exactly what these have to not do.
+///
+/// <para><b>How the menu is opened here.</b> Avalonia raises ContextMenu.Opening from its
+/// ContextRequested handler on the attached control, not from ContextMenu.Open(): calling Open()
+/// directly sets IsOpen and never asks. So <see cref="RightClick"/> raises ContextRequestedEvent on
+/// the tab header, which is the same path a real right-click takes.</para>
+/// </summary>
+public class CopyPathVisibilityTests
+{
+    /// <summary>
+    /// The report, end to end: scratch query, no path, save, right-click, and the item is there
+    /// and copies the file it was saved to.
+    /// </summary>
+    [Fact]
+    public void CopyPathAppearsOnceAScratchQueryHasBeenSaved()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var savedAs = Path.Combine(Path.GetTempPath(), $"saved_{Path.GetRandomFileName()}.sql");
+            try
+            {
+                var window = new MainWindow();
+                window.NewQuery_Click(window, new RoutedEventArgs());
+
+                var tab = QueryTabs(window).Last();
+                var session = (QuerySessionControl)tab.Content!;
+                var copyPath = ContextMenuItem(tab, "Copy Path");
+
+                RightClick(tab);
+                Assert.False(copyPath.IsVisible,
+                    "a never-saved scratch query has no file, so there is nothing to copy");
+
+                session.QueryEditor.Text = "SELECT 1 AS saved;";
+                Assert.True(window.SaveQueryToPath(tab, session, savedAs));
+
+                RightClick(tab);
+                Assert.True(copyPath.IsVisible,
+                    "the query has a file now, and this menu is being opened after the save");
+
+                copyPath.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
+                Assert.Equal(savedAs, Pump(ClipboardHelper.TryGetTextAsync(window)));
+            }
+            finally
+            {
+                if (File.Exists(savedAs))
+                    File.Delete(savedAs);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The other direction, which recomputing gets for free: a tab that stops having a file stops
+    /// offering to copy one. A stale <c>true</c> would put a Copy Path on the menu that copies
+    /// nothing when clicked.
+    /// </summary>
+    [Fact]
+    public void CopyPathGoesAwayAgainWhenTheTabStopsHavingAFile()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1 AS opened;");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                var tab = QueryTabs(window).Last();
+                var copyPath = ContextMenuItem(tab, "Copy Path");
+
+                RightClick(tab);
+                Assert.True(copyPath.IsVisible, "the query was opened from a file");
+
+                ((QuerySessionControl)tab.Content!).SourceFilePath = null;
+
+                RightClick(tab);
+                Assert.False(copyPath.IsVisible, "there is no longer a path behind this tab");
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Raises the event a real right-click raises on the tab header, then closes the menu again so
+    /// the next call is a fresh open rather than a no-op on an already-open menu.
+    /// </summary>
+    private static void RightClick(TabItem tab)
+    {
+        var header = (StackPanel)tab.Header!;
+        header.RaiseEvent(new ContextRequestedEventArgs());
+        header.ContextMenu!.Close();
+    }
+
+    private static MenuItem ContextMenuItem(TabItem tab, string header) =>
+        ((StackPanel)tab.Header!).ContextMenu!.Items
+            .OfType<MenuItem>()
+            .Single(i => (i.Header as string) == header);
+
+    /// <summary>
+    /// Drains the UI queue until the clipboard call finishes: Copy Path starts its write without
+    /// awaiting it, so the read that follows can be a dispatcher turn early.
+    /// </summary>
+    private static T Pump<T>(Task<T> task)
+    {
+        for (var i = 0; i < 100 && !task.IsCompleted; i++)
+            Dispatcher.UIThread.RunJobs();
+
+        Assert.True(task.IsCompleted, "the clipboard call never completed");
+        return task.GetAwaiter().GetResult();
+    }
+
+    private static string TempSql(string text)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+        File.WriteAllText(path, text);
+        return path;
+    }
+
+    private static IEnumerable<TabItem> QueryTabs(MainWindow window) =>
+        window.MainTabControl.Items.OfType<TabItem>().Where(t => t.Content is QuerySessionControl);
+}


### PR DESCRIPTION
Closes #472.

`CreateTab` worked out whether Copy Path had anything to copy exactly once, while the tab was being built, and then never asked again:

```csharp
var filePath = GetTabFilePath(tab);
copyPathItem.IsVisible = filePath != null;
```

Open a scratch query, save it. The session now has a `SourceFilePath`, the tab is retitled after the file, and Copy Path is still missing from the menu, because it was told there was nothing to copy back when that was the truth. It stayed wrong until a restart rebuilt the tab.

The gate now recomputes on `ContextMenu.Opening`. The menu is only ever consulted when it opens, so that is the honest moment to answer the question, and it covers the reverse for free — a tab that stops having a file stops offering to copy one, instead of leaving a menu item that copies nothing when you click it. The construction-time call stays, because a menu nobody has opened yet still needs a right answer.

## On the tests

They drive the gesture, not the handler. Avalonia raises `ContextMenu.Opening` from its `ContextRequested` handler on the attached control, not from `ContextMenu.Open()` — calling `Open()` programmatically sets `IsOpen` and never asks the question, which I confirmed the hard way. So the tests raise `ContextRequestedEvent` on the tab header, which is the path a real right-click takes, and close the menu again so the next one is a fresh open.

Two of them, both red against the one-shot code and each failing on the assertion *after* the change rather than the one before it:

- the report end to end: new scratch query, right-click, hidden; `SaveQueryToPath`; right-click, visible, and clicking it puts the saved path on the clipboard
- the other direction: a query opened from a file offers Copy Path, and stops once the path is gone

Full suite: 353 total, 0 failed, 2 skipped (351 before, so +2 and nothing disturbed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xj7HmCKrnsz2PWkRKT2Jx
