### PR TITLE
Put the parameter values back where the analysis is built (#482)

### DIFF
--- a/src/PlanViewer.App/Mcp/McpPlanTools.cs
+++ b/src/PlanViewer.App/Mcp/McpPlanTools.cs
@@ -308,7 +308,16 @@ public sealed class McpPlanTools
             if (statement is null)
                 return "No executable statement found in this plan.";
 
-            var queryText = session.QueryText ?? statement.StatementText ?? "";
+            /* #482: the parameterized form on purpose. ReproScriptBuilder wraps this body in
+               sp_executesql with a parameter list read out of the same plan, so a body that already
+               has the literals inlined would declare parameters that appear nowhere in it — and the
+               plan it produced would be the constant-folded one, not the parameterized compile the
+               repro script exists to reproduce. Falls through to StatementText, which is the same
+               string whenever nothing was substituted. */
+            var queryText = session.QueryText
+                ?? statement.ParameterizedStatementText
+                ?? statement.StatementText
+                ?? "";
             var databaseName = session.DatabaseName ?? statement.OperatorTree?.DatabaseName;
 
             return ReproScriptBuilder.BuildReproScript(

--- a/src/PlanViewer.Core/Output/AnalysisResult.cs
+++ b/src/PlanViewer.Core/Output/AnalysisResult.cs
@@ -54,8 +54,30 @@ public class AnalysisSummary
 
 public class StatementResult
 {
+    /// <summary>
+    /// The statement, with the plan's captured parameter values put back where the engine left
+    /// <c>@0</c>, <c>@1</c> … (#482). Identical to what the plan records for any statement with
+    /// nothing to substitute, which is nearly all of them.
+    /// </summary>
     [JsonPropertyName("statement_text")]
     public string StatementText { get; set; } = "";
+
+    /// <summary>
+    /// The statement exactly as the plan records it, present only when
+    /// <see cref="StatementText"/> had values substituted into it and therefore says something
+    /// different.
+    ///
+    /// <para>This is the text that matches the plan cache and Query Store, and the text that has to
+    /// be paired with a declared parameter list — <c>get_repro_script</c> builds an
+    /// <c>sp_executesql</c> call around it, and a body with the literals already inlined would
+    /// declare parameters it never uses and stop reproducing the parameterized compile the script
+    /// exists to reproduce.</para>
+    ///
+    /// <para>Not to be confused with <c>PlanStatement.ParameterizedText</c>, which is showplan's own
+    /// <c>ParameterizedText</c> element and comes from the plan rather than from this mapping.</para>
+    /// </summary>
+    [JsonPropertyName("parameterized_statement_text")]
+    public string? ParameterizedStatementText { get; set; }
 
     [JsonPropertyName("statement_type")]
     public string StatementType { get; set; } = "";

--- a/src/PlanViewer.Core/Output/ResultMapper.cs
+++ b/src/PlanViewer.Core/Output/ResultMapper.cs
@@ -87,9 +87,26 @@ public static class ResultMapper
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
+
+        /* #482: every consumer of the analysis — advice for humans, advice for robots, the HTML
+           export, the comparison report, the MCP tools — reads its statement text from here, so this
+           is where the parameter values go back in. #467 substituted at the two copy paths it was
+           looking at, which left the same @0 in every one of these.
+
+           The parser's PlanStatement is deliberately untouched: the analyzer's rules regex over that
+           text (OPTIMIZE FOR UNKNOWN, NOT IN, MAXDOP hints), the properties panel shows what the plan
+           records, and none of that should start reading manufactured literals. */
+        var runnable = ParameterSubstitution.Apply(stmt.StatementText, stmt.Parameters);
+
         var result = new StatementResult
         {
-            StatementText = stmt.StatementText,
+            StatementText = runnable.Text,
+
+            /* Carried, not discarded — this is the text that matches the plan cache and Query Store,
+               and get_repro_script has to pair a query body with a declared parameter list. Null when
+               nothing was substituted so it never appears on the overwhelming majority of statements
+               that have nothing to say here. */
+            ParameterizedStatementText = runnable.SubstitutionCount > 0 ? stmt.StatementText : null,
             StatementType = stmt.StatementType,
             EstimatedCost = stmt.StatementSubTreeCost,
             EstimatedRows = stmt.StatementEstRows,

--- a/src/PlanViewer.Core/Services/ParameterSubstitution.cs
+++ b/src/PlanViewer.Core/Services/ParameterSubstitution.cs
@@ -93,7 +93,8 @@ public static class ParameterSubstitution
                     end++;
 
                 var token = statementText[i..end];
-                if (values.TryGetValue(token, out var value))
+                if (values.TryGetValue(token, out var value)
+                    && !IsAssignmentTarget(statementText, i, end))
                 {
                     sb.Append(value);
                     substitutions++;
@@ -114,6 +115,55 @@ public static class ParameterSubstitution
         return substitutions == 0
             ? new ParameterSubstitutionResult(statementText, 0)
             : new ParameterSubstitutionResult(sb.ToString(), substitutions);
+    }
+
+    /// <summary>
+    /// True when the parameter token spanning <paramref name="start"/> to <paramref name="end"/> is
+    /// being assigned TO rather than read from, in which case its value must not be written over it.
+    ///
+    /// <para><b>Why (#482).</b> <c>SELECT @job_name = name, @owner_sid = owner_sid FROM …</c> is a
+    /// real committed plan, and its ParameterList records both of those variables with a compiled
+    /// value of <c>NULL</c>. Substituted blindly it reads <c>SELECT NULL = name, NULL = owner_sid</c>
+    /// — not merely unrunnable but quietly misleading, because it now looks like a comparison. That
+    /// mattered less while substitution was something you asked for on the clipboard; #482 makes it
+    /// what the advice, the exports and the MCP tools show by default.</para>
+    ///
+    /// <para>The three lead-ins below are the ones T-SQL assigns through — <c>SELECT @a = …</c>,
+    /// <c>SET @a = …</c>, and the second and later items of either list. A parameter on the right of
+    /// an <c>=</c> is a read and is left to be substituted, and so is one followed by <c>&gt;=</c>,
+    /// <c>&lt;=</c>, <c>&lt;&gt;</c> or <c>!=</c>, since the scan forward from the token meets that
+    /// operator's first character rather than the <c>=</c>.</para>
+    /// </summary>
+    private static bool IsAssignmentTarget(string text, int start, int end)
+    {
+        var forward = end;
+        while (forward < text.Length && char.IsWhiteSpace(text[forward]))
+            forward++;
+
+        if (forward >= text.Length || text[forward] != '=')
+            return false;
+
+        if (forward + 1 < text.Length && text[forward + 1] == '=')
+            return false;
+
+        var back = start - 1;
+        while (back >= 0 && char.IsWhiteSpace(text[back]))
+            back--;
+
+        if (back < 0)
+            return false;
+
+        /* "SELECT @a = x, @b = y" — everything after the first comma is still a select list. */
+        if (text[back] == ',')
+            return true;
+
+        var wordEnd = back + 1;
+        while (back >= 0 && IsIdentifierPart(text[back]))
+            back--;
+
+        var word = text[(back + 1)..wordEnd];
+        return word.Equals("SELECT", StringComparison.OrdinalIgnoreCase)
+            || word.Equals("SET", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/PlanViewer.Web/PlanViewer.Web.csproj
+++ b/src/PlanViewer.Web/PlanViewer.Web.csproj
@@ -36,6 +36,7 @@
     <Compile Include="..\PlanViewer.Core\Services\PlanIconMapper.cs" Link="Core\Services\PlanIconMapper.cs" />
     <Compile Include="..\PlanViewer.Core\Services\PlanLayoutEngine.cs" Link="Core\Services\PlanLayoutEngine.cs" />
     <Compile Include="..\PlanViewer.Core\Services\TimeDisplayHelper.cs" Link="Core\Services\TimeDisplayHelper.cs" />
+    <Compile Include="..\PlanViewer.Core\Services\ParameterSubstitution.cs" Link="Core\Services\ParameterSubstitution.cs" />
     <Compile Include="..\PlanViewer.Core\Output\AnalysisResult.cs" Link="Core\Output\AnalysisResult.cs" />
     <Compile Include="..\PlanViewer.Core\Output\ResultMapper.cs" Link="Core\Output\ResultMapper.cs" />
     <Compile Include="..\PlanViewer.Core\Output\TextFormatter.cs" Link="Core\Output\TextFormatter.cs" />

--- a/tests/PlanViewer.Core.Tests/AnalysisParameterSubstitutionTests.cs
+++ b/tests/PlanViewer.Core.Tests/AnalysisParameterSubstitutionTests.cs
@@ -1,0 +1,206 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using PlanViewer.App.Mcp;
+using AnalyzerConfig = PlanViewer.Core.Models.AnalyzerConfig;
+using CorePlanSession = PlanViewer.Core.Models.PlanSession;
+using PlanViewer.Core.Output;
+using PlanViewer.Core.Services;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #482: #467 put the parameter values back at the two copy paths it was looking at, and the
+/// reporter came straight back with "still shows parametrized in Human and Robot Advice". Both
+/// advice buttons — and the HTML export, the comparison report, and every MCP tool — read their
+/// statement text out of <see cref="ResultMapper"/>, so that is the seam these cover.
+///
+/// <para>The plan is the #466 reproduction: seven parameters the engine manufactured under
+/// <c>PARAMETERIZATION FORCED</c>, six of them carrying a runtime value and the seventh only a
+/// compiled one.</para>
+/// </summary>
+public class AnalysisParameterSubstitutionTests
+{
+    private const string ParameterizedPlan = "forced_parameterization_plan.sqlplan";
+    private const string NamedParameterPlan = "local_variable_plan.sqlplan";
+
+    /* Two of the seven. The first is a string that keeps its quotes, the second a numeric IN list
+       whose values arrive from showplan wrapped in parentheses. */
+    private const string SubstitutedPredicate = "[t0].[AuthUserId]='123456'";
+    private const string ParameterizedPredicate = "[t0].[AuthUserId]=@0";
+    private const string SubstitutedInList = "[t].[StatusId] in (5,6,7,8,9)";
+
+    [Fact]
+    public void AdviceForHumans_ShowsTheValuesInsteadOfTheParameterNames()
+    {
+        var text = TextFormatter.Format(Analyze(ParameterizedPlan));
+
+        Assert.Contains(SubstitutedPredicate, text);
+        Assert.Contains(SubstitutedInList, text);
+        Assert.Contains("[t].[FromDateTime]>='2026-05-28 10:28:07.3132561'", text);
+
+        /* Scoped to the predicate rather than a bare "@0" — the Parameters section below the
+           statement lists the names on purpose, and should keep doing so. */
+        Assert.DoesNotContain(ParameterizedPredicate, text);
+    }
+
+    [Fact]
+    public void AdviceForRobots_ShowsTheValuesAndStillCarriesTheParameterizedForm()
+    {
+        var json = JsonSerializer.Serialize(Analyze(ParameterizedPlan), AnalysisJson.Indented);
+
+        using var document = JsonDocument.Parse(json);
+        var statement = document.RootElement.GetProperty("statements")[0];
+        var runnable = statement.GetProperty("statement_text").GetString();
+        var parameterized = statement.GetProperty("parameterized_statement_text").GetString();
+
+        Assert.NotNull(runnable);
+        Assert.NotNull(parameterized);
+
+        Assert.Contains(SubstitutedPredicate, runnable);
+        Assert.DoesNotContain(ParameterizedPredicate, runnable);
+
+        /* Both forms, and they say different things — the parameterized one is what matches the
+           plan cache and Query Store, and throwing it away to fix the advice would have been a
+           trade nobody asked for. */
+        Assert.Contains(ParameterizedPredicate, parameterized);
+        Assert.NotEqual(runnable, parameterized);
+    }
+
+    [Fact]
+    public void HtmlExport_ShowsTheValues()
+    {
+        var analysis = Analyze(ParameterizedPlan);
+
+        var html = HtmlExporter.Export(analysis, TextFormatter.Format(analysis));
+
+        /* The IN list rather than the string predicate: the export HTML-encodes what it writes, and
+           an assertion carrying quotes would be testing HttpUtility rather than this change. */
+        Assert.Contains(SubstitutedInList, html);
+        Assert.DoesNotContain("[t].[StatusId] in (@1,@2,@3,@4,@5)", html);
+    }
+
+    [Fact]
+    public void ComparisonReport_ShowsTheValues()
+    {
+        var analysis = Analyze(ParameterizedPlan);
+
+        var comparison = ComparisonFormatter.Compare(analysis, analysis, "before", "after");
+
+        Assert.Contains(SubstitutedPredicate, comparison);
+        Assert.DoesNotContain(ParameterizedPredicate, comparison);
+    }
+
+    [Fact]
+    public void ComparisonStillPairsTwoRunsOfTheSameQueryWithDifferentParameterValues()
+    {
+        /* The reason this change had to be established before it was made. Substituting gives two
+           executions of one query two different statement texts, so if pairing had keyed on that
+           text, comparing a fast run against a slow one would have stopped matching them and
+           reported two unrelated statements instead of one regression. It pairs on QueryHash, which
+           is why substituting here is safe — and this fails the moment somebody changes that. */
+        var slow = Analyze(ParameterizedPlan);
+        var fast = ResultMapper.Map(
+            ShowPlanParser.Parse(PlanXml(ParameterizedPlan).Replace("123456", "999999", StringComparison.Ordinal)),
+            ParameterizedPlan);
+
+        Assert.NotEqual(slow.Statements[0].StatementText, fast.Statements[0].StatementText);
+        Assert.Equal(slow.Statements[0].QueryHash, fast.Statements[0].QueryHash);
+
+        var comparison = ComparisonFormatter.Compare(slow, fast, "before", "after");
+
+        Assert.Contains("--- Statement 1 ---", comparison);
+        Assert.DoesNotContain("only in Plan", comparison);
+    }
+
+    [Fact]
+    public async Task McpAnalyzePlan_HandsTheModelTheRunnableStatement()
+    {
+        /* The consumer that matters most: a model handed @0 with no values is being handed a
+           question it cannot answer. */
+        var manager = new PlanSessionManager();
+        var sessionId = $"mcp-{Guid.NewGuid():N}";
+        manager.Register(new CorePlanSession
+        {
+            SessionId = sessionId,
+            Label = ParameterizedPlan,
+            Source = "file",
+            Plan = PlanTestHelper.LoadAndAnalyze(ParameterizedPlan)
+        });
+        var operations = new PlanOperations(manager, AnalyzerConfig.Default, enforceQueryAdmission: false);
+
+        var json = await McpPlanTools.AnalyzePlan(
+            manager,
+            operations,
+            sessionId,
+            TestContext.Current.CancellationToken);
+
+        using var document = JsonDocument.Parse(json);
+        var statement = document.RootElement.GetProperty("statements")[0];
+        Assert.Contains(SubstitutedPredicate, statement.GetProperty("statement_text").GetString());
+    }
+
+    [Fact]
+    public void McpReproScript_StillBuildsAParameterizedBody()
+    {
+        /* The one consumer that wants the other form. get_repro_script wraps this body in
+           sp_executesql with a parameter list read out of the same plan; a body with the literal
+           already inlined would declare a parameter it never uses, and would compile the
+           constant-folded plan rather than the parameterized one the script exists to reproduce.
+
+           A named parameter rather than the forced-parameterization plan, because ReproScriptBuilder
+           requires a parameter name a human could have typed and drops @0 … @6 before it gets this
+           far — so that plan never reaches the sp_executesql branch this is about. */
+        var manager = new PlanSessionManager();
+        var sessionId = $"repro-{Guid.NewGuid():N}";
+        manager.Register(new CorePlanSession
+        {
+            SessionId = sessionId,
+            Label = NamedParameterPlan,
+            Source = "file",
+            Plan = PlanTestHelper.LoadAndAnalyze(NamedParameterPlan)
+        });
+
+        var script = McpPlanTools.GetReproScript(manager, sessionId);
+
+        Assert.Contains("sp_executesql", script);
+        Assert.Contains("@date datetime", script);
+        Assert.Contains("CreationDate >= @date", script);
+        Assert.DoesNotContain("CreationDate >= '2013-01-01 00:00:00.000'", script);
+    }
+
+    [Fact]
+    public void AssignmentTargets_AreLeftAloneRatherThanTurnedIntoComparisons()
+    {
+        /* SELECT @job_name = name, @owner_sid = owner_sid FROM msdb.dbo.sysjobs_view WHERE
+           (job_id = @job_id) — both assigned variables carry a compiled value of NULL, and writing
+           it over them gives "SELECT NULL = name", which reads as a comparison. The parameter that
+           is actually read still gets its value. */
+        var statement = Analyze("compile_memory_exceeded_plan.sqlplan").Statements[0];
+
+        Assert.Contains("@job_name = name", statement.StatementText);
+        Assert.Contains("@owner_sid = owner_sid", statement.StatementText);
+        Assert.DoesNotContain("NULL = name", statement.StatementText);
+        Assert.Contains("job_id = '846EFE14-2AEE-4A65-9EE0-213187F82250'", statement.StatementText);
+    }
+
+    [Fact]
+    public void StatementWithNothingToSubstitute_KeepsItsTextAndCarriesNoSecondForm()
+    {
+        /* Nearly every plan. The mapped text has to stay byte-identical here, because the CLI's
+           JSON output is hashed as a contract against a plan of exactly this shape — a change in
+           these bytes is something to decide on, not to discover. */
+        var plan = PlanTestHelper.LoadAndAnalyze("row_goal_plan.sqlplan");
+
+        var statement = ResultMapper.Map(plan, "row_goal_plan.sqlplan").Statements[0];
+
+        Assert.Equal(PlanTestHelper.FirstStatement(plan).StatementText, statement.StatementText);
+        Assert.Null(statement.ParameterizedStatementText);
+    }
+
+    private static AnalysisResult Analyze(string planFile) =>
+        ResultMapper.Map(PlanTestHelper.LoadAndAnalyze(planFile), planFile);
+
+    private static string PlanXml(string planFile) =>
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Plans", planFile));
+}

--- a/tests/PlanViewer.Core.Tests/ParameterSubstitutionTests.cs
+++ b/tests/PlanViewer.Core.Tests/ParameterSubstitutionTests.cs
@@ -63,6 +63,62 @@ public class ParameterSubstitutionTests
     }
 
     [Fact]
+    public void AssignedVariable_IsNotOverwrittenWithItsOwnValue()
+    {
+        /* #482: the shape that made this worth handling is a real committed plan —
+           "SELECT @job_name = name, @owner_sid = owner_sid" with both compiled values NULL. Writing
+           the value over the target gives "SELECT NULL = name", which is not merely unrunnable but
+           reads as a comparison. Both list positions, because the second one arrives after a comma
+           rather than after SELECT. */
+        var result = ParameterSubstitution.Apply(
+            "SELECT @a = name, @b = owner FROM t WHERE id = @c",
+            new List<PlanParameter> { Param("@a", "NULL"), Param("@b", "NULL"), Param("@c", "(9)") });
+
+        Assert.Equal("SELECT @a = name, @b = owner FROM t WHERE id = 9", result.Text);
+        Assert.Equal(1, result.SubstitutionCount);
+    }
+
+    [Fact]
+    public void SetAssignment_IsNotOverwrittenEither()
+    {
+        var result = ParameterSubstitution.Apply(
+            "SET @a = @b",
+            new List<PlanParameter> { Param("@a", "(1)"), Param("@b", "(2)") });
+
+        Assert.Equal("SET @a = 2", result.Text);
+        Assert.Equal(1, result.SubstitutionCount);
+    }
+
+    [Fact]
+    public void ComparisonOperatorsThatEndInEquals_AreStillSubstituted()
+    {
+        /* The parameter on the LEFT, which is the only side where the assignment check has anything
+           to decide. It looks forward for a lone "=", and ">=" / "<=" / "<>" / "!=" all put their own
+           character in front of it — so a comparison written with the parameter first must not be
+           mistaken for an assignment. The last one is a bare "=" that is still a comparison, because
+           what precedes it is AND rather than SELECT, SET or a list comma. */
+        var result = ParameterSubstitution.Apply(
+            "WHERE @0 >= a AND @0 <= b AND @0 <> c AND @0 != d AND @0 = e",
+            new List<PlanParameter> { Param("@0", "(3)") });
+
+        Assert.Equal("WHERE 3 >= a AND 3 <= b AND 3 <> c AND 3 != d AND 3 = e", result.Text);
+        Assert.Equal(5, result.SubstitutionCount);
+    }
+
+    [Fact]
+    public void SelectListAliasAssignment_IsStillSubstituted()
+    {
+        /* "VoteTypeId = @VoteTypeId" is an alias on the left and the parameter on the right — a read,
+           and the exact shape param-sniffing-posttypeid2 carries. */
+        var result = ParameterSubstitution.Apply(
+            "SELECT VoteTypeId = @p FROM v WHERE v.VoteTypeId = @p",
+            new List<PlanParameter> { Param("@p", "(2)") });
+
+        Assert.Equal("SELECT VoteTypeId = 2 FROM v WHERE v.VoteTypeId = 2", result.Text);
+        Assert.Equal(2, result.SubstitutionCount);
+    }
+
+    [Fact]
     public void NameInsideAStringLiteral_IsLeftAlone()
     {
         var result = ParameterSubstitution.Apply(


### PR DESCRIPTION
Closes #482. Out of #467, out of #466.

## What was wrong

@joshdbe confirmed #467 worked and then said the rest of the app hadn't moved:

> Shows actual values in Copy/Paste and query editor. Still shows parametrized in Human and Robot Advice

He's right, and it's the same mistake as #447. #467 fixed the three consumers I
happened to be looking at — Copy Query Text, Open in Query Editor, and `Ctrl+C`
on the statements grid — and every other consumer went on handing out `@0`.

There aren't two bugs here, there's one seam. **Advice for Humans** is
`TextFormatter.Format(analysis)`. **Advice for Robots** is
`JsonSerializer.Serialize(analysis)`. Both read `StatementResult.StatementText`,
which comes from `ResultMapper.MapStatement`, and so does the HTML export, the
comparison report, `PlanOperations`' ranked-operator and warning labels, and the
MCP tools. Fixing one place fixes all of them, and the MCP tools are the ones
that mattered most: handing a model `@0` and no values is handing it a question
it cannot answer.

The parser's `PlanStatement` is deliberately untouched. The analyzer's rules
regex over that text — `OPTIMIZE FOR UNKNOWN`, `NOT IN`, the `MAXDOP 2` hint,
the row-goal cause — and the properties panel is a view of the XML. Neither
should start reading manufactured literals. `WarningBaseline.txt` did not move,
which is the evidence that the change landed at the right layer rather than a
comment claiming it did.

## The question the issue told me to answer first

**Does anything match, pair, key or dedupe on statement text? No.**
`ComparisonFormatter.MatchStatements` pairs on `QueryHash`, then falls back to
position; statement text is only ever printed, truncated to 500 characters.
Nothing else in the repo groups, keys or hashes on it. So the failure mode I was
warned about — two runs of one query with different parameter values no longer
matching each other — does not exist here. There is a test that pins it anyway,
because "it pairs on QueryHash" is a fact about today's code and this is exactly
the sort of thing that gets quietly rewritten.

**Is the CLI's JSON a contract? Yes, and the repo says so in its own words.**
`HistoricalCliContractTests` hashes `analyze --compact` against a pinned SHA256,
and the comment on that constant says it has rolled twice, both times additively,
"so a consumer reading fields by name is unaffected — but anything diffing or
hashing whole output sees different bytes, which is exactly what this constant
exists to make somebody decide on rather than discover."

That alone would have been arguable. What settled it is a consumer inside this
repo that genuinely needs the parameterized form: `get_repro_script` falls back
to `StatementText` and hands it to `ReproScriptBuilder`, which wraps the body in
`sp_executesql` with a parameter list read out of the same plan. A body with the
literals already inlined would declare parameters that appear nowhere in it, and
the plan it produced would be the constant-folded one rather than the
parameterized compile the repro script exists to reproduce. That is precisely
the "something was quietly relying on it" case, and it is not hypothetical.

## So: both forms

`StatementText` is the runnable text. `parameterized_statement_text` carries the
plan's own record, and is null unless something was actually substituted —
which is nearly every statement, so the JSON does not grow for plans this does
not touch. `get_repro_script` reaches for it and falls through to `StatementText`,
which is the same string whenever there was nothing to substitute.

The pinned CLI hash is still green, and not by luck: `row_goal_plan.sqlplan` has
no `ParameterList`, so its `statement_text` is byte-identical and the new key is
absent. A test pins both halves of that.

I did consider the other shape — leave `statement_text` alone and add
`runnable_statement_text` — which would have been purely additive. I didn't take
it, for the reason this issue exists: it would leave `statement_text`, the
obvious field, still saying `@0`, and every future consumer would default to the
wrong one. That is how #467 and #447 both shipped incomplete. The right default
belongs at the seam.

## One thing the issue didn't ask for, which this change forced

`compile_memory_exceeded_plan.sqlplan` is
`SELECT @job_name = name, @owner_sid = owner_sid FROM msdb.dbo.sysjobs_view WHERE (job_id = @job_id)`,
and its ParameterList records both assigned variables with a compiled value of
`NULL`. Substituted blindly that reads `SELECT NULL = name, NULL = owner_sid` —
not merely unrunnable but quietly misleading, because it now looks like a
comparison.

That defect is #467's, not this PR's. But it was reachable only by explicitly
choosing "Copy Query Text (with values)", and this change makes it what the
advice, the exports and the MCP tools show by default. Shipping that knowingly
isn't on, so `ParameterSubstitution` grew an assignment-target check: a
parameter followed by a lone `=` and preceded by `SELECT`, `SET`, or a list
comma is being assigned to, not read from, and keeps its name. `@job_id` in the
`WHERE` still gets its value.

It is three lead-ins and a forward scan, not a parser, and it is deliberately
narrow. A parameter on the right of an `=` is a read. A parameter followed by
`>=`, `<=`, `<>` or `!=` is a comparison, because the scan forward meets that
operator's own character rather than the `=`. `SELECT VoteTypeId = @VoteTypeId`
— an alias on the left, the parameter on the right, which is the shape
`param-sniffing-posttypeid2` carries — is still substituted. All four of those
have tests, and the two guarding against over-suppression were proven red
against an over-eager rule rather than against no rule at all, since no rule
passes them trivially.

## Also: the web viewer links Core files by hand

`PlanViewer.Web.csproj` lists the Core sources it compiles one by one, so
`ResultMapper` reaching for `ParameterSubstitution` broke the Blazor build while
the full test suite stayed green. The file is now on the list. It is pure string
work with no WASM-hostile dependencies, and the web viewer renders the same
`AnalysisResult`, so it gets the fix too.

## What this does not do

- **It does not touch the plan properties panel.** `Text` shows what the plan
  records, next to `ParameterizedText`, and that panel stays a view of the XML.
- **It does not touch the analyzer.** Every rule still reads the plan's own text.
- **It does not widen `ReproScriptBuilder`'s parameter-name check.** `@0` … `@6`
  fail its `^@[\p{L}_@#$]` identifier test and get dropped, so a
  forced-parameterization plan never reaches its `sp_executesql` branch at all.
  That's arguably wrong — `sp_executesql N'…', N'@0 varchar(8000)', @0='123456'`
  is legal — but it is a separate question from this one and I left it alone.
- **`get_plan_parameters` now shows the substituted statement** next to the
  parameter list it is describing, so the `@0` anchor is gone from that label.
  The values are right there in the same object, so it reads fine, but it is a
  deliberate call rather than an oversight.

## Tests

Thirteen new, in two files: the analysis-level consumers in
`AnalysisParameterSubstitutionTests`, the substitution rule itself alongside
#467's own cases in `ParameterSubstitutionTests`.

Every one was proven red first, against four separate reverts, because a test
that passes either way is how #467 shipped incomplete:

- **Revert the mapper** → 7 of the 9 analysis tests fail. The two that don't are
  the preservation pins, which is the point of them.
- **Remove the assignment guard** → the 3 assignment tests fail.
- **Make the assignment guard over-eager** → the 2 over-suppression guards fail,
  and so does one of #467's existing tests, which is a decent sign the wrong
  rule really is wrong.
- **Implement #482 the naive way** (substitute in place, no second form, repro
  script reading `StatementText`) → the 2 preservation pins fail. Those are red
  against exactly the tempting implementation, which is the only counterfactual
  that makes them worth having.

Suite: 392 on `origin/dev` (`018a82f`), 405 here, 0 failed, 2 skipped
(Windows-only), four consecutive full runs, ~20s each, no flakes.
`WarningBaseline.txt` unchanged. Full solution builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016a1AnKAHwcALrwdYVVrpgR
