### PR TITLE
Notice a plan arriving by every route, not just the one with a test (#447)

### DIFF
--- a/src/PlanViewer.App/Controls/QuerySessionControl.Execution.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.Execution.cs
@@ -197,15 +197,7 @@ public partial class QuerySessionControl : UserControl
 
             // Replace loading content with the plan viewer
             SetStatus($"{planType} plan captured ({sw.Elapsed.TotalSeconds:F1}s)");
-            var viewer = new PlanViewerControl();
-            viewer.Metadata = _serverMetadata;
-            viewer.ConnectionString = _connectionString;
-            viewer.SetConnectionServices(_credentialService, _connectionStore);
-            if (_serverConnection != null)
-                viewer.SetConnectionStatus(_serverConnection.ServerName, _selectedDatabase);
-            viewer.OpenInEditorRequested += OnOpenInEditorRequested;
-            viewer.LoadPlan(planXml, tabLabel, queryText);
-            loadingTab.Content = viewer;
+            ShowCapturedPlan(loadingTab, planXml, tabLabel, queryText);
             HumanAdviceButton.IsEnabled = true;
             RobotAdviceButton.IsEnabled = true;
         }
@@ -222,6 +214,32 @@ public partial class QuerySessionControl : UserControl
         {
             ShowExecutionFailure(loadingPanel, statusLabel, progressBar, cancelBtn, ex.Message);
         }
+    }
+
+    /// <summary>
+    /// Puts a captured plan into the tab that has been showing the progress spinner for it.
+    ///
+    /// <para>Both execution paths end here — the estimated/actual capture and Get Actual Plan — and
+    /// this is the moment a plan appears in a session, so it is the moment Compare Plans has to be
+    /// re-decided. That happens through the sub-tab
+    /// <see cref="Helpers.TabContentWatcher"/> rather than a call added below, because the assignment
+    /// on the last line is what it is watching for (#447).</para>
+    ///
+    /// <para>Internal so a test can drive the plan landing with XML it already has, rather than
+    /// needing a SQL Server to produce some. The half of these paths that reaches out to a server
+    /// is above this; everything that decides what the user ends up looking at is here.</para>
+    /// </summary>
+    internal void ShowCapturedPlan(TabItem planTab, string planXml, string tabLabel, string queryText)
+    {
+        var viewer = new PlanViewerControl();
+        viewer.Metadata = _serverMetadata;
+        viewer.ConnectionString = _connectionString;
+        viewer.SetConnectionServices(_credentialService, _connectionStore);
+        if (_serverConnection != null)
+            viewer.SetConnectionStatus(_serverConnection.ServerName, _selectedDatabase);
+        viewer.OpenInEditorRequested += OnOpenInEditorRequested;
+        viewer.LoadPlan(planXml, tabLabel, queryText);
+        planTab.Content = viewer;
     }
 
     /// <summary>
@@ -402,15 +420,7 @@ public partial class QuerySessionControl : UserControl
             }
 
             SetStatus($"Actual plan captured ({sw.Elapsed.TotalSeconds:F1}s)");
-            var actualViewer = new PlanViewerControl();
-            actualViewer.Metadata = _serverMetadata;
-            actualViewer.ConnectionString = _connectionString;
-            actualViewer.SetConnectionServices(_credentialService, _connectionStore);
-            if (_serverConnection != null)
-                actualViewer.SetConnectionStatus(_serverConnection.ServerName, _selectedDatabase);
-            actualViewer.OpenInEditorRequested += OnOpenInEditorRequested;
-            actualViewer.LoadPlan(actualPlanXml, tabLabel, queryText);
-            loadingTab.Content = actualViewer;
+            ShowCapturedPlan(loadingTab, actualPlanXml, tabLabel, queryText);
         }
         catch (OperationCanceledException)
         {

--- a/src/PlanViewer.App/Controls/QuerySessionControl.Plans.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.Plans.cs
@@ -13,12 +13,14 @@ using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
+using Avalonia.LogicalTree;
 using Avalonia.Media;
 using AvaloniaEdit;
 using AvaloniaEdit.CodeCompletion;
 using AvaloniaEdit.TextMate;
 using Microsoft.Data.SqlClient;
 using PlanViewer.App.Dialogs;
+using PlanViewer.App.Helpers;
 using PlanViewer.App.Services;
 using PlanViewer.Core.Interfaces;
 using PlanViewer.Core.Models;
@@ -108,7 +110,6 @@ public partial class QuerySessionControl : UserControl
 
         SubTabControl.Items.Add(tab);
         SubTabControl.SelectedItem = tab;
-        UpdateCompareButtonState();
         return true;
     }
 
@@ -159,7 +160,6 @@ public partial class QuerySessionControl : UserControl
             if (tab.Content is PlanViewerControl viewer)
                 viewer.Clear();
             SubTabControl.Items.Remove(tab);
-            UpdateCompareButtonState();
         }
     }
 
@@ -180,7 +180,6 @@ public partial class QuerySessionControl : UserControl
                     if (tab.Content is PlanViewerControl closeViewer)
                         closeViewer.Clear();
                     SubTabControl.Items.Remove(tab);
-                    UpdateCompareButtonState();
                 }
                 break;
 
@@ -199,7 +198,6 @@ public partial class QuerySessionControl : UserControl
                         SubTabControl.Items.Remove(t);
                     }
                     SubTabControl.SelectedItem = keepTab;
-                    UpdateCompareButtonState();
                 }
                 break;
 
@@ -215,7 +213,6 @@ public partial class QuerySessionControl : UserControl
                     SubTabControl.Items.Remove(t);
                 }
                 SubTabControl.SelectedIndex = 0; // back to Editor
-                UpdateCompareButtonState();
                 break;
         }
     }
@@ -225,10 +222,21 @@ public partial class QuerySessionControl : UserControl
     /// from another is the ordinary case, and counting only this session's own tabs left the button
     /// disabled in both — the reporter had to save a plan and reopen it to get at a comparison the
     /// app could already do.
+    ///
+    /// <para>Called by the <see cref="TabContentWatcher"/> wired to this session's sub-tabs, and by
+    /// nothing else. It used to be called by hand at the five places that add or remove a plan tab,
+    /// which is why the paths that instead fill in an existing tab — every executed query — never
+    /// reached it.</para>
     /// </summary>
     private void UpdateCompareButtonState()
     {
-        if (TopLevel.GetTopLevel(this) is MainWindow owner)
+        /* Logical tree, not TopLevel.GetTopLevel. A TabControl realises the selected tab's content
+           and nothing else, so a session sitting in a background tab has no visual root and cannot
+           see its own window — and a query started in one tab and left to run while the user works
+           in another lands its plan in exactly that state. GetTopLevel returned null there and the
+           fallback below silently reinstated the bug this method exists to fix. The logical parent
+           chain holds whether the tab is on screen or not. */
+        if (this.FindLogicalAncestorOfType<MainWindow>() is { } owner)
         {
             /* Refreshes every session, not just this one: a plan appearing here can be the second
                plan that makes Compare available over THERE. */

--- a/src/PlanViewer.App/Controls/QuerySessionControl.QueryStore.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.QueryStore.cs
@@ -261,7 +261,14 @@ public partial class QuerySessionControl : UserControl
         SubTabControl.SelectedItem = tab;
     }
 
-    private void OnQueryStorePlansSelected(object? sender, List<QueryStorePlan> plans)
+    /// <summary>
+    /// Opens a plan tab for each plan picked out of the Query Store grid.
+    ///
+    /// <para>Internal so a test can hand it plans it already has. The grid is what fetches them from
+    /// a server; nothing below this line needs one, which is what makes the Query Store side of
+    /// #447 testable without a live instance.</para>
+    /// </summary>
+    internal void OnQueryStorePlansSelected(object? sender, List<QueryStorePlan> plans)
     {
         int loaded = 0;
         foreach (var qsPlan in plans)

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -18,6 +18,7 @@ using AvaloniaEdit.CodeCompletion;
 using AvaloniaEdit.TextMate;
 using Microsoft.Data.SqlClient;
 using PlanViewer.App.Dialogs;
+using PlanViewer.App.Helpers;
 using PlanViewer.App.Services;
 using PlanViewer.Core.Interfaces;
 using PlanViewer.Core.Models;
@@ -130,6 +131,13 @@ public partial class QuerySessionControl : UserControl
             _statusClearCts?.Dispose();
             _statusClearCts = null;
         };
+
+        /* #447: a plan appearing in — or leaving — this session changes whether Compare Plans is
+           offered in every session in the window, not just this one. Watched here rather than
+           called at each site that produces a plan, because the sites that produce a plan are the
+           ones nobody remembers: executing a query fills in a tab that already exists, which is
+           neither an Add nor a Remove and is exactly the case the first fix missed. */
+        TabContentWatcher.Watch(SubTabControl, UpdateCompareButtonState);
 
         // Focus the editor when the Editor tab is selected; toggle plan-dependent buttons
         SubTabControl.SelectionChanged += (_, _) =>

--- a/src/PlanViewer.App/Helpers/TabContentWatcher.cs
+++ b/src/PlanViewer.App/Helpers/TabContentWatcher.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+
+namespace PlanViewer.App.Helpers;
+
+/// <summary>
+/// Reports every change to what a <see cref="TabControl"/> is showing, so state derived from its
+/// contents can be recomputed without a call planted at each site that changes them (#447).
+///
+/// <para><b>Why a collection subscription is not enough.</b> A tab's content is changed two ways,
+/// and only one of them is a collection change. Tabs are added and removed, which
+/// <c>Items</c> raises; but a tab is also created holding a progress spinner and later has its
+/// <c>Content</c> swapped for the finished article — which is how every plan produced by executing
+/// a query arrives, and which the collection says nothing about. #449 watched the collection alone
+/// and so fixed the file path while leaving the execution path exactly as broken as it was
+/// reported.</para>
+///
+/// <para>Both are watched here, which is the point: the next path that produces a plan is correct
+/// without its author knowing this exists, because a plan cannot reach the screen without either
+/// adding a tab or filling one in.</para>
+/// </summary>
+internal static class TabContentWatcher
+{
+    /// <summary>
+    /// Invokes <paramref name="onChanged"/> whenever a tab is added to or removed from
+    /// <paramref name="tabs"/>, or an existing tab's content is replaced.
+    ///
+    /// <para>Meant to be called once, where the control is built. The subscriptions live as long as
+    /// the tab control does, which for both call sites is the lifetime of the window.</para>
+    /// </summary>
+    internal static void Watch(TabControl tabs, Action onChanged)
+    {
+        /* Tracked rather than derived from the collection-changed args, because a Reset carries
+           neither OldItems nor NewItems and would otherwise leave stale subscriptions behind. */
+        var watched = new HashSet<TabItem>();
+
+        void OnTabPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+        {
+            if (e.Property == ContentControl.ContentProperty)
+                onChanged();
+        }
+
+        void Resync()
+        {
+            var current = tabs.Items.OfType<TabItem>().ToHashSet();
+
+            foreach (var gone in watched.Except(current).ToList())
+            {
+                gone.PropertyChanged -= OnTabPropertyChanged;
+                watched.Remove(gone);
+            }
+
+            foreach (var arrived in current.Except(watched).ToList())
+            {
+                arrived.PropertyChanged += OnTabPropertyChanged;
+                watched.Add(arrived);
+            }
+        }
+
+        /* Tabs declared in XAML are already in the collection before anyone gets to watch it. */
+        Resync();
+
+        if (tabs.Items is INotifyCollectionChanged observable)
+        {
+            observable.CollectionChanged += (_, _) =>
+            {
+                Resync();
+                onChanged();
+            };
+        }
+    }
+}

--- a/src/PlanViewer.App/MainWindow.PlanViewer.cs
+++ b/src/PlanViewer.App/MainWindow.PlanViewer.cs
@@ -27,7 +27,13 @@ namespace PlanViewer.App;
 
 public partial class MainWindow : Window
 {
-    private DockPanel CreatePlanTabContent(PlanViewerControl viewer)
+    /// <summary>
+    /// Wraps a loaded plan in the toolbar a window-level plan tab shows above it.
+    ///
+    /// <para>Internal so a test can reproduce what Get Actual Plan does to a file tab — build this
+    /// and assign it over a tab that was holding a spinner — without executing anything (#447).</para>
+    /// </summary>
+    internal DockPanel CreatePlanTabContent(PlanViewerControl viewer)
     {
         var humanBtn = new Button
         {

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.IO;
 using System.IO.Pipes;
 using System.Linq;
@@ -19,6 +18,7 @@ using Avalonia.Platform.Storage;
 using Avalonia.Threading;
 using PlanViewer.App.Controls;
 using PlanViewer.App.Dialogs;
+using PlanViewer.App.Helpers;
 using PlanViewer.App.Services;
 using PlanViewer.Core.Interfaces;
 using PlanViewer.Core.Models;
@@ -79,9 +79,12 @@ public partial class MainWindow : Window
            remove a tab. Compare Plans depends on how many plans exist across the WHOLE window, so
            opening or closing any tab can change whether it is available in every OTHER tab, and a
            refresh that has to be remembered at sixteen call sites is one that gets forgotten at the
-           seventeenth. */
-        if (MainTabControl.Items is INotifyCollectionChanged tabs)
-            tabs.CollectionChanged += (_, _) => RefreshComparePlanAvailability();
+           seventeenth.
+
+           Watching content replacement as well as the collection is the part the first attempt at
+           this got wrong: Get Actual Plan opens a tab holding a spinner and later swaps in the plan,
+           so the tab that gains a plan is one this window already had. */
+        TabContentWatcher.Watch(MainTabControl, RefreshComparePlanAvailability);
 
         // Global hotkeys via tunnel routing so they fire before AvaloniaEdit consumes them
         AddHandler(KeyDownEvent, (_, e) =>

--- a/tests/PlanViewer.Core.Tests/ComparePlansAvailabilityTests.cs
+++ b/tests/PlanViewer.Core.Tests/ComparePlansAvailabilityTests.cs
@@ -1,9 +1,11 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using PlanViewer.App;
 using PlanViewer.App.Controls;
+using PlanViewer.Core.Models;
 
 namespace PlanViewer.Core.Tests;
 
@@ -14,13 +16,128 @@ namespace PlanViewer.Core.Tests;
 /// able to see across sessions. The reporter had to save a plan and reopen it to get at a comparison
 /// the app could already do.
 ///
-/// The scenario is built from plan FILES rather than executed queries deliberately: getting a plan
-/// into a session needs a live SQL Server, and the defect does not require one. What it requires is
-/// plans existing somewhere OTHER than the session whose button is being judged, which two file tabs
-/// provide exactly.
+/// <para><b>The first version of this file is why the issue was reopened.</b> It built its scenario
+/// out of plan FILES on purpose, reasoning that getting a plan into a session needed a live SQL
+/// Server and that the defect did not require one. The second half of that was true and the first
+/// half was the bug: a plan file opens a window-level tab, which is the one path that was already
+/// recomputing. Every test passed against a build in which running two queries — the thing being
+/// reported — still left both buttons dead.</para>
+///
+/// <para>So the tests below drive the paths a plan actually arrives by. What still needs a server is
+/// the round trip that produces plan XML, and only that: the landing step each path performs with
+/// the XML in hand is reachable directly, and is where the whole defect lived.</para>
 /// </summary>
 public class ComparePlansAvailabilityTests
 {
+    /// <summary>
+    /// The report, verbatim: a query run in one tab, another query run in a second tab, Compare
+    /// disabled in both. Driven through the same <c>ShowCapturedPlan</c> both execution paths use
+    /// once the server has answered.
+    /// </summary>
+    [Fact]
+    public void RunningAQueryInEachOfTwoSessionsOffersCompareInBoth()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new MainWindow();
+
+            var first = NewSession(window);
+            var second = NewSession(window);
+
+            RunQuery(first, "row_goal_plan.sqlplan", "Plan 1");
+
+            Assert.All(new[] { first, second }, session => Assert.False(
+                CompareButton(session).IsEnabled,
+                "one plan cannot be compared against anything"));
+
+            RunQuery(second, "key_lookup_plan.sqlplan", "Plan 1");
+
+            Assert.All(new[] { first, second }, session => Assert.True(
+                CompareButton(session).IsEnabled,
+                "a query has now run in each session, which is the whole of the report"));
+        });
+    }
+
+    /// <summary>
+    /// Two queries run in the SAME session, which is the case the pre-#449 arithmetic did handle.
+    /// Here because that arithmetic no longer exists — the count comes from the window now, and a
+    /// window-wide count has its own way of getting a single session wrong.
+    /// </summary>
+    [Fact]
+    public void RunningTwoQueriesInOneSessionOffersCompareThere()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new MainWindow();
+            var session = NewSession(window);
+
+            RunQuery(session, "row_goal_plan.sqlplan", "Plan 1");
+            RunQuery(session, "key_lookup_plan.sqlplan", "Plan 2");
+
+            Assert.True(CompareButton(session).IsEnabled);
+        });
+    }
+
+    /// <summary>
+    /// The Query Store path, which opens its plans by adding tabs rather than filling one in, and a
+    /// plan tab being closed again. Both used to say so with a call written out at the site; they
+    /// now go through the same watcher as everything else, so they need pinning where they did not
+    /// before.
+    /// </summary>
+    [Fact]
+    public void QueryStorePlansOfferCompare_AndClosingOneTakesItAway()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new MainWindow();
+            var session = NewSession(window);
+
+            session.OnQueryStorePlansSelected(null, new List<QueryStorePlan>
+            {
+                QueryStorePlanFrom(11, "row_goal_plan.sqlplan"),
+                QueryStorePlanFrom(22, "key_lookup_plan.sqlplan")
+            });
+
+            Assert.True(CompareButton(session).IsEnabled,
+                "two Query Store plans are open in this session");
+
+            ClosePlanTab(session);
+
+            Assert.False(CompareButton(session).IsEnabled,
+                "one of the two was closed, so there is nothing left to compare against");
+        });
+    }
+
+    /// <summary>
+    /// Get Actual Plan on a window-level plan tab, which produces its plan the same way an executed
+    /// query does — into a tab that has been showing a spinner since the query was sent, and so is
+    /// not an addition to anything.
+    /// </summary>
+    [Fact]
+    public void AnActualPlanArrivingInAnExistingWindowTabIsNoticed()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new MainWindow();
+
+            window.LoadPlanFile(PlanPath("row_goal_plan.sqlplan"));
+            var session = NewSession(window);
+
+            Assert.False(CompareButton(session).IsEnabled);
+
+            var tabs = window.FindControl<TabControl>("MainTabControl")!;
+            var spinnerTab = new TabItem { Header = "Actual Plan", Content = new Grid() };
+            tabs.Items.Add(spinnerTab);
+
+            var viewer = new PlanViewerControl();
+            Assert.True(viewer.LoadPlan(PlanXml("key_lookup_plan.sqlplan"), "Actual Plan"));
+            spinnerTab.Content = window.CreatePlanTabContent(viewer);
+
+            Assert.True(CompareButton(session).IsEnabled,
+                "the window gained a second plan without gaining a tab");
+        });
+    }
+
     [Fact]
     public void ASessionOffersCompareWhenThePlansAreElsewhereInTheWindow()
     {
@@ -86,14 +203,71 @@ public class ComparePlansAvailabilityTests
         });
     }
 
+    /// <summary>
+    /// Runs a query in a session as far as a test without a SQL Server can.
+    ///
+    /// <para>The tab holding the progress spinner is opened first, exactly as the execution paths
+    /// open it, and the session is then handed plan XML from a fixture in place of what the server
+    /// would have returned. Everything after that — building the viewer, loading the plan into it,
+    /// and assigning it over the spinner — is the session's own code, and the assignment is the
+    /// statement #447 was about.</para>
+    /// </summary>
+    private static void RunQuery(QuerySessionControl session, string planFileName, string tabLabel)
+    {
+        var subTabs = SubTabs(session);
+        var spinnerTab = new TabItem { Header = tabLabel, Content = new Grid() };
+        subTabs.Items.Add(spinnerTab);
+        subTabs.SelectedItem = spinnerTab;
+
+        session.ShowCapturedPlan(spinnerTab, PlanXml(planFileName), tabLabel, "select 1;");
+    }
+
+    /// <summary>
+    /// Closes the session's first plan tab through its own close button, rather than reaching into
+    /// the collection — the removal paths are production code too, and they lost their hand-written
+    /// refresh along with the paths that add.
+    /// </summary>
+    private static void ClosePlanTab(QuerySessionControl session)
+    {
+        var tab = SubTabs(session).Items
+            .OfType<TabItem>()
+            .First(t => t.Content is PlanViewerControl);
+
+        var closeButton = ((StackPanel)tab.Header!).Children.OfType<Button>().Last();
+        closeButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+    }
+
+    private static QueryStorePlan QueryStorePlanFrom(long id, string planFileName) =>
+        new()
+        {
+            QueryId = id,
+            PlanId = id,
+            QueryText = "select 1;",
+            PlanXml = PlanXml(planFileName)
+        };
+
+    private static QuerySessionControl NewSession(MainWindow window)
+    {
+        window.NewQuery_Click(window, new RoutedEventArgs());
+        return Sessions(window).Last();
+    }
+
     private static string PlanPath(string name) =>
         Path.Combine(System.AppContext.BaseDirectory, "Plans", name);
 
-    private static System.Collections.Generic.IEnumerable<QuerySessionControl> Sessions(MainWindow window) =>
+    /// <summary>SSMS writes plan files as UTF-16 and declares it; the parser wants the declaration
+    /// to match what it is handed. Same substitution the other plan-loading tests make.</summary>
+    private static string PlanXml(string name) =>
+        File.ReadAllText(PlanPath(name)).Replace("encoding=\"utf-16\"", "encoding=\"utf-8\"");
+
+    private static IEnumerable<QuerySessionControl> Sessions(MainWindow window) =>
         window.FindControl<TabControl>("MainTabControl")!.Items
             .OfType<TabItem>()
             .Select(tab => tab.Content)
             .OfType<QuerySessionControl>();
+
+    private static TabControl SubTabs(QuerySessionControl session) =>
+        session.FindControl<TabControl>("SubTabControl")!;
 
     private static Button CompareButton(QuerySessionControl session) =>
         session.FindControl<Button>("ComparePlansButton")!;


### PR DESCRIPTION
Fixes #447, which I closed once already and should not have.

## What was actually wrong

#449 fixed the enablement *rule*. It did not fix the *refresh*, and joshdbe's report was never about the rule.

A plan gets into a session's sub-tabs two ways, and they are shaped differently:

- **Adding a tab.** Query Store does this, through `AddPlanTab`.
- **Filling in a tab that is already there.** Executing a query does this. The tab opens the moment you hit F5, holding a progress spinner, and when the server answers `loadingTab.Content = viewer` swaps the plan in. The tab count never changes.

#449 subscribed to `MainTabControl.Items` collection-changed and called that the single seam. A collection subscription cannot see the second shape, so every plan produced by running a query landed without a word to anybody. Two queries in two tabs, Compare dead in both — exactly as reported, on a build containing the fix.

The same shape sits at window level: Get Actual Plan on a file tab opens a spinner tab and later assigns `tab.Content = CreatePlanTabContent(actualViewer)` over it. Second instance of the same bug, never reported because you need a server to reach it.

And a third, found by the new tests rather than by reading: `UpdateCompareButtonState` located its window with `TopLevel.GetTopLevel`. A `TabControl` realises the selected tab's content and nothing else, so a session sitting in a background tab has no visual root, cannot find its own window, and falls back to counting its own plans — which is the original bug, restored. Start a query in one tab, work in another while it runs, and its plan lands in precisely that state.

## Correcting my own table

I posted a table on the issue. Two of its three rows are wrong, and following it would have fixed the wrong things:

| What I said | What is true |
|---|---|
| Opening a `.sqlplan` file into a session refreshes, via `Plans.cs:109` | There is no such path. `AddPlanTab` has exactly two callers and both are Query Store. Opening a plan file opens a **window-level** tab (`MainWindow.FileOps.cs`), which the collection subscription did catch. |
| Query Store does not refresh, at four `SubTabControl.Items.Add` sites | Query Store **did** refresh. Its two plan-producing sites go through `AddPlanTab`, which called `UpdateCompareButtonState`. The four `Items.Add` sites I pointed at add the QS grid, the QS overview and the history tab — containers, not plans. |
| Executing a query does not refresh | Correct, and this was the whole defect. |

The new Query Store test passes on `dev` unmodified. It is in here as a pin on the seam swap below, not as a reproduction of anything.

## The seam

`Helpers/TabContentWatcher.cs`, wired once to `MainTabControl` and once to each session's `SubTabControl`. It reports collection changes **and** content replacement on any tab it holds.

I considered just adding the missing calls at the three sites. The reason I did not is the reason we are here: #449's call sites were correct for the paths their author had in mind, and the next author did not know to look. A plan cannot reach the screen without either adding a tab or filling one in, so watching both is the smallest thing that is also complete — the next plan-producing path is right without anyone remembering this file exists.

Given that, the five hand-written `UpdateCompareButtonState()` calls in `Plans.cs` are gone. Leaving them would have meant two mechanisms doing one job, and the whole argument is that there should be one place that decides.

Content replacement is watched through `TabItem.PropertyChanged` filtered to `ContentProperty`, with subscriptions tracked in a set rather than derived from the collection-changed args — a `Reset` carries neither `OldItems` nor `NewItems` and would leave stale subscriptions behind.

## The test, which is the part I got wrong last time

The old test file built its scenario from plan **files**, with a comment saying executed queries need a live SQL Server and the defect does not require one. The second half was true. The first half was the bug: a plan file opens a window-level tab, which is the one path that was already recomputing. Every assertion passed against a build where the reported behaviour was unchanged. A test that cannot reach the broken code is not coverage, and I shipped it as though it were.

Four new tests, driving the paths a plan actually arrives by:

- `RunningAQueryInEachOfTwoSessionsOffersCompareInBoth` — the report, verbatim.
- `RunningTwoQueriesInOneSessionOffersCompareThere` — the case the pre-#449 arithmetic did handle, now that the arithmetic is gone.
- `QueryStorePlansOfferCompare_AndClosingOneTakesItAway` — Query Store's add path, and closing a plan tab through its own close button.
- `AnActualPlanArrivingInAnExistingWindowTabIsNoticed` — window-level content replacement.

No SQL Server. What needs one is producing plan XML, and only that: `ShowCapturedPlan` is the landing step both execution paths end at, and it is now internal so a test can hand it a committed fixture in place of what the server would have returned. Same for `OnQueryStorePlansSelected`, which needs plans, not a connection.

**Red first, three ways.** With the extractions kept so the tests compile, and behaviour put back to `dev`:

| Reverted | Failing |
|---|---|
| All of it (`dev` behaviour) | the two execution tests + the window-level test — 3 of 4 |
| Sub-tab watcher only, hand-calls left deleted | both execution tests + Query Store |
| Owner lookup back to `TopLevel.GetTopLevel` | the cross-session execution test |

All four green with the fix in.

## What is still uncovered

- **The SQL round trip.** `CaptureAndShowPlan` and `GetActualPlan_Click` above the landing step — connecting, `SET STATISTICS XML ON`, cancellation, the error paths. Unchanged by this and still server-only.
- **The loading tab.** The tests open their own placeholder rather than the ~35 lines each execution path builds. Those two blocks are near-identical and want extracting; not in a bug fix I cannot run against a server.
- **The Query Store history path.** `OnHistoryPlanLoadRequested` goes through the same `AddPlanTab` as the grid path that is covered; one of the two is tested.
- **Background-tab landing.** The `TopLevel` hole is fixed and the tests happen to exercise the unrealised case, but nothing asserts it deliberately — no test switches tabs mid-flight.

## Counts

388 tests on `origin/dev` before this, 0 failed, 2 skipped. 392 after, 0 failed, 2 skipped. Five consecutive full runs, stable, ~15s each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016a1AnKAHwcALrwdYVVrpgR
