### PR TITLE
Ask before a detached window throws away unsaved query changes (#473)

### DIFF
--- a/src/PlanViewer.App/Helpers/DetachedWindowHelper.cs
+++ b/src/PlanViewer.App/Helpers/DetachedWindowHelper.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.Threading;
 
 namespace PlanViewer.App.Helpers;
 
@@ -20,6 +22,17 @@ internal static class DetachedWindowHelper
 	/// <param name="backgroundBrush">Window background brush.</param>
 	/// <param name="onRedock">Called when the user clicks Re-dock. Content has already been removed from the wrapper.</param>
 	/// <param name="onClosing">Called when the window is closing (before destroy). Use to cancel fetches etc.</param>
+	/// <param name="closeGuard">
+	/// Asked, synchronously, whether this close has a question attached to it (#473).
+	///
+	/// <para>Returning null closes on the spot with nothing asked and nothing delayed — that is
+	/// read-only content, an unmodified query, and app shutdown, so the path a plan or a Query
+	/// Store window takes is the one it always took. Returning a task cancels the close until
+	/// that task answers: true re-issues it, false leaves the window open.</para>
+	///
+	/// <para>Re-dock never consults it. The content is being moved, not destroyed, so there is
+	/// nothing to save it from.</para>
+	/// </param>
 	/// <returns>The created Window instance.</returns>
 	public static Window ShowDetached(
 		Control content,
@@ -27,7 +40,8 @@ internal static class DetachedWindowHelper
 		WindowIcon? icon,
 		Avalonia.Media.IBrush? backgroundBrush,
 		Action<Control> onRedock,
-		Action<Control>? onClosing = null)
+		Action<Control>? onClosing = null,
+		Func<Control, Window, Task<bool>?>? closeGuard = null)
 	{
 		var redockBtn = new Button
 		{
@@ -70,6 +84,9 @@ internal static class DetachedWindowHelper
 
 		bool redocked = false;
 
+		// Set once the guard has answered, so the re-issued close is not questioned again.
+		bool closeConfirmed = false;
+
 		redockBtn.Click += (_, _) =>
 		{
 			if (redocked) return;
@@ -81,10 +98,41 @@ internal static class DetachedWindowHelper
 			onRedock(content);
 		};
 
-		detachedWindow.Closing += (_, _) =>
+		// Avalonia's Closing is synchronous and an unsaved-changes prompt is not, so the first
+		// pass cancels the close outright and re-issues it once the question has an answer.
+		// Same cancel-then-reissue MainWindow.OnClosing uses (#462); closeConfirmed is the
+		// latch that stops the second pass asking all over again.
+		async Task ReissueCloseIfConfirmed(Task<bool> pending)
 		{
-			if (!redocked)
-				onClosing?.Invoke(content);
+			if (!await pending)
+				return;
+
+			closeConfirmed = true;
+
+			// Posted rather than called: a guard that answers without ever actually waiting
+			// would otherwise land Close() in the middle of the Closing handler that called
+			// it. Safe to post because the guard returns null during app shutdown, so nothing
+			// is ever queued against a dispatcher that is going away.
+			Dispatcher.UIThread.Post(detachedWindow.Close);
+		}
+
+		detachedWindow.Closing += (_, e) =>
+		{
+			if (redocked)
+				return;
+
+			if (!closeConfirmed && closeGuard != null)
+			{
+				var pending = closeGuard(content, detachedWindow);
+				if (pending != null)
+				{
+					e.Cancel = true;
+					_ = ReissueCloseIfConfirmed(pending);
+					return;
+				}
+			}
+
+			onClosing?.Invoke(content);
 		};
 
 		detachedWindow.Show();

--- a/src/PlanViewer.App/MainWindow.FileOps.cs
+++ b/src/PlanViewer.App/MainWindow.FileOps.cs
@@ -119,10 +119,18 @@ public partial class MainWindow : Window
     /// Saves a named tab rather than whichever one is selected. The unsaved-changes prompt
     /// (#462) walks every tab, so it needs to save one that is not the active one, and a
     /// scratch tab answering Save arrives here to get a path.
+    ///
+    /// <para>#473 brings two wrinkles, both from sessions that are no longer tabs. A detached
+    /// session has no <paramref name="tab"/> to retitle, hence the null. And the picker has to
+    /// come off the window doing the asking: <see cref="Window.StorageProvider"/> here is the
+    /// main window's, so a detached window closing with unsaved work would put its Save As
+    /// dialog on a window behind the one the user is looking at — and, at shutdown, on one
+    /// that is closing. <paramref name="storage"/> is how the caller says which window.</para>
     /// </summary>
     /// <returns>Whether the query reached disk. False also covers the user closing the picker.</returns>
-    private async Task<bool> SaveQueryAsync(TabItem tab, QuerySessionControl session)
+    private async Task<bool> SaveQueryAsync(TabItem? tab, QuerySessionControl session, IStorageProvider? storage = null)
     {
+        var picker = storage ?? StorageProvider;
         var existing = session.SourceFilePath;
 
         var options = new FilePickerSaveOptions
@@ -144,10 +152,10 @@ public partial class MainWindow : Window
         {
             var directory = Path.GetDirectoryName(existing);
             if (!string.IsNullOrEmpty(directory))
-                options.SuggestedStartLocation = await StorageProvider.TryGetFolderFromPathAsync(directory);
+                options.SuggestedStartLocation = await picker.TryGetFolderFromPathAsync(directory);
         }
 
-        var file = await StorageProvider.SaveFilePickerAsync(options);
+        var file = await picker.SaveFilePickerAsync(options);
 
         var path = file?.TryGetLocalPath();
         return path != null && SaveQueryToPath(tab, session, path);
@@ -156,8 +164,12 @@ public partial class MainWindow : Window
     /// <summary>
     /// The half of saving that does not need a human: write the text, remember where it went,
     /// and retitle the tab to match. Split out from the picker so it can be tested.
+    ///
+    /// <para><paramref name="tab"/> is null for a session that has been detached into its own
+    /// window (#473). There is no tab to retitle; everything else about the save is the same,
+    /// including which side of the write settles the dirty state.</para>
     /// </summary>
-    internal bool SaveQueryToPath(TabItem tab, QuerySessionControl session, string path)
+    internal bool SaveQueryToPath(TabItem? tab, QuerySessionControl session, string path)
     {
         try
         {
@@ -166,7 +178,10 @@ public partial class MainWindow : Window
             // Only a write that actually happened settles the dirty state; the catch below
             // deliberately leaves the session modified so the work is still guarded.
             session.MarkClean();
-            SetTabLabel(tab, Path.GetFileName(path));
+
+            if (tab != null)
+                SetTabLabel(tab, Path.GetFileName(path));
+
             return true;
         }
         catch (Exception ex)

--- a/src/PlanViewer.App/MainWindow.Tabs.cs
+++ b/src/PlanViewer.App/MainWindow.Tabs.cs
@@ -289,11 +289,17 @@ public partial class MainWindow : Window
     /// Detaches a tab's content into a standalone free-floating window.
     /// The window's Close button closes it permanently.
     /// A "Re-dock" button in the toolbar allows the user to explicitly return the content to a tab.
+    ///
+    /// <para>#473: permanently used to mean silently. A query session that leaves the tab strip
+    /// takes its unsaved edit with it, out of reach of both #462 prompts, so the window gets a
+    /// close guard and the session goes on the detached register until it comes back or the
+    /// window closes.</para>
     /// </summary>
-    private void DetachTabToWindow(TabItem tab)
+    /// <returns>The detached window, or null when the tab had no content to detach.</returns>
+    internal Window? DetachTabToWindow(TabItem tab)
     {
         var content = tab.Content as Control;
-        if (content == null) return;
+        if (content == null) return null;
 
         var label = GetTabLabel(tab);
 
@@ -305,13 +311,15 @@ public partial class MainWindow : Window
         if (content is QueryStoreHistoryControl historyControl)
             historyControl.ShowCloseButton(false);
 
-        DetachedWindowHelper.ShowDetached(
+        var detachedWindow = DetachedWindowHelper.ShowDetached(
             content,
             title: label,
             icon: this.Icon,
             backgroundBrush: (Avalonia.Media.IBrush?)this.FindResource("BackgroundBrush"),
             onRedock: c =>
             {
+                ForgetDetachedQuerySession(c);
+
                 if (!IsShuttingDown)
                 {
                     var newTab = CreateTab(label, c);
@@ -322,8 +330,14 @@ public partial class MainWindow : Window
             },
             onClosing: c =>
             {
+                ForgetDetachedQuerySession(c);
+
                 if (c is QueryStoreHistoryControl hc)
                     hc.CancelFetch();
-            });
+            },
+            closeGuard: DetachedQueryCloseGuard);
+
+        RememberDetachedQuerySession(detachedWindow, content);
+        return detachedWindow;
     }
 }

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -294,6 +294,122 @@ public partial class MainWindow : Window
     internal List<TabItem> TabsWithUnsavedChanges() =>
         MainTabControl.Items.OfType<TabItem>().Where(HasUnsavedChanges).ToList();
 
+    // ── Unsaved changes in a detached window (#473) ───────────────────────
+
+    /// <summary>
+    /// The query sessions living in a detached window right now, and the window each is in.
+    ///
+    /// <para>A detached session is not in <see cref="MainTabControl"/>.Items, so
+    /// <see cref="TabsWithUnsavedChanges"/> cannot see it: without this register the shutdown
+    /// prompt honestly reports nothing to save while a dirty edit sits in another window.
+    /// Detaching adds to it; re-docking and closing both take back out, which is why the
+    /// register is keyed on the content control rather than on the tab it came from — by then
+    /// there is no tab.</para>
+    ///
+    /// <para>Only query sessions go on it. Plan and Query Store windows are read-only and have
+    /// nothing to lose, so there is nothing to remember about them.</para>
+    /// </summary>
+    private readonly List<(Window Window, QuerySessionControl Session)> _detachedQuerySessions = new();
+
+    /// <summary>Every query session currently detached, dirty or not.</summary>
+    internal IReadOnlyList<(Window Window, QuerySessionControl Session)> DetachedQuerySessions =>
+        _detachedQuerySessions;
+
+    internal void RememberDetachedQuerySession(Window window, Control content)
+    {
+        if (content is QuerySessionControl session)
+            _detachedQuerySessions.Add((window, session));
+    }
+
+    internal void ForgetDetachedQuerySession(Control content)
+    {
+        if (content is QuerySessionControl session)
+            _detachedQuerySessions.RemoveAll(d => d.Session == session);
+    }
+
+    /// <summary>
+    /// Whether closing a detached window has to stop and ask.
+    ///
+    /// <para>Static and pure so the decision is testable without a window to click, the same
+    /// trade <see cref="DecideClose"/> makes. Three ways to answer no, and each one matters:
+    /// read-only content (a plan, a Query Store window) has nothing to save, an unmodified
+    /// session has nothing to save, and once the app is shutting down the question has already
+    /// been asked — <see cref="ConfirmWindowCloseAsync"/> asks it while the main window is
+    /// still up, precisely so that <see cref="OnClosed"/> can force these windows shut without
+    /// raising a dialog over a window that no longer exists.</para>
+    /// </summary>
+    internal static bool DetachedContentNeedsSavePrompt(Control content, bool isShuttingDown) =>
+        !isShuttingDown && content is QuerySessionControl { IsDirty: true };
+
+    /// <summary>
+    /// The close guard handed to every detached window. Returning null is the whole read-only
+    /// path: no prompt, no cancelled close, no detour.
+    /// </summary>
+    internal Task<bool>? DetachedQueryCloseGuard(Control content, Window detachedWindow) =>
+        DetachedContentNeedsSavePrompt(content, IsShuttingDown)
+            ? ConfirmDetachedCloseAsync((QuerySessionControl)content, detachedWindow)
+            : null;
+
+    /// <summary>
+    /// Asks about a detached session, owned by the window that is being closed rather than by
+    /// the main one — the answer is about that window's content, and a prompt parented to a
+    /// window behind it is a prompt nobody can see. The file picker a Save As needs is taken
+    /// from the same window for the same reason.
+    /// </summary>
+    /// <returns>Whether the close may proceed.</returns>
+    private async Task<bool> ConfirmDetachedCloseAsync(QuerySessionControl session, Window owner)
+    {
+        // The shutdown walk works from a snapshot, and a save taken during it settles more than
+        // its own entry. Same early out ConfirmCloseAsync has, for the same reason.
+        if (!session.IsDirty)
+            return true;
+
+        owner.Activate(); // show what is being asked about, as the tab walk does with selection
+
+        var choice = await UnsavedChangesDialog.ShowAsync(owner, owner.Title ?? "this query");
+
+        return DecideClose(choice, session.SourceFilePath != null) switch
+        {
+            CloseAction.Cancel => false,
+            CloseAction.Close => true,
+            CloseAction.SaveInPlace => SaveQueryToPath(null, session, session.SourceFilePath!),
+            _ => await SaveQueryAsync(null, session, owner.StorageProvider)
+        };
+    }
+
+    /// <summary>
+    /// Every detached window that would lose work if the app closed right now.
+    /// </summary>
+    internal List<(Window Window, QuerySessionControl Session)> DetachedSessionsWithUnsavedChanges() =>
+        _detachedQuerySessions.Where(d => d.Session.IsDirty).ToList();
+
+    /// <summary>
+    /// Everything closing the app would throw away, in the order it will be asked about: the
+    /// tabs first in tab order, then the detached windows.
+    ///
+    /// <para>One list rather than two walks, because two walks is how the second one gets
+    /// forgotten — which is the whole of #473. <c>Tab</c> is null for a detached session; there
+    /// is no tab, and <c>Owner</c> is the window that has to own its prompt.</para>
+    /// </summary>
+    internal List<(TabItem? Tab, QuerySessionControl Session, Window Owner)> UnsavedWorkOnClose()
+    {
+        var work = new List<(TabItem? Tab, QuerySessionControl Session, Window Owner)>();
+
+        foreach (var tab in TabsWithUnsavedChanges())
+            work.Add((tab, (QuerySessionControl)tab.Content!, this));
+
+        foreach (var detached in DetachedSessionsWithUnsavedChanges())
+            work.Add((null, detached.Session, detached.Window));
+
+        return work;
+    }
+
+    /// <summary>
+    /// Whether closing the main window has anything to ask about at all. Tabs and detached
+    /// windows both count: "Detach to Window" is not a way to opt out of being asked.
+    /// </summary>
+    internal bool CloseNeedsConfirmation() => UnsavedWorkOnClose().Count > 0;
+
     /// <summary>
     /// What the close path does with an answer to the prompt.
     /// </summary>
@@ -395,10 +511,13 @@ public partial class MainWindow : Window
     /// outright and re-issues it from <see cref="ConfirmWindowCloseAsync"/> once every tab
     /// has answered. Anything that is not a query tab, and any window with nothing modified,
     /// closes on the first pass without a detour.</para>
+    ///
+    /// <para>#473: "every tab" is not everything. A detached session is off the tab strip and
+    /// still holds unsaved work, so <see cref="CloseNeedsConfirmation"/> counts those too.</para>
     /// </summary>
     protected override void OnClosing(WindowClosingEventArgs e)
     {
-        if (!_closeConfirmed && TabsWithUnsavedChanges().Count > 0)
+        if (!_closeConfirmed && CloseNeedsConfirmation())
         {
             e.Cancel = true;
             _ = ConfirmWindowCloseAsync();
@@ -410,9 +529,19 @@ public partial class MainWindow : Window
 
     private async Task ConfirmWindowCloseAsync()
     {
-        foreach (var tab in MainTabControl.Items.OfType<TabItem>().ToList())
+        /* #473: the sessions that are no longer tabs are asked about here, while every window
+           is still up, rather than from OnClosed where they are force-closed. By then the main
+           window is gone and the app is on its way out — a dialog raised there is at best a
+           window nobody expects and at worst a shutdown that never finishes. Asking here is
+           what earns DetachedContentNeedsSavePrompt the right to wave that force-close
+           through. */
+        foreach (var work in UnsavedWorkOnClose())
         {
-            if (!await ConfirmCloseAsync(tab))
+            var mayClose = work.Tab != null
+                ? await ConfirmCloseAsync(work.Tab)
+                : await ConfirmDetachedCloseAsync(work.Session, work.Owner);
+
+            if (!mayClose)
                 return; // one Cancel cancels the shutdown
         }
 

--- a/tests/PlanViewer.Core.Tests/DetachedUnsavedChangesTests.cs
+++ b/tests/PlanViewer.Core.Tests/DetachedUnsavedChangesTests.cs
@@ -1,0 +1,503 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using PlanViewer.App;
+using PlanViewer.App.Controls;
+using PlanViewer.App.Helpers;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #473: #462 gave query tabs an unsaved-changes prompt on tab close and on window close, and
+/// a detached window dodged both. Its close path is the helper's own and asked nobody anything,
+/// and while detached the session is out of MainTabControl.Items, so the shutdown walk honestly
+/// reported nothing to save with a dirty edit sitting in another window.
+///
+/// <para>Same testing shape as UnsavedQueryChangesTests: the dialog cannot be clicked headlessly,
+/// so the decision is a pure value — <see cref="MainWindow.DetachedContentNeedsSavePrompt"/> for
+/// whether to ask at all, <see cref="MainWindow.DecideClose"/> (#462, already pinned) for what to
+/// do with the answer — and what is tested here is the walk and the wiring around them.</para>
+///
+/// <para>Nothing here puts a PlanViewerControl inside a Window. Read-only content is represented
+/// by a <see cref="QueryStoreHistoryControl"/>, which detaches through the same helper and takes
+/// the same silent path a plan does.</para>
+/// </summary>
+public class DetachedUnsavedChangesTests
+{
+    [Fact]
+    public void ADirtyDetachedSessionIsSeenWhereACleanOneIsNot()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            Window? detached = null;
+            QuerySessionControl? session = null;
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                var tab = LastQueryTab(window);
+                session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 2; -- unsaved work";
+
+                detached = window.DetachTabToWindow(tab)!;
+
+                /* The bug, stated as an assertion: the edit is no longer on the tab strip, which
+                   is the only place #462 knew to look. */
+                Assert.Empty(window.TabsWithUnsavedChanges());
+
+                Assert.Equal(
+                    new[] { session },
+                    window.DetachedSessionsWithUnsavedChanges().Select(d => d.Session));
+
+                session.MarkClean();
+                Assert.Empty(window.DetachedSessionsWithUnsavedChanges());
+                Assert.Single(window.DetachedQuerySessions); // still detached, just not dirty
+            }
+            finally
+            {
+                PutAway(detached, session);
+                File.Delete(path);
+            }
+        });
+    }
+
+    [Fact]
+    public void TheShutdownPromptCountsDetachedSessionsAsWellAsTabs()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            Window? detached = null;
+            QuerySessionControl? session = null;
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                var tab = LastQueryTab(window);
+                session = (QuerySessionControl)tab.Content!;
+
+                Assert.False(window.CloseNeedsConfirmation(), "nothing modified anywhere");
+
+                session.QueryEditor.Text = "SELECT 2; -- unsaved work";
+                Assert.True(window.CloseNeedsConfirmation());
+
+                detached = window.DetachTabToWindow(tab)!;
+
+                /* Detaching is not a way to opt out of being asked. Before this change the tab
+                   walk was the whole question, so this went back to false the moment the window
+                   was torn off and the app shut down over the top of the edit. */
+                Assert.Empty(window.TabsWithUnsavedChanges());
+                Assert.True(window.CloseNeedsConfirmation());
+
+                session.MarkClean();
+                Assert.False(window.CloseNeedsConfirmation());
+            }
+            finally
+            {
+                PutAway(detached, session);
+                File.Delete(path);
+            }
+        });
+    }
+
+    [Fact]
+    public void TheShutdownWalkAsksAboutTabsAndDetachedWindowsAlike()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var stays = TempSql("SELECT 1;");
+            var leaves = TempSql("SELECT 2;");
+            var clean = TempSql("SELECT 3;");
+            Window? detached = null;
+            QuerySessionControl? torn = null;
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(stays);
+                window.LoadSqlFile(leaves);
+                window.LoadSqlFile(clean);
+
+                var tabs = window.MainTabControl.Items.OfType<TabItem>()
+                    .Where(t => t.Content is QuerySessionControl).ToList();
+
+                var stayingTab = tabs[^3];
+                var leavingTab = tabs[^2];
+                var cleanTab = tabs[^1];
+
+                var staying = (QuerySessionControl)stayingTab.Content!;
+                torn = (QuerySessionControl)leavingTab.Content!;
+
+                staying.QueryEditor.Text = "SELECT 1; -- edited";
+                torn.QueryEditor.Text = "SELECT 2; -- edited";
+
+                detached = window.DetachTabToWindow(leavingTab)!;
+
+                /* What the shutdown prompt will actually ask about, in the order it will ask.
+                   Tabs first, then the windows that used to be tabs; the clean tab is in neither
+                   list. Before this the second half of the walk did not exist, and an edit was
+                   one Detach to Window away from being discarded without a question. */
+                var work = window.UnsavedWorkOnClose();
+
+                Assert.Equal(new[] { staying, torn }, work.Select(w => w.Session));
+                Assert.Equal(new TabItem?[] { stayingTab, null }, work.Select(w => w.Tab));
+
+                /* And the prompt each one gets is owned by the window it is about. A dialog
+                   parented to the main window while the session it names is in another one is
+                   a question about something the user cannot see. */
+                Assert.Same(window, work[0].Owner);
+                Assert.Same(detached, work[1].Owner);
+
+                Assert.DoesNotContain(cleanTab.Content, work.Select(w => (object?)w.Session));
+            }
+            finally
+            {
+                PutAway(detached, torn);
+                File.Delete(stays);
+                File.Delete(leaves);
+                File.Delete(clean);
+            }
+        });
+    }
+
+    [Fact]
+    public void ReadOnlyDetachedContentIsNeverAskedAbout()
+    {
+        HeadlessUi.Run(() =>
+        {
+            /* Plans and Query Store windows detach through the same helper and have nothing to
+               save. The guard has to answer no for them without a dialog and without cancelling
+               anything, or every read-only close grows a detour it has no use for. */
+            Assert.False(
+                MainWindow.DetachedContentNeedsSavePrompt(new QueryStoreHistoryControl(), isShuttingDown: false));
+
+            var window = new MainWindow();
+            Assert.Null(window.DetachedQueryCloseGuard(new QueryStoreHistoryControl(), window));
+        });
+    }
+
+    [Fact]
+    public void OnlyADirtySessionIsAskedAboutAndNotOnceTheAppIsShuttingDown()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+                var session = (QuerySessionControl)LastQueryTab(window).Content!;
+
+                Assert.False(
+                    MainWindow.DetachedContentNeedsSavePrompt(session, isShuttingDown: false),
+                    "an unmodified session has nothing to lose");
+
+                session.QueryEditor.Text = "SELECT 2; -- unsaved work";
+
+                Assert.True(
+                    MainWindow.DetachedContentNeedsSavePrompt(session, isShuttingDown: false));
+
+                /* The shutdown answer, and the reason it is a parameter rather than something the
+                   guard reads for itself in a test. OnClosed force-closes every detached window
+                   after the main window is already gone; a prompt raised there is owned by a
+                   window nobody is looking at and gates a shutdown that has nowhere left to ask.
+                   ConfirmWindowCloseAsync asks while everything is still up, which is what earns
+                   this no. */
+                Assert.False(
+                    MainWindow.DetachedContentNeedsSavePrompt(session, isShuttingDown: true));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    [Fact]
+    public void RedockingDoesNotPrompt()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            Window? detached = null;
+            QuerySessionControl? session = null;
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                var tab = LastQueryTab(window);
+                session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 2; -- unsaved work";
+
+                detached = window.DetachTabToWindow(tab)!;
+
+                /* Re-dock moves the content, it does not destroy it, so there is nothing to save
+                   it from — and the session is dirty, so a guard that did fire here would have
+                   plenty to say. */
+                RedockButton(detached).RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                Dispatcher.UIThread.RunJobs();
+
+                /* The two assertions that catch a guard firing on this path. Re-dock hands the
+                   content back whether or not the window agreed to close, so the tab coming back
+                   proves nothing on its own: what a guard would leave behind is the emptied
+                   window still open, with a prompt on it, asking about a session that is already
+                   somewhere else. */
+                Assert.False(detached.IsVisible, "Re-dock has to actually close the window");
+                Assert.Empty(detached.OwnedWindows);
+
+                Assert.Empty(window.DetachedQuerySessions);
+
+                var redockedTab = LastQueryTab(window);
+                Assert.Same(session, redockedTab.Content);
+                Assert.True(MainWindow.HasUnsavedChanges(redockedTab), "the edit came back with it");
+            }
+            finally
+            {
+                PutAway(detached, session);
+                File.Delete(path);
+            }
+        });
+    }
+
+    [Fact]
+    public void TheGuardCancelsACloseAndTheAnswerIsOnlyAskedForOnce()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var asked = 0;
+            var destroyed = 0;
+            var answer = false;
+
+            var detached = DetachedWindowHelper.ShowDetached(
+                new TextBlock { Text = "content" },
+                title: "Detached",
+                icon: null,
+                backgroundBrush: null,
+                onRedock: _ => { },
+                onClosing: _ => destroyed++,
+                /* The cap is a fuse, not part of the contract: a helper that lost its latch
+                   would re-ask its way round the post-and-close loop forever, and a test that
+                   hangs tells you nothing. Four asks is already the failure. */
+                closeGuard: (_, _) => { asked++; return Task.FromResult(answer && asked <= 3); });
+            try
+            {
+                detached.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.Equal(1, asked);
+                Assert.Equal(0, destroyed);
+                Assert.True(detached.IsVisible, "Cancel has to actually keep the window open");
+
+                answer = true;
+                detached.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                /* Two closes, two questions. The re-issued close is not a third, and that is
+                   the latch doing its job — without it the close the guard just authorised gets
+                   handed straight back to the guard. */
+                Assert.Equal(2, asked);
+                Assert.Equal(1, destroyed);
+            }
+            finally
+            {
+                answer = true;
+                PutAway(detached);
+            }
+        });
+    }
+
+    [Fact]
+    public void AGuardlessDetachIsUntouchedAndClosesOnTheFirstPass()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var destroyed = 0;
+
+            /* The Query Store sub-tab detach passes no guard at all, so its close is the one it
+               always was: straight through, nothing cancelled, nothing posted. */
+            var detached = DetachedWindowHelper.ShowDetached(
+                new QueryStoreHistoryControl(),
+                title: "History",
+                icon: null,
+                backgroundBrush: null,
+                onRedock: _ => { },
+                onClosing: _ => destroyed++);
+            try
+            {
+                detached.Close();
+
+                Assert.Equal(1, destroyed);
+            }
+            finally
+            {
+                PutAway(detached);
+            }
+        });
+    }
+
+    [Fact]
+    public void ClosingADetachedWindowWithUnsavedWorkDoesNotJustCloseIt()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            Window? detached = null;
+            QuerySessionControl? session = null;
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                var tab = LastQueryTab(window);
+                session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 2; -- unsaved work";
+
+                detached = window.DetachTabToWindow(tab)!;
+
+                detached.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                /* The whole of #473 in one assertion. This used to be a closed window and a lost
+                   edit; the close is now held while the prompt is up. Headless, nobody ever
+                   answers it, so the window is still here — which is the right shape of failure
+                   for a close that has a question outstanding. */
+                Assert.True(detached.IsVisible);
+                Assert.Single(window.DetachedQuerySessions);
+                Assert.True(session.IsDirty, "nothing was written and nothing was discarded");
+            }
+            finally
+            {
+                PutAway(detached, session);
+                File.Delete(path);
+            }
+        });
+    }
+
+    [Fact]
+    public void ADetachedSessionSavesWithNoTabToRetitle()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var opened = TempSql("SELECT 1;");
+            var savedAs = Path.Combine(Path.GetTempPath(), $"saved_{Path.GetRandomFileName()}.sql");
+            /* A directory that does not exist, so File.WriteAllText throws. */
+            var unwritable = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), "nope.sql");
+            Window? detached = null;
+            QuerySessionControl? session = null;
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(opened);
+
+                var tab = LastQueryTab(window);
+                session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 2 AS edited;";
+
+                detached = window.DetachTabToWindow(tab)!;
+
+                /* The save the prompt runs for a detached session has no tab behind it. The tab
+                   is what SaveQueryToPath retitles, so it has to tolerate not having one — and
+                   everything else about the save, including which side of the write settles the
+                   dirty state, still has to hold. */
+                Assert.False(window.SaveQueryToPath(null, session, unwritable));
+                Assert.True(session.IsDirty, "a save that threw has not saved anything");
+                Assert.Single(window.DetachedSessionsWithUnsavedChanges());
+
+                Assert.True(window.SaveQueryToPath(null, session, savedAs));
+                Assert.False(session.IsDirty);
+                Assert.Equal("SELECT 2 AS edited;", File.ReadAllText(savedAs));
+                Assert.Equal(savedAs, session.SourceFilePath);
+                Assert.Empty(window.DetachedSessionsWithUnsavedChanges());
+            }
+            finally
+            {
+                PutAway(detached, session);
+                File.Delete(opened);
+                if (File.Exists(savedAs))
+                    File.Delete(savedAs);
+            }
+        });
+    }
+
+    [Fact]
+    public void ClosingADetachedWindowTakesTheSessionOffTheRegister()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            Window? detached = null;
+            QuerySessionControl? session = null;
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                var tab = LastQueryTab(window);
+                detached = window.DetachTabToWindow(tab)!;
+                Assert.Single(window.DetachedQuerySessions);
+
+                /* Clean, so nothing is asked and the close goes through on the first pass. A
+                   register that kept the entry would have the shutdown prompt asking about a
+                   window that is not there any more. */
+                detached.Close();
+
+                Assert.Empty(window.DetachedQuerySessions);
+                Assert.False(window.CloseNeedsConfirmation());
+            }
+            finally
+            {
+                PutAway(detached, session);
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Puts a detached window and any prompt it is showing away, from a finally, whatever the
+    /// test did or failed to do.
+    ///
+    /// <para>One Avalonia application serves the whole assembly (see HeadlessUi), so a window
+    /// left open outlives the test that made it, and #474 is what that costs: a leaked window
+    /// poisons the session for everything queued behind it, and the failure surfaces somewhere
+    /// else entirely. Which makes cleanup a finally, not a last line — the run where it matters
+    /// is the run where an assertion above it failed.</para>
+    ///
+    /// <para>Deliberately not routed through the detached register: a test that has just broken
+    /// the register still has to be able to tidy up after itself.</para>
+    /// </summary>
+    private static void PutAway(Window? detached, QuerySessionControl? session = null)
+    {
+        if (detached == null)
+            return;
+
+        // Nothing headless can click one of the prompt's three buttons, so dismissing it is
+        // Cancel — which is why the session is settled before the window is closed again.
+        foreach (var prompt in detached.OwnedWindows.ToList())
+            prompt.Close();
+
+        session?.MarkClean();
+        detached.Close();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static Button RedockButton(Window detached) =>
+        ((DockPanel)detached.Content!).Children.OfType<StackPanel>().Single()
+            .Children.OfType<Button>().Single();
+
+    private static string TempSql(string text)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+        File.WriteAllText(path, text);
+        return path;
+    }
+
+    private static TabItem LastQueryTab(MainWindow window) =>
+        window.MainTabControl.Items.OfType<TabItem>()
+            .Last(t => t.Content is QuerySessionControl);
+}


### PR DESCRIPTION
Closes #473.

## What was actually wrong

#462 gave query tabs an unsaved-changes prompt on tab close and on window close. **Detach to Window** walked out past both of them.

Two separate holes, one root cause — a detached session stops being a tab:

1. **The window's own close asked nobody anything.** `DetachedWindowHelper.ShowDetached` owns that path, and its `Closing` handler did exactly one thing: tell the content it was going away so a Query Store fetch could be cancelled. There was no question in it, because the helper is shared with plan and Query Store content and neither of those has anything to lose. A dirty query session went out the same door.

2. **The shutdown prompt could not see it.** `TabsWithUnsavedChanges()` is over `MainTabControl.Items`, and a detached session is not in `MainTabControl.Items`. So the app closed reporting nothing to save, honestly, while the edit sat in a window two inches to the left.

The second one is the nastier of the two. The first is at least a window you are looking at when you close it. The second discards work in a window you are not.

## The guard

`ShowDetached` gains one parameter:

```csharp
Func<Control, Window, Task<bool>?>? closeGuard = null
```

It is asked, synchronously, once, before anything is destroyed, and it answers in one of two shapes:

- **null** — close now, nothing asked, nothing delayed. That is read-only content, an unmodified session, and app shutdown. A plan window and a Query Store window take *exactly* the path they took before this change: no cancelled close, no dispatcher post, no detour. `AGuardlessDetachIsUntouchedAndClosesOnTheFirstPass` pins that, and the mutation that gives everyone the detour reddens it.
- **a task** — cancel the close and hold the window until that task answers. True re-issues it, false leaves the window open.

That is the same cancel-then-reissue `MainWindow.OnClosing` does, and for the same reason: `Window.Closing` is synchronous and a prompt is not. A `closeConfirmed` latch is what stops the second pass asking the question all over again. The re-issued `Close()` is *posted* rather than called, so a guard that answers without ever actually waiting cannot land `Close()` in the middle of the `Closing` handler that called it — safe to post precisely because the guard returns null during shutdown, so nothing is ever queued against a dispatcher that is going away.

Re-dock never reaches the guard. The `redocked` flag is set before `Close()`, and the handler checks it first: the content is being *moved*, not destroyed, so there is nothing to save it from.

## The shutdown design decision, and why it is not where you would first put it

The obvious place to ask about detached windows is where they are closed — `MainWindow.OnClosed`, which force-closes every other window. That is the wrong place, and the issue says as much: by then the main window is already gone, the app is on its way out, and a modal raised there is at best a window nobody expects and at worst a shutdown that never finishes. A detached window that answers "Cancel" from `OnClosed` is a cancelled close on a window whose parent no longer exists.

So the question is asked one step earlier, from `ConfirmWindowCloseAsync`, while every window is still up. `DetachedContentNeedsSavePrompt` then returns false whenever `IsShuttingDown`, which is what lets `OnClosed` force those windows shut with no dialog and no cancelled close — the guard waves the force-close through because the question has already been asked and answered.

That inverts the usual reading of the flag: `IsShuttingDown` is not "skip the prompt to be safe", it is "the prompt already happened". The three ways `DetachedContentNeedsSavePrompt` answers no are all in that method with the reasoning attached, because the shutdown one is the one a future reader will otherwise delete.

The walk itself is now a single list:

```csharp
internal List<(TabItem? Tab, QuerySessionControl Session, Window Owner)> UnsavedWorkOnClose()
```

Tabs first in tab order, then the detached windows. One list rather than two walks, because two walks is how the second one gets forgotten — which is the whole of #473. `Tab` is null for a detached session; there is no tab. `Owner` is the window that has to own its prompt.

**No known gap on shutdown.** It is not merely lossy-but-clean; the shutdown confirmation genuinely counts detached dirty sessions and cancels on any Cancel.

## Which window the prompt belongs to

The prompt for a detached session is owned by the **detached** window, not the main one. A dialog parented to a window behind the one you are looking at is a question about something you cannot see, and at shutdown it is a question about a window that is closing.

The Save As picker had the same problem in a quieter way. `SaveQueryAsync` reached for `StorageProvider` — an unqualified `this.StorageProvider`, the main window's — so a detached window's Save As would have opened its picker on the wrong window. It now takes an `IStorageProvider` and the detached path hands it `owner.StorageProvider`.

`SaveQueryToPath` also had to learn that `tab` can be null. There is no tab to retitle. Everything else about the save is unchanged, including which side of the write settles the dirty state: the mutation that moves `MarkClean()` before the write is still red under #462's tests.

## Red-then-green

Every test was written against the fix, then proven red by reverting the specific behaviour it covers, then green again. Run in the shared single-session harness the rest of the suite uses, not in isolation.

| Mutation of the fix | Tests that went red |
|---|---|
| `DetachTabToWindow` passes no `closeGuard` (the pre-fix close path) | `ClosingADetachedWindowWithUnsavedWorkDoesNotJustCloseIt` |
| Detached session never goes on the register | 5: dirty-detected, shutdown-count, close-refused, register-cleared, tabless-save |
| Register never cleared when the detached window closes | `ClosingADetachedWindowTakesTheSessionOffTheRegister` |
| Register never cleared on Re-dock | `RedockingDoesNotPrompt` |
| `CloseNeedsConfirmation` counts tabs only (the #462 state) | `TheShutdownPromptCountsDetachedSessionsAsWellAsTabs` |
| `UnsavedWorkOnClose` stops at the tab strip | 2: shutdown-count, shutdown-walk |
| Detached prompt owned by the main window | `TheShutdownWalkAsksAboutTabsAndDetachedWindowsAlike` |
| `DetachedContentNeedsSavePrompt` ignores `isShuttingDown` | `OnlyADirtySessionIsAskedAboutAndNotOnceTheAppIsShuttingDown` |
| `DetachedContentNeedsSavePrompt` claims read-only content too | 3: shutting-down, read-only, register-cleared |
| Re-dock consults the guard | `RedockingDoesNotPrompt` |
| No `closeConfirmed` latch — the re-issued close is questioned again | `TheGuardCancelsACloseAndTheAnswerIsOnlyAskedForOnce` |
| `onClosing` fires before the question is answered | 2: guard-cancels, close-refused |
| Every detach gets the detour, guard or not | 2: guardless-detach, register-cleared |
| `SaveQueryToPath` still insists on a tab | `ADetachedSessionSavesWithNoTabToRetitle` |
| **Detached Save As uses the main window's picker** | **none — see below** |

Two of these are worth calling out because they caught me rather than confirming me.

**Re-dock.** My first version of `RedockingDoesNotPrompt` asserted the session came back to a tab with its edit intact — and it stayed green when I wired the guard into the re-dock path. Re-dock hands the content back whether or not the window agreed to close, so the tab coming back proves nothing on its own. What a firing guard actually leaves behind is the *emptied window still open, with a prompt on it*, asking about a session that is already somewhere else. The test asserts `detached.IsVisible` is false and `detached.OwnedWindows` is empty, and it reddens now.

**The latch.** Removing it makes the helper re-ask its way around the post-and-close loop forever, which is a hang, and a test that hangs tells you nothing. The test's stub guard carries a fuse — it refuses after three asks — so the failure is `asked == 4` instead of a wedged runner. The fuse is scaffolding, not contract, and says so.

## Tests

`376 passed / 0 failed / 2 skipped` → `385 passed / 0 failed / 2 skipped`, measured on `origin/dev` at `ba50e6d` and on this branch. Run with the in-process runner; `dotnet test` reports zero tests under SDK 10.0.302 here, which is pre-existing and unrelated.

Covered: the dirty-detached walk in both directions, the shutdown list including its order and which window owns each prompt, the guard's three no-answers, the read-only path staying silent, Re-dock not asking, the cancel-and-keep-open behaviour, the ask-once latch, and a save with no tab behind it in both the written and the threw case.

The new tests put a real `QuerySessionControl` in a real detached window, and every one of them puts that window away from a `finally` — #474 is what a leaked window costs in a single-application headless session, and the run where cleanup matters is the run where an assertion above it failed. Nothing here puts a `PlanViewerControl` in a `Window`; read-only content is represented by a `QueryStoreHistoryControl`, which detaches through the same helper and takes the same silent path a plan does.

## Known gaps

- **Which `IStorageProvider` the Save As picker gets is not covered by a test.** The mutation that reverts it to the main window's provider stays green. A file picker cannot be driven headlessly, so which window it parents to is not observable from a test — the same limit #462 hit and said so about. It rests on reading the code.
- **Clicking one of the prompt's three buttons is still not testable.** As in #462, that is why the decision is a value: `DetachedContentNeedsSavePrompt` for whether to ask, `DecideClose` for what to do with the answer. `ClosingADetachedWindowWithUnsavedWorkDoesNotJustCloseIt` drives a real close to a real prompt and asserts the window is still there with the edit intact, which is as far as headless goes.
- **macOS app termination.** Cmd+Q / Dock → Quit may not route through `Window.Closing` on every platform. Unchanged from #462, not chased here.
- **A detached window's title does not follow a Save As.** The window is closing at that point, so nothing sees the stale title. Not fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xj7HmCKrnsz2PWkRKT2Jx
