### PR TITLE
Stop a leftover render pass from killing the headless session (#474)

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.Statements.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.Statements.cs
@@ -174,13 +174,8 @@ public partial class PlanViewerControl : UserControl
     ///
     /// <para>Runs when the menu opens rather than when selection changes, so it describes whatever
     /// is selected at the moment it is shown — the same row the two click handlers act on.</para>
-    ///
-    /// <para>Internal rather than private only so the tests can reach it: a headless
-    /// <c>ContextMenu.Open</c> needs the control inside a window, and a
-    /// <see cref="PlanViewerControl"/> in a headless window takes the shared Avalonia session's font
-    /// manager down with it.</para>
     /// </summary>
-    internal void UpdateStatementMenuForSelection()
+    private void UpdateStatementMenuForSelection()
     {
         var substitutable = StatementsGrid.SelectedItem is StatementRow row
             && ParameterSubstitution.Apply(row.Statement.StatementText, row.Statement.Parameters)

--- a/tests/PlanViewer.Core.Tests/HeadlessSessionSurvivalTests.cs
+++ b/tests/PlanViewer.Core.Tests/HeadlessSessionSurvivalTests.cs
@@ -1,0 +1,53 @@
+using System.IO;
+using Avalonia.Controls;
+using PlanViewer.App.Controls;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #474: showing a <see cref="PlanViewerControl"/> inside a headless <see cref="Window"/> used to
+/// leave the shared Avalonia session unable to construct any window at all, for the rest of the
+/// process. Everything that ran afterwards died in <c>FontManager.SystemFonts</c>, the test that
+/// did it passed, and which tests went red depended on the order the runner picked that day.
+///
+/// <para>The cause was a deferred render pass still sitting on the dispatcher queue when the
+/// dispatch ended — see <see cref="HeadlessUi"/> for the mechanism and the fix. This test exists
+/// because the fix lives in the harness, where nothing else would notice it being removed.</para>
+/// </summary>
+public class HeadlessSessionSurvivalTests
+{
+    /// <summary>
+    /// Two dispatches in one test rather than two tests, because the damage was never done by the
+    /// body — it was done by that dispatch's teardown, after the test's result was recorded. A pair
+    /// of tests would only reproduce it in the orders where one happened to follow the other.
+    /// </summary>
+    [Fact]
+    public void APlanViewerShownInAWindowLeavesTheSessionUsable()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new Window { Content = LoadedViewer(), Width = 1400, Height = 900 };
+            window.Show();
+            window.UpdateLayout();
+        });
+
+        HeadlessUi.Run(() =>
+        {
+            var window = new Window { Content = new TextBlock { Text = "still here" }, Width = 400, Height = 300 };
+            window.Show();
+            window.UpdateLayout();
+        });
+    }
+
+    private static PlanViewerControl LoadedViewer()
+    {
+        var path = Path.Combine("Plans", "forced_parameterization_plan.sqlplan");
+        Assert.True(File.Exists(path), $"Test plan not found: {path}");
+        var xml = File.ReadAllText(path).Replace("encoding=\"utf-16\"", "encoding=\"utf-8\"");
+
+        var viewer = new PlanViewerControl();
+        Assert.True(viewer.LoadPlan(xml, "forced_parameterization_plan.sqlplan"), viewer.LastLoadError);
+
+        return viewer;
+    }
+}

--- a/tests/PlanViewer.Core.Tests/HeadlessUi.cs
+++ b/tests/PlanViewer.Core.Tests/HeadlessUi.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Headless;
+using Avalonia.Threading;
 
 namespace PlanViewer.Core.Tests;
 
@@ -21,10 +24,14 @@ namespace PlanViewer.Core.Tests;
 /// classic desktop lifetime, which a headless session is not, so nothing is spawned behind the
 /// tests.</para>
 ///
-/// <para><b>One session for the whole assembly.</b> Avalonia allows a single Application per
-/// process, so this cannot be per-test or per-class. It is created on first use and never disposed:
-/// the process is about to exit, and tearing an Avalonia session down while another test class may
-/// still be queued is a good way to reintroduce the kind of test-host wedge #441 was about.</para>
+/// <para><b>One session for the whole assembly.</b> The session is created on first use and never
+/// disposed: the process is about to exit, and tearing an Avalonia session down while another test
+/// class may still be queued is a good way to reintroduce the kind of test-host wedge #441 was
+/// about. The session itself runs at <c>PerTest</c> isolation, which is not the same thing as one
+/// Application: each <see cref="Dispatch"/> enters a fresh <c>AvaloniaLocator</c> scope, builds a
+/// fresh <c>Application</c> in it, and tears both down afterwards. What is shared assembly-wide is
+/// the dispatcher thread and the loop feeding it — which is exactly enough to be poisoned once and
+/// stay poisoned, as #474 was.</para>
 /// </summary>
 internal static class HeadlessUi
 {
@@ -38,10 +45,93 @@ internal static class HeadlessUi
     /// </summary>
     internal static void Run(Action body)
     {
+        var failure = Dispatch(body);
+        var sessionBroken = Dispatch(EnsureSessionSurvived);
+
+        /* The body's own failure wins. A test that both failed its assertion and left the session
+           unusable is still described best by the assertion it failed. */
+        if (failure is not null)
+        {
+            ExceptionDispatchInfo.Capture(failure).Throw();
+        }
+
+        if (sessionBroken is not null)
+        {
+            ExceptionDispatchInfo.Capture(sessionBroken).Throw();
+        }
+    }
+
+    /// <summary>
+    /// Runs one body on the UI thread and hands back whatever it threw rather than throwing here,
+    /// so <see cref="Run"/> can decide which of two failures to report.
+    ///
+    /// <para><b>Why the queue is drained before returning (#474).</b> Avalonia's per-dispatch
+    /// teardown disposes the session's <c>FontManager</c> and only then calls
+    /// <c>Dispatcher.ResetForUnitTests</c>, which executes whatever is still queued. A window whose
+    /// content is involved enough to leave a deferred render pass behind — a
+    /// <c>PlanViewerControl</c> reliably does, a TextBlock does not — therefore renders text against
+    /// a font manager that has just been disposed, throws <c>KeyNotFoundException</c> for
+    /// <c>fonts:SystemFonts</c>, and that exception escapes the teardown delegate before it reaches
+    /// <c>scope.Dispose()</c>. The locator scope is then never popped: every later dispatch nests
+    /// inside the leaked one, resolves the disposed font manager through its parent chain, and dies
+    /// constructing any <see cref="Window"/> at all. The guilty test passes, because the throw
+    /// happens after its result has been recorded.</para>
+    ///
+    /// <para>Draining here leaves the teardown nothing to run, which is the whole fix. It is done
+    /// even when the body failed, because a failing test is no less capable of poisoning the
+    /// session than a passing one.</para>
+    /// </summary>
+    private static Exception? Dispatch(Action body)
+    {
+        Exception? failure = null;
+
         Session.Value.Dispatch(() =>
         {
-            body();
+            try
+            {
+                body();
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+
+            try
+            {
+                Dispatcher.UIThread.RunJobs();
+            }
+            catch (Exception ex)
+            {
+                failure ??= ex;
+            }
+
             return Task.CompletedTask;
         }, default).GetAwaiter().GetResult();
+
+        return failure;
+    }
+
+    /// <summary>
+    /// Checks that the session a test just used is still usable by the next one, so a test that
+    /// breaks it fails saying so instead of leaving a trail of unrelated red.
+    ///
+    /// <para>Constructing a <see cref="Window"/> is the check because it is the symptom: a window
+    /// builds a compositor, which asks the font manager for a typeface before it does anything
+    /// else. Nothing is shown and nothing is laid out, so this costs one object.</para>
+    /// </summary>
+    private static void EnsureSessionSurvived()
+    {
+        try
+        {
+            _ = new Window();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                "This test left the shared Avalonia session unusable — a bare Window can no longer " +
+                "be constructed, so every UI test that runs after it will fail too, on something " +
+                "that is not their fault. See #474.",
+                ex);
+        }
     }
 }

--- a/tests/PlanViewer.Core.Tests/StatementParameterMenuTests.cs
+++ b/tests/PlanViewer.Core.Tests/StatementParameterMenuTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
 using PlanViewer.App.Controls;
@@ -15,11 +16,11 @@ namespace PlanViewer.Core.Tests;
 /// #466 was not in producing text — it was in which text the two existing menu entries handed out.
 /// A pure test of the rewriter would have passed all along.</para>
 ///
-/// <para><b>No window, deliberately.</b> Putting a <see cref="PlanViewerControl"/> inside a
-/// <see cref="Window"/> headlessly leaves the shared Avalonia session unable to construct any later
-/// window — every UI test that runs afterwards dies in <c>FontManager.SystemFonts</c>. Without a
-/// window the control still loads a plan and fills its statements grid, but a ContextMenu cannot be
-/// opened, so the menu's Opening work is invoked directly.</para>
+/// <para>They also open the real menu on a real control in a real window. That used to be
+/// impossible — a <see cref="PlanViewerControl"/> in a headless <see cref="Window"/> took the
+/// shared Avalonia session's font manager down with it, so these tests called the menu's Opening
+/// work directly instead. #474 fixed the session, so the right-click the reporter performed is now
+/// the right-click the test performs.</para>
 /// </summary>
 public class StatementParameterMenuTests
 {
@@ -84,13 +85,24 @@ public class StatementParameterMenuTests
     }
 
     /// <summary>
-    /// Does what a right-click on the statements grid does: configures the menu for the selected
-    /// statement, then hands back the grid the menu hangs off.
+    /// Right-clicks the statements grid and hands back the grid the menu hangs off.
+    ///
+    /// <para>The window and the layout pass are what make the right-click possible: a ContextMenu
+    /// needs a TopLevel to open into, and the grid has no rows to select from until it has been
+    /// laid out. The request is raised rather than <c>ContextMenu.Open</c> being called, because
+    /// <c>Open</c> skips the Opening event and Opening is where the labels are decided — calling it
+    /// would test the menu with nothing having configured it.</para>
     /// </summary>
     private static DataGrid OpenStatementMenu(PlanViewerControl viewer)
     {
-        viewer.UpdateStatementMenuForSelection();
-        return viewer.GetLogicalDescendants().OfType<DataGrid>().First(g => g.Name == "StatementsGrid");
+        var window = new Window { Content = viewer, Width = 1400, Height = 900 };
+        window.Show();
+        window.UpdateLayout();
+
+        var grid = viewer.GetLogicalDescendants().OfType<DataGrid>().First(g => g.Name == "StatementsGrid");
+        grid.RaiseEvent(new ContextRequestedEventArgs());
+
+        return grid;
     }
 
     private static MenuItem MenuItemNamed(DataGrid grid, string name) =>


### PR DESCRIPTION
Closes #474.

## It reproduces, but not the way the issue describes it

The issue says `HeadlessUi.Run(() => new Window { Content = new PlanViewerControl(...) }.Show())` followed by any test that constructs a `Window`. That on its own does **not** fail. I ran it, then ran it with `UpdateLayout`, with a render tick, with the statements panel toggled, with the minimap toggled, with the context menu opened, with the window closed afterwards, and with the whole 387-test suite behind it. All green, and the font manager was identical before and after — one collection, `fonts:SystemFonts`, count 1.

What actually reproduces it is `Show()` **plus a layout pass**, and the damage does not happen during the test at all. It happens in that dispatch's teardown, after the test's result has been recorded. This is the bisect, one `HeadlessUi.Run` per line, probing the font manager at the start and end of each:

```
DISPATCH bare window show+layout      after keys=[fonts:SystemFonts]  chain: #59559901(n=31) -> #17566981(n=0)
DISPATCH probe A                      after keys=[fonts:SystemFonts]  chain: #55341663(n=31) -> #17566981(n=0)
DISPATCH viewer in window show+layout after keys=[fonts:SystemFonts]  chain: #66921295(n=33) -> #17566981(n=0)
DISPATCH probe C                      after keys=[]                   chain: #52852147(n=27) -> #58563035(n=33) -> #17566981(n=0)
```

Two things happen at once on the last line. The font collection dictionary is empty, and the locator chain has grown a level — the previous dispatch's scope is still sitting there as a parent, because it was never popped.

## What broke it

`AppDomain.CurrentDomain.FirstChanceException`, on the dispatch that does the damage:

```
System.Collections.Generic.KeyNotFoundException: The given key 'fonts:SystemFonts' was not present in the dictionary.
   at Avalonia.Media.FontManager.get_SystemFonts()
   at Avalonia.Media.FontManager.TryGetGlyphTypeface(Typeface typeface, IGlyphTypeface& glyphTypeface)
   at Avalonia.Media.Typeface.get_GlyphTypeface()
   at Avalonia.Media.TextFormatting.TextRunProperties.get_CachedGlyphTypeface()
   at Avalonia.Media.TextFormatting.TextFormatterImpl.CreateEmptyTextLine(...)
   at Avalonia.Media.TextFormatting.TextLayout.CreateTextLines()
   at Avalonia.Controls.TextBlock.get_TextLayout()
   at Avalonia.Controls.TextBlock.RenderCore(DrawingContext context)
   at Avalonia.Rendering.Composition.CompositingRenderer.UpdateCore()
   at Avalonia.Media.MediaContext.Render()
   at Avalonia.Threading.DispatcherOperation.Execute()
   at Avalonia.Threading.Dispatcher.ExecuteJob(DispatcherOperation job)
   at Avalonia.Threading.Dispatcher.ResetForUnitTests()
   at Avalonia.Headless.HeadlessUnitTestSession.<>c__DisplayClass14_0.<EnsureIsolatedApplication>b__0()
   at Avalonia.Reactive.Disposable.AnonymousDisposable.Dispose()
   at Avalonia.Headless.HeadlessUnitTestSession.<>c__DisplayClass12_0`1.<DispatchCore>b__0()
```

That is the teardown, and the teardown is this (Avalonia 11.3.20, `HeadlessUnitTestSession.EnsureIsolatedApplication`):

```csharp
return Disposable.Create(() =>
{
    ((ToolTipService?)AvaloniaLocator.Current.GetService<IToolTipService>())?.Dispose();
    (AvaloniaLocator.Current.GetService<FontManager>() as IDisposable)?.Dispose();
    Dispatcher.ResetForUnitTests();
    scope.Dispose();
    ...
});
```

`FontManager.Dispose` clears `_fontCollections`. `ResetForUnitTests` runs the jobs still on the queue. So a dispatch that ends with a deferred render pass pending renders text against a font manager that was disposed on the line above, throws, and the throw walks out of the delegate **before** `scope.Dispose()`. The `AvaloniaLocator` scope is never popped. From then on every dispatch nests a new scope inside the leaked one, `GetService<FontManager>()` walks the parent chain and finds the disposed instance, and `new Window()` dies in `Compositor.get_DiagnosticTextRenderer()` before the constructor is finished.

Established, not theorised: the cause is upstream, in Avalonia. The teardown disposes the font manager before draining the queue, and it does not put `scope.Dispose()` in a `finally`. Nothing in `PlanViewerControl` touches the font manager, `AvaloniaLocator`, `RenderOptions`, TextMate or anything else session-global — I looked, and the instrumentation says the font manager is byte-identical across the control's entire lifecycle. The control's only crime is being a big enough visual tree to leave a render pass pending. A `TextBlock` in a window does not; a `DataGrid` in a window does not; a plan viewer does, every time.

Also worth correcting, because it is what sent me down the wrong path first: the harness comment said "Avalonia allows a single Application per process, so this cannot be per-test or per-class". That is not what the session does. It runs at `PerTest` isolation, and `Application.Current` and the locator are **both new on every single dispatch** — I printed their identities and they change every time. What is shared assembly-wide is the dispatcher thread and the loop feeding it, which is exactly enough surface to be poisoned once and stay poisoned. The comment is fixed in this change.

## Which fix, and why

Shape 1, the cure — with a small piece of shape 2 behind it.

The cause is upstream, but it is trivially avoidable from here: if the queue is empty when the dispatch ends, the teardown has nothing to run and never touches the disposed font manager. `HeadlessUi.Run` now calls `Dispatcher.UIThread.RunJobs()` at the end of every dispatch. That is the whole fix, and it un-forbids the pattern entirely rather than merely making it fail politely.

The health check is there because the cure is invisible. Nothing else in the suite would notice `RunJobs()` being deleted until the next person spent a day bisecting eight red tests that did nothing wrong. So each `Run` is followed by a second dispatch that constructs one bare `Window` — the symptom itself, since a window builds a compositor and a compositor asks the font manager for a typeface before it does anything else — and a test that leaves the session unusable now fails with:

> This test left the shared Avalonia session unusable — a bare Window can no longer be constructed, so every UI test that runs after it will fail too, on something that is not their fault. See #474.

The body's own failure still wins if a test both fails an assertion and breaks the session, because the assertion describes it better.

## Proof it is not decoration

Deleting only `RunJobs()` and keeping everything else:

- `HeadlessSessionSurvivalTests` fails with the message above, wrapping the `KeyNotFoundException`.
- The full suite goes to **45 failures**, spread across every test class in the suite that touches the UI, none of which have anything to do with any of this.

Restoring the harness to exactly what is on `dev` (no drain, no check):

- `HeadlessSessionSurvivalTests` fails with the raw `KeyNotFoundException: The given key 'fonts:SystemFonts' was not present in the dictionary.` at `Window..ctor()`.
- The full suite goes to **38 failures**.

Both directions restored, both green afterwards.

## The workaround is gone, which is the real proof

`StatementParameterMenuTests` documented why it could not open the menu. It now does. It shows the control in a window, lays it out, and raises the context request that a right-click raises — not `ContextMenu.Open`, which skips the `Opening` event, and `Opening` is where the labels are decided. That distinction is load-bearing rather than pedantry: calling `Open` directly made `WithParameters_...` fail with `Expected: Copy Query Text (with values) / Actual: Copy Query Text`, because nothing had configured the menu. So the test is genuinely exercising the path now, and it says so if it stops.

`UpdateStatementMenuForSelection` was `internal` only so the test could reach past the problem. It is `private` again.

## Numbers

Measured on this machine, not inherited:

| | Total | Failed | Skipped |
|---|---|---|---|
| `origin/dev` baseline | 387 | 0 | 2 |
| this branch | 388 | 0 | 2 |

Fifteen full-suite runs on this branch, four of them with the order randomised (`:seed 1 / 7 / 42 / 1234`), one `-parallelMode none`, one `-parallelMode all`. 388/0/2 every time, ~20s, unchanged from the baseline's ~20s. The order variation is deliberate: this bug is order-sensitive, so one green run proves close to nothing.

## What this deliberately does not do

- **It does not patch Avalonia or pin a workaround to a version.** If upstream fixes the teardown ordering, the drain becomes a no-op rather than a conflict.
- **It does not restructure the suite.** No per-collection or per-process scheme, no isolation attributes, no fixtures. One session, one dispatcher, same as before — dodging the harness would not have found the cause.
- **It does not try to heal a poisoned session.** Once the scope has leaked, the only honest answer is to fail loudly. Rebinding a fresh font manager into the current scope is reachable through reflection and is the kind of cleverness that becomes someone else's afternoon.
- **It does not drain more than once.** `RunJobs()` loops until the queue is empty; a bounded retry loop would be guessing at a failure mode I have not seen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016a1AnKAHwcALrwdYVVrpgR
