### PR TITLE
Close three ways the app could quietly lose a user's work

### DIFF
--- a/src/PlanViewer.App/AboutWindow.axaml.cs
+++ b/src/PlanViewer.App/AboutWindow.axaml.cs
@@ -231,6 +231,23 @@ public partial class AboutWindow : Window
 
             if (result)
             {
+                /* ApplyUpdatesAndRestart kills the process outright: MainWindow.OnClosing
+                   never fires, so the unsaved-changes walk (#462/#473) never ran on this
+                   route and dirty edits were discarded without a question — and OnClosed's
+                   session save never ran either, so the relaunched app restored nothing
+                   (RestoreOpenPlans had already cleared the saved list at startup). Ask the
+                   same questions the close path asks, and if anyone answers Cancel, abort
+                   the restart and leave this window usable — the update stays downloaded. */
+                if (Owner is MainWindow main)
+                {
+                    if (!await main.ConfirmAllUnsavedWorkAsync())
+                        return;
+
+                    /* After the walk, not before: a Save answer in the walk can give a
+                       scratch tab a file, which this then writes down for the restore. */
+                    main.PersistSessionForRestart();
+                }
+
                 _velopackMgr.ApplyUpdatesAndRestart(_velopackUpdate.TargetFullRelease);
             }
             return;

--- a/src/PlanViewer.App/AboutWindow.axaml.cs
+++ b/src/PlanViewer.App/AboutWindow.axaml.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using Avalonia.Controls;
@@ -188,7 +189,28 @@ public partial class AboutWindow : Window
 
     private bool _updateDownloaded;
 
+    /* Every branch of UpdateLink_Click awaits — a dialog, the unsaved-work walk, a download —
+       and the link stays clickable the whole time, so a second click would start a second
+       concurrent copy of whichever step is in flight (two restart dialogs, two walks prompting
+       about the same tabs, two downloads). One latch at the top covers all of them. */
+    private bool _updateActionInFlight;
+
     private async void UpdateLink_Click(object? sender, PointerPressedEventArgs e)
+    {
+        if (_updateActionInFlight)
+            return;
+        _updateActionInFlight = true;
+        try
+        {
+            await HandleUpdateLinkClickAsync();
+        }
+        finally
+        {
+            _updateActionInFlight = false;
+        }
+    }
+
+    private async Task HandleUpdateLinkClickAsync()
     {
         // Step 3: User clicks "Restart now" after download — confirm first
         if (_updateDownloaded && _velopackMgr != null && _velopackUpdate != null)
@@ -238,7 +260,17 @@ public partial class AboutWindow : Window
                    (RestoreOpenPlans had already cleared the saved list at startup). Ask the
                    same questions the close path asks, and if anyone answers Cancel, abort
                    the restart and leave this window usable — the update stays downloaded. */
-                if (Owner is MainWindow main)
+                /* Resolved through the application lifetime, not Owner: an Owner-typed check
+                   would fail OPEN — shown with any other owner, the walk silently vanishes and
+                   this route is right back to discarding dirty edits, the exact bug being
+                   fixed. The main window owns every session, so if none exists there is no
+                   unsaved work to lose and restarting without a walk is genuinely safe. */
+                var main = Owner as MainWindow
+                    ?? (Avalonia.Application.Current?.ApplicationLifetime
+                        as Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime)
+                        ?.MainWindow as MainWindow;
+
+                if (main != null)
                 {
                     if (!await main.ConfirmAllUnsavedWorkAsync())
                         return;

--- a/src/PlanViewer.App/Controls/QuerySessionControl.Editor.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.Editor.cs
@@ -167,12 +167,22 @@ public partial class QuerySessionControl : UserControl
     internal static bool ReplaceNeedsConfirmation(bool isDirty, string? currentText) =>
         isDirty && !string.IsNullOrEmpty(currentText);
 
+    /* The prompt below puts an await between the dirty check and the replacement, so without
+       a latch two back-to-back "Open in Query Editor" clicks would each read the same dirty
+       state and stack two Replace prompts — the same reentrancy class the About window's
+       update link had. Not data loss (the assignment stays gated on an explicit Replace
+       either way), just two dialogs racing; first click wins, the second is a no-op. */
+    private bool _replacePromptInFlight;
+
     /// <summary>
     /// Puts a statement from a plan into the query editor. Internal (like the MainWindow
     /// Click handlers) so tests can drive it without a plan viewer to click through.
     /// </summary>
     internal async void OnOpenInEditorRequested(object? sender, string queryText)
     {
+        if (_replacePromptInFlight)
+            return;
+
         /* This used to assign unconditionally — the one wholesale overwrite in the app that
            skipped #462's dirty tracking, so a typed-but-unsaved query was replaced without a
            question. ConfirmationDialog rather than the three-button UnsavedChangesDialog:
@@ -181,10 +191,19 @@ public partial class QuerySessionControl : UserControl
            Dismissing the dialog is a no, and a no leaves the editor and the sub-tab alone. */
         if (ReplaceNeedsConfirmation(IsDirty, QueryEditor.Text))
         {
-            var replace = await ShowConfirmationDialog(
-                "Unsaved Changes",
-                "The query editor has unsaved changes.\n\nReplace them with this statement? Your current text will be lost.",
-                confirmCaption: "Replace");
+            _replacePromptInFlight = true;
+            bool replace;
+            try
+            {
+                replace = await ShowConfirmationDialog(
+                    "Unsaved Changes",
+                    "The query editor has unsaved changes.\n\nReplace them with this statement? Your current text will be lost.",
+                    confirmCaption: "Replace");
+            }
+            finally
+            {
+                _replacePromptInFlight = false;
+            }
 
             if (!replace)
                 return;

--- a/src/PlanViewer.App/Controls/QuerySessionControl.Editor.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.Editor.cs
@@ -155,8 +155,41 @@ public partial class QuerySessionControl : UserControl
         }
     }
 
-    private void OnOpenInEditorRequested(object? sender, string queryText)
+    /// <summary>
+    /// Whether "Open in Query Editor" has to stop and ask before pasting over the editor.
+    ///
+    /// <para>Only typed-but-unsaved work earns a prompt: a clean editor is already on disk
+    /// (or empty), and a dirty-but-empty one is a buffer the user deleted everything out of —
+    /// replacing nothing loses nothing, so both stay as frictionless as they always were.
+    /// Split out pure so the decision is testable without a dialog to click, the same trade
+    /// CollectOpenTabPaths made for the session-restore list.</para>
+    /// </summary>
+    internal static bool ReplaceNeedsConfirmation(bool isDirty, string? currentText) =>
+        isDirty && !string.IsNullOrEmpty(currentText);
+
+    /// <summary>
+    /// Puts a statement from a plan into the query editor. Internal (like the MainWindow
+    /// Click handlers) so tests can drive it without a plan viewer to click through.
+    /// </summary>
+    internal async void OnOpenInEditorRequested(object? sender, string queryText)
     {
+        /* This used to assign unconditionally — the one wholesale overwrite in the app that
+           skipped #462's dirty tracking, so a typed-but-unsaved query was replaced without a
+           question. ConfirmationDialog rather than the three-button UnsavedChangesDialog:
+           a Save answer here would need the save pipeline, which lives on MainWindow and
+           takes the tab — machinery this control has no business growing for one prompt.
+           Dismissing the dialog is a no, and a no leaves the editor and the sub-tab alone. */
+        if (ReplaceNeedsConfirmation(IsDirty, QueryEditor.Text))
+        {
+            var replace = await ShowConfirmationDialog(
+                "Unsaved Changes",
+                "The query editor has unsaved changes.\n\nReplace them with this statement? Your current text will be lost.",
+                confirmCaption: "Replace");
+
+            if (!replace)
+                return;
+        }
+
         QueryEditor.Text = queryText;
         SubTabControl.SelectedIndex = 0; // Switch to the editor tab
         QueryEditor.Focus();

--- a/src/PlanViewer.App/Controls/QuerySessionControl.Execution.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.Execution.cs
@@ -442,10 +442,10 @@ public partial class QuerySessionControl : UserControl
     }
 
     /// <summary>
-    /// Shows a modal confirmation dialog and returns true if the user clicked OK.
+    /// Shows a modal confirmation dialog and returns true if the user confirmed.
     /// </summary>
-    private Task<bool> ShowConfirmationDialog(string title, string message)
-        => Dialogs.ConfirmationDialog.ShowAsync(GetParentWindow(), title, message);
+    private Task<bool> ShowConfirmationDialog(string title, string message, string confirmCaption = "OK")
+        => Dialogs.ConfirmationDialog.ShowAsync(GetParentWindow(), title, message, confirmCaption);
 
     /// <summary>
     /// Extracts the database name from plan XML's StmtSimple DatabaseContext attribute.

--- a/src/PlanViewer.App/Dialogs/ConfirmationDialog.cs
+++ b/src/PlanViewer.App/Dialogs/ConfirmationDialog.cs
@@ -13,7 +13,10 @@ namespace PlanViewer.App.Dialogs;
 /// </summary>
 public static class ConfirmationDialog
 {
-    public static async Task<bool> ShowAsync(Window owner, string title, string message)
+    /// <param name="confirmCaption">What the confirming button says. "OK" reads fine for
+    /// gating an execution; a destructive confirmation ("Replace") should name the act, so
+    /// the button says what clicking it costs.</param>
+    public static async Task<bool> ShowAsync(Window owner, string title, string message, string confirmCaption = "OK")
     {
         var result = false;
 
@@ -28,9 +31,10 @@ public static class ConfirmationDialog
 
         var okBtn = new Button
         {
-            Content = "OK",
+            Content = confirmCaption,
             Height = 32,
-            Width = 80,
+            // Min rather than fixed: "OK" renders the same, a longer caption ("Replace") isn't clipped.
+            MinWidth = 80,
             Padding = new Avalonia.Thickness(16, 0),
             FontSize = 12,
             HorizontalContentAlignment = HorizontalAlignment.Center,
@@ -42,7 +46,7 @@ public static class ConfirmationDialog
         {
             Content = "Cancel",
             Height = 32,
-            Width = 80,
+            MinWidth = 80,
             Padding = new Avalonia.Thickness(16, 0),
             FontSize = 12,
             Margin = new Avalonia.Thickness(8, 0, 0, 0),

--- a/src/PlanViewer.App/MainWindow.FileOps.cs
+++ b/src/PlanViewer.App/MainWindow.FileOps.cs
@@ -173,7 +173,14 @@ public partial class MainWindow : Window
     {
         try
         {
-            File.WriteAllText(path, session.QueryEditor.Text);
+            /* Atomic on purpose: on the save-in-place path this file is the user's only copy
+               of their query, and a plain truncate-then-write destroys it when the write dies
+               halfway — disk full, crash, yanked share. AtomicFile stages a sibling .tmp and
+               renames it over the top, so a failed save leaves the original bytes on disk and
+               lands in the catch below with the session still dirty. The rename gives the file
+               the temp's attributes and inherited ACLs rather than preserving the original's —
+               the trade every editor that saves this way makes. */
+            AtomicFile.WriteAllText(path, session.QueryEditor.Text);
             session.SourceFilePath = path;
             // Only a write that actually happened settles the dirty state; the catch below
             // deliberately leaves the session modified so the work is still guarded.
@@ -447,6 +454,15 @@ public partial class MainWindow : Window
 
         AppSettingsService.Save(_appSettings);
     }
+
+    /// <summary>
+    /// Writes the open-tab list down for the session that comes back after a Velopack
+    /// restart. <see cref="OnClosed"/> does this on every ordinary shutdown, but
+    /// ApplyUpdatesAndRestart exits the process without closing the window — and
+    /// <see cref="RestoreOpenPlans"/> already cleared the saved list at startup, so without
+    /// this the updated app relaunched with nothing.
+    /// </summary>
+    internal void PersistSessionForRestart() => SaveOpenPlans();
 
     /// <summary>
     /// Restores the tabs from the previous session. Skips files that no longer exist.

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -532,12 +532,33 @@ public partial class MainWindow : Window
 
     private async Task ConfirmWindowCloseAsync()
     {
-        /* #473: the sessions that are no longer tabs are asked about here, while every window
-           is still up, rather than from OnClosed where they are force-closed. By then the main
-           window is gone and the app is on its way out — a dialog raised there is at best a
-           window nobody expects and at worst a shutdown that never finishes. Asking here is
-           what earns DetachedContentNeedsSavePrompt the right to wave that force-close
-           through. */
+        if (!await ConfirmAllUnsavedWorkAsync())
+            return; // one Cancel cancels the shutdown
+
+        _closeConfirmed = true;
+        Close();
+    }
+
+    /// <summary>
+    /// Asks about every piece of unsaved work in the app, and answers whether whatever is
+    /// about to destroy that work may proceed.
+    ///
+    /// <para>Split out of <see cref="ConfirmWindowCloseAsync"/> because the window close is
+    /// not the only way the process ends: the About window's Velopack "Restart Now" calls
+    /// ApplyUpdatesAndRestart, which exits without ever raising Closing — so #462's and
+    /// #473's walk never ran on that route and dirty edits were discarded without a word.
+    /// This is only the walk: it does not latch <see cref="_closeConfirmed"/> and does not
+    /// Close, so the restart path can take the answer without the close's bookkeeping.</para>
+    ///
+    /// <para>#473: the sessions that are no longer tabs are asked about here, while every
+    /// window is still up, rather than from OnClosed where they are force-closed. By then the
+    /// main window is gone and the app is on its way out — a dialog raised there is at best a
+    /// window nobody expects and at worst a shutdown that never finishes. Asking here is what
+    /// earns DetachedContentNeedsSavePrompt the right to wave that force-close through.</para>
+    /// </summary>
+    /// <returns>False the moment anyone answers Cancel, or a save they asked for fails.</returns>
+    internal async Task<bool> ConfirmAllUnsavedWorkAsync()
+    {
         foreach (var work in UnsavedWorkOnClose())
         {
             var mayClose = work.Tab != null
@@ -545,11 +566,10 @@ public partial class MainWindow : Window
                 : await ConfirmDetachedCloseAsync(work.Session, work.Owner);
 
             if (!mayClose)
-                return; // one Cancel cancels the shutdown
+                return false;
         }
 
-        _closeConfirmed = true;
-        Close();
+        return true;
     }
 
 

--- a/tests/PlanViewer.Core.Tests/OpenInEditorOverwriteTests.cs
+++ b/tests/PlanViewer.Core.Tests/OpenInEditorOverwriteTests.cs
@@ -1,0 +1,180 @@
+using System.IO;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using PlanViewer.App;
+using PlanViewer.App.Controls;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// "Open in Query Editor" pasted a plan's statement over whatever was in the editor, no
+/// questions asked — the one wholesale overwrite in the app that skipped #462's dirty
+/// tracking entirely, so a typed-but-unsaved query was simply gone.
+///
+/// <para>Same testing shape as UnsavedQueryChangesTests: whether to ask is a pure value
+/// (<see cref="QuerySessionControl.ReplaceNeedsConfirmation"/>, split out to be testable the
+/// way CollectOpenTabPaths was), and the handler is driven directly with the prompt answered
+/// by closing it — which is Cancel — or by raising a click on its Replace button.</para>
+/// </summary>
+public class OpenInEditorOverwriteTests
+{
+    [Fact]
+    public void OnlyADirtyNonEmptyEditorNeedsAsking()
+    {
+        Assert.False(QuerySessionControl.ReplaceNeedsConfirmation(isDirty: false, currentText: ""));
+        Assert.False(QuerySessionControl.ReplaceNeedsConfirmation(isDirty: false, currentText: "SELECT 1;"));
+
+        /* Dirty-but-empty is a buffer the user deleted everything out of. Replacing nothing
+           loses nothing, so it stays as frictionless as a clean editor. */
+        Assert.False(QuerySessionControl.ReplaceNeedsConfirmation(isDirty: true, currentText: ""));
+        Assert.False(QuerySessionControl.ReplaceNeedsConfirmation(isDirty: true, currentText: null));
+
+        Assert.True(QuerySessionControl.ReplaceNeedsConfirmation(isDirty: true, currentText: "SELECT 1;"));
+    }
+
+    [Fact]
+    public void ACleanEditorIsReplacedWithoutAPrompt()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+                var session = LastSession(window);
+
+                /* The window is deliberately never shown: a prompt raised here would need a
+                   visible owner and blow up, so replacement going through quietly is itself
+                   the no-prompt assertion. This is the everyday path and it must not grow a
+                   detour — a clean editor is already on disk. */
+                session.OnOpenInEditorRequested(null, "SELECT 99 AS from_plan;");
+
+                Assert.Equal("SELECT 99 AS from_plan;", session.QueryEditor.Text);
+                Assert.Equal(0, session.SubTabControl.SelectedIndex);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    [Fact]
+    public void ADismissedPromptLeavesTheDirtyEditorUntouched()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            MainWindow? window = null;
+            QuerySessionControl? session = null;
+            try
+            {
+                window = new MainWindow();
+                window.Show(); // the prompt's ShowDialog needs a visible owner
+                window.LoadSqlFile(path);
+                window.UpdateLayout(); // attach the tab's content so the session can find its window
+
+                session = LastSession(window);
+                session.QueryEditor.Text = "SELECT 2; -- typed, not saved";
+
+                session.OnOpenInEditorRequested(null, "SELECT 99 AS from_plan;");
+                Dispatcher.UIThread.RunJobs();
+
+                /* The question is up and nothing has been replaced while it is. */
+                var prompt = Assert.Single(window.OwnedWindows);
+                Assert.Equal("SELECT 2; -- typed, not saved", session.QueryEditor.Text);
+
+                /* Dismissing the prompt is a no, and a no leaves the work exactly where it
+                   was — this line is the whole bug, stated as an assertion. */
+                prompt.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.Equal("SELECT 2; -- typed, not saved", session.QueryEditor.Text);
+                Assert.True(session.IsDirty, "the unsaved work is still unsaved, not gone");
+            }
+            finally
+            {
+                PutAway(window, session);
+                File.Delete(path);
+            }
+        });
+    }
+
+    [Fact]
+    public void AnsweringReplaceGoesThroughWithIt()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            MainWindow? window = null;
+            QuerySessionControl? session = null;
+            try
+            {
+                window = new MainWindow();
+                window.Show();
+                window.LoadSqlFile(path);
+                window.UpdateLayout();
+
+                session = LastSession(window);
+                session.QueryEditor.Text = "SELECT 2; -- typed, not saved";
+
+                session.OnOpenInEditorRequested(null, "SELECT 99 AS from_plan;");
+                Dispatcher.UIThread.RunJobs();
+
+                var prompt = Assert.Single(window.OwnedWindows);
+                PromptButton(prompt, "Replace").RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                Dispatcher.UIThread.RunJobs();
+
+                /* An explicit yes is still a yes: the statement lands and the editor sub-tab
+                   comes to the front, exactly as the unguarded path always did. */
+                Assert.Equal("SELECT 99 AS from_plan;", session.QueryEditor.Text);
+                Assert.Equal(0, session.SubTabControl.SelectedIndex);
+            }
+            finally
+            {
+                PutAway(window, session);
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Digs the named button out of a ConfirmationDialog: content StackPanel, then the button
+    /// row, then the caption. Same shape as DetachedUnsavedChangesTests.RedockButton.
+    /// </summary>
+    private static Button PromptButton(Window prompt, string caption) =>
+        ((StackPanel)prompt.Content!).Children.OfType<StackPanel>().Single()
+            .Children.OfType<Button>().Single(b => (string?)b.Content == caption);
+
+    /// <summary>
+    /// Same job as DetachedUnsavedChangesTests.PutAway: prompts closed, session settled,
+    /// window shut — from a finally, because the run where it matters is the run where an
+    /// assertion above it failed (#474).
+    /// </summary>
+    private static void PutAway(MainWindow? window, QuerySessionControl? session)
+    {
+        if (window == null)
+            return;
+
+        foreach (var prompt in window.OwnedWindows.ToList())
+            prompt.Close();
+
+        session?.MarkClean();
+        window.Close();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static QuerySessionControl LastSession(MainWindow window) =>
+        window.MainTabControl.Items.OfType<TabItem>()
+            .Select(t => t.Content).OfType<QuerySessionControl>().Last();
+
+    private static string TempSql(string text)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+        File.WriteAllText(path, text);
+        return path;
+    }
+}

--- a/tests/PlanViewer.Core.Tests/OpenSaveQueryTests.cs
+++ b/tests/PlanViewer.Core.Tests/OpenSaveQueryTests.cs
@@ -107,6 +107,76 @@ public class OpenSaveQueryTests
     }
 
     [Fact]
+    public void SavingInPlaceRoundTripsAndLeavesNoStagingFileBehind()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var opened = TempSql("SELECT 1;");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(opened);
+
+                var tab = QueryTabs(window).Last();
+                var session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 2 AS edited;";
+
+                /* Save-in-place — same path in, same path out — is the route the unsaved-
+                   changes prompt takes for a file-backed tab, and the one where a botched
+                   write costs the user their only copy. It now stages through a sibling
+                   .tmp (AtomicFile), which must be gone once the save has landed. */
+                Assert.True(window.SaveQueryToPath(tab, session, opened));
+
+                Assert.Equal("SELECT 2 AS edited;", File.ReadAllText(opened));
+                Assert.False(session.IsDirty);
+                Assert.Equal(opened, session.SourceFilePath);
+                Assert.False(File.Exists(opened + ".tmp"), "the staging file must not linger");
+            }
+            finally
+            {
+                File.Delete(opened);
+            }
+        });
+    }
+
+    [Fact]
+    public void ASaveThatCannotStageItsTempLeavesTheOriginalFileAlone()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var opened = TempSql("SELECT 1;");
+            /* A directory squatting where AtomicFile stages its temp, so the staging write
+               throws while the target file itself is perfectly writable. */
+            var tmpBlocker = opened + ".tmp";
+            Directory.CreateDirectory(tmpBlocker);
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(opened);
+
+                var tab = QueryTabs(window).Last();
+                var session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 2 AS edited;";
+
+                /* The point of routing SaveQueryToPath through AtomicFile: a save that dies
+                   before it finishes must not have truncated the user's file first. Under
+                   the old truncate-then-write this save would have gone straight to the
+                   target and "succeeded" — failing here, with the original bytes untouched
+                   and the session still dirty, is the new contract. */
+                Assert.False(window.SaveQueryToPath(tab, session, opened));
+
+                Assert.Equal("SELECT 1;", File.ReadAllText(opened));
+                Assert.True(session.IsDirty, "a save that threw has not saved anything");
+            }
+            finally
+            {
+                Directory.Delete(tmpBlocker);
+                File.Delete(opened);
+            }
+        });
+    }
+
+    [Fact]
     public void AFailedSaveLeavesTheSessionPointingAtItsOriginalFile()
     {
         HeadlessUi.Run(() =>

--- a/tests/PlanViewer.Core.Tests/UpdateRestartGuardTests.cs
+++ b/tests/PlanViewer.Core.Tests/UpdateRestartGuardTests.cs
@@ -1,0 +1,154 @@
+using System.IO;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using PlanViewer.App;
+using PlanViewer.App.Controls;
+using PlanViewer.App.Services;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// The About window's Velopack "Restart Now" calls ApplyUpdatesAndRestart, which exits the
+/// process without ever raising Closing — so the unsaved-changes walk (#462/#473) never ran
+/// on that route and dirty edits were discarded without a question, and OnClosed's session
+/// save never ran either, so the relaunched app restored nothing (RestoreOpenPlans had
+/// already cleared the saved list at startup). The fix reuses the close path's walk,
+/// <see cref="MainWindow.ConfirmAllUnsavedWorkAsync"/>, and persists the open tabs before
+/// the restart.
+///
+/// <para>Same testing shape as UnsavedQueryChangesTests: nothing headless can click a
+/// dialog's buttons, so what is pinned is the walk itself — a clean window answers yes
+/// without raising anything, and a dirty one stops, asks, and takes a dismissal as no.</para>
+/// </summary>
+public class UpdateRestartGuardTests
+{
+    [Fact]
+    public void ACleanWindowConfirmsImmediatelyWithoutRaisingAPrompt()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                var task = window.ConfirmAllUnsavedWorkAsync();
+
+                /* Nothing dirty means the walk has nobody to ask, so the task must finish on
+                   the spot. A prompt would leave it pending forever headlessly — completing
+                   at all is the proof that no dialog went up. */
+                Assert.True(task.IsCompletedSuccessfully, "a clean window has nothing to ask about");
+                Assert.True(task.Result);
+                Assert.Empty(window.OwnedWindows);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    [Fact]
+    public void ADirtyTabHoldsTheRestartAndADismissedPromptRefusesIt()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            MainWindow? window = null;
+            QuerySessionControl? session = null;
+            try
+            {
+                window = new MainWindow();
+                window.Show(); // the prompt's ShowDialog needs a visible owner, headless or not
+                window.LoadSqlFile(path);
+
+                var tab = window.MainTabControl.Items.OfType<TabItem>()
+                    .Last(t => t.Content is QuerySessionControl);
+                session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 2; -- unsaved work";
+
+                var task = window.ConfirmAllUnsavedWorkAsync();
+                Dispatcher.UIThread.RunJobs();
+
+                /* The restart cannot go ahead while the question is open. */
+                Assert.False(task.IsCompleted);
+                var prompt = Assert.Single(window.OwnedWindows);
+
+                /* Dismissing the prompt is Cancel, and Cancel has to refuse the restart with
+                   everything intact: no save, no close, and no latch set behind the caller's
+                   back — the About window aborts and the app carries on as it was. */
+                prompt.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.True(task.IsCompleted, "the refused answer still has to arrive");
+                Assert.False(task.Result);
+                Assert.True(session.IsDirty, "nothing was written and nothing was discarded");
+                Assert.True(window.IsVisible, "the walk must not close anything on its own");
+                Assert.Contains(tab, window.MainTabControl.Items.OfType<TabItem>());
+            }
+            finally
+            {
+                PutAway(window, session);
+                File.Delete(path);
+            }
+        });
+    }
+
+    [Fact]
+    public void PersistSessionForRestartWritesTheOpenTabsDown()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            var settings = AppSettingsService.Load();
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                /* OnClosed does this on an ordinary shutdown; ApplyUpdatesAndRestart exits
+                   without one, and RestoreOpenPlans cleared the list at startup — so the
+                   restart path has to write the tabs down itself or the updated app comes
+                   back empty-handed. Load returns the process-wide cached instance, the same
+                   object the window writes through (see RestoreQueryTabsTests.Seed). */
+                window.PersistSessionForRestart();
+
+                Assert.Contains(path, settings.OpenTabs);
+            }
+            finally
+            {
+                /* Leave nothing seeded for the next test's MainWindow to restore. */
+                settings.OpenTabs.Clear();
+                AppSettingsService.Save(settings);
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Same job as DetachedUnsavedChangesTests.PutAway, for the main window: prompts closed,
+    /// session settled, window shut — from a finally, because the run where it matters is the
+    /// run where an assertion above it failed (#474).
+    /// </summary>
+    private static void PutAway(MainWindow? window, QuerySessionControl? session)
+    {
+        if (window == null)
+            return;
+
+        foreach (var prompt in window.OwnedWindows.ToList())
+            prompt.Close();
+
+        session?.MarkClean();
+        window.Close();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static string TempSql(string text)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+        File.WriteAllText(path, text);
+        return path;
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the three Major data-loss findings from the 2026-09-02 adversarial review:

- **Velopack "Restart Now" bypassed every guard**: `ApplyUpdatesAndRestart` exits without raising `Closing`, so the #462/#473 unsaved-changes walk never ran and the session save never happened — dirty edits silently discarded and the updated app relaunched with no tabs. The walk now lives in `ConfirmAllUnsavedWorkAsync` (pure: no close bookkeeping), reused by the close path and run by the About window before restarting; Cancel aborts the restart with the update still downloaded, and the session is persisted after the walk since a Save answer can give a scratch tab a path worth restoring.
- **Save-in-place was truncate-then-write** over the user's only copy. `SaveQueryToPath` now stages through the existing `AtomicFile` (sibling .tmp + rename), so a failed save leaves the original bytes on disk and the session dirty. Attribute/ACL trade documented in a comment.
- **"Open in Query Editor" overwrote a dirty buffer unconditionally** — the one wholesale replacement that skipped dirty tracking. It now confirms (Replace/Cancel) via the existing `ConfirmationDialog` when the editor holds typed-but-unsaved work; clean or empty editors replace without a prompt, exactly as before. The decision is a pure testable seam (`ReplaceNeedsConfirmation`).

## How was this tested?

Nine new tests across `UpdateRestartGuardTests`, `OpenInEditorOverwriteTests`, and extended `OpenSaveQueryTests` — including a save that cannot stage its temp leaving the original untouched (that save *succeeded* under the old code). Full suite at dev tip + fix: 417 tests, 416 passed, 1 platform skip, 0 failed, on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvAv72Pwb8czsjDWsCCk7n