### PR TITLE
v1.23.0 release prep: version bump

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
     website: "https://erikdarling.com"
 repository-code: "https://github.com/erikdarlingdata/PerformanceStudio"
 license: MIT
-version: "1.22.0"
-date-released: "2026-08-31"
+version: "1.23.0"
+date-released: "2026-09-02"
 keywords:
   - sql-server
   - execution-plan

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
     Tests and server/ projects are outside src/ and are unaffected.
   -->
   <PropertyGroup>
-    <Version>1.22.0</Version>
+    <Version>1.23.0</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
+++ b/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
@@ -7,5 +7,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Performance Studio for SSMS")]
 [assembly: AssemblyCopyright("Copyright Darling Data 2026")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("1.22.0.0")]
-[assembly: AssemblyFileVersion("1.22.0.0")]
+[assembly: AssemblyVersion("1.23.0.0")]
+[assembly: AssemblyFileVersion("1.23.0.0")]

--- a/src/PlanViewer.Ssms/source.extension.vsixmanifest
+++ b/src/PlanViewer.Ssms/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="PlanViewer.Ssms.64F79022-9D9A-4463-A1AE-4B19426A0CB1"
-              Version="1.22.0"
+              Version="1.23.0"
               Language="en-US"
               Publisher="Darling Data" />
     <DisplayName>Performance Studio for SSMS</DisplayName>


### PR DESCRIPTION
Version bump for the 1.23.0 release. Only the four files that carry the version:

- `src/Directory.Build.props` — `<Version>`
- `CITATION.cff` — `version` and `date-released`
- `src/PlanViewer.Ssms/Properties/AssemblyInfo.cs` — `AssemblyVersion` + `AssemblyFileVersion`
- `src/PlanViewer.Ssms/source.extension.vsixmanifest` — `Identity Version`

Minor bump: four user-facing features have landed on `dev` since v1.22.0 (#463, #462, #467, #473), alongside three bug fixes and a test-harness repair.

Nothing else in the repo references 1.22.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016a1AnKAHwcALrwdYVVrpgR
