### PR TITLE
Finish #456's descent: score, override, display, and share proc-body statements

### DIFF
--- a/server/PlanShare/Program.cs
+++ b/server/PlanShare/Program.cs
@@ -105,6 +105,16 @@ app.UseCors();
 
 const int MaxTtlDays = 365;
 
+// Depth ceiling for parsing an uploaded share, mirroring PlanViewer.Core's
+// AnalysisJson.MaxDepth — that class is the source of truth for how deep a serialized
+// AnalysisResult can go (#431: an operator costs two JSON levels, so the JsonDocument
+// default of 64 rejects a plan ~30 operators deep as "Invalid JSON" after the client
+// happily serialized it at 1024). Mirrored rather than referenced because this project
+// deliberately takes no dependency on PlanViewer.Core, and a shared constant only helps
+// call sites that reference it; this one cannot. If AnalysisJson.MaxDepth ever changes,
+// change this with it — the client-side depth tests pin 1024, so start there.
+var shareDocumentOptions = new JsonDocumentOptions { MaxDepth = 1024 };
+
 // --- Endpoints ---
 
 app.MapGet("/health", () => Results.Content("OK", "text/plain"));
@@ -127,11 +137,13 @@ app.MapPost("/api/share", async (HttpContext ctx) =>
         return Results.BadRequest("Empty body");
     }
 
-    // Parse and extract ttl_days from the JSON
+    // Parse and extract ttl_days from the JSON. shareDocumentOptions, not defaults: this body
+    // wraps a full serialized analysis, and the default 64-level ceiling turned a deep plan's
+    // legitimate upload into a 400 before ttl_days was ever read.
     int ttlDays = 7;
     try
     {
-        using var doc = JsonDocument.Parse(body);
+        using var doc = JsonDocument.Parse(body, shareDocumentOptions);
         if (doc.RootElement.TryGetProperty("ttl_days", out var ttlProp) && ttlProp.TryGetInt32(out var t))
             ttlDays = Math.Clamp(t, 1, MaxTtlDays);
     }

--- a/src/PlanViewer.App/Controls/PlanViewerControl.Statements.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.Statements.cs
@@ -16,13 +16,16 @@ namespace PlanViewer.App.Controls;
 
 public partial class PlanViewerControl : UserControl
 {
-    private void PopulateStatementsGrid(List<PlanStatement> statements)
+    /* Takes the container-aware entries rather than bare statements (#456 follow-up): the grid
+       now lists stored procedure and UDF body statements alongside the outer batch, and a row
+       needs to say WHICH module its statement came from or five bare SELECTs are indistinguishable. */
+    private void PopulateStatementsGrid(List<StatementWithContainer> statements)
     {
         StatementsHeader.Text = $"Statements ({statements.Count})";
 
-        var hasActualTimes = statements.Any(s => s.QueryTimeStats != null &&
-            (s.QueryTimeStats.CpuTimeMs > 0 || s.QueryTimeStats.ElapsedTimeMs > 0));
-        var hasUdf = statements.Any(s => s.QueryUdfElapsedTimeMs > 0);
+        var hasActualTimes = statements.Any(e => e.Statement.QueryTimeStats != null &&
+            (e.Statement.QueryTimeStats.CpuTimeMs > 0 || e.Statement.QueryTimeStats.ElapsedTimeMs > 0));
+        var hasUdf = statements.Any(e => e.Statement.QueryUdfElapsedTimeMs > 0);
 
         // Build columns
         StatementsGrid.Columns.Clear();
@@ -129,7 +132,7 @@ public partial class PlanViewerControl : UserControl
         var rows = new List<StatementRow>();
         for (int i = 0; i < statements.Count; i++)
         {
-            var stmt = statements[i];
+            var stmt = statements[i].Statement;
             var allWarnings = stmt.PlanWarnings.ToList();
             if (stmt.RootNode != null)
                 CollectNodeWarnings(stmt.RootNode, allWarnings);
@@ -137,6 +140,14 @@ public partial class PlanViewerControl : UserControl
             var fullText = stmt.StatementText;
             if (string.IsNullOrWhiteSpace(fullText))
                 fullText = $"Statement {i + 1}";
+
+            /* A body statement gets its module name in front ("dbo.Proc > SELECT ...") in both
+               the cell and its tooltip — display only. Copy/open-in-editor read
+               row.Statement.StatementText and hand out the statement exactly as the plan
+               recorded it, prefix-free. */
+            if (!string.IsNullOrEmpty(statements[i].ContainerPath))
+                fullText = $"{statements[i].ContainerPath} > {fullText}";
+
             var displayText = fullText.Length > 120 ? fullText[..120] + "..." : fullText;
 
             rows.Add(new StatementRow

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -345,9 +345,20 @@ public partial class PlanViewerControl : UserControl
 
         PlanAnalysisPipeline.AnalyzeParsed(_currentPlan, ConfigLoader.Load(), _serverMetadata);
 
-        var allStatements = _currentPlan.Batches
-            .SelectMany(b => b.Statements)
-            .Where(s => s.RootNode != null)
+        /* #456 gave the analysis pipeline and Human/Robot Advice (ResultMapper) the shared
+           PlanStatements.EnumerateAll traversal, which descends into stored procedure and UDF
+           bodies. The grid and the MCP registration below kept walking batch.Statements, so an
+           EXEC <procedure> plan showed one grid row — the EXEC itself — and registered near-zero
+           counts, while the advice discussed dozens of warnings the UI could neither display nor
+           navigate to. Same traversal here so what the grid shows, what the session reports, and
+           what the advice says are the same plan. */
+        var everyStatement = PlanStatements.EnumerateAllWithContainer(_currentPlan).ToList();
+
+        /* Only statements with a root node can render on the canvas. The same filter has always
+           applied to the outer batch (where the parser's synthetic statement roots mean it
+           rarely excludes anything); it now applies across the whole traversal. */
+        var allStatements = everyStatement
+            .Where(e => e.Statement.RootNode != null)
             .ToList();
 
         if (allStatements.Count == 0)
@@ -361,16 +372,20 @@ public partial class PlanViewerControl : UserControl
         PlanScrollViewer.IsVisible = true;
 
         // Always show statement grid — useful summary even for single-statement plans
-        _allStatements = allStatements;
+        _allStatements = allStatements.Select(e => e.Statement).ToList();
         PopulateStatementsGrid(allStatements);
         ShowStatementsPanel();
         StatementsGrid.SelectedIndex = 0;
 
-        // Register with MCP session manager for AI tool access
-        // Count warnings from both statement-level PlanWarnings and all node Warnings
+        /* Register with MCP session manager for AI tool access. Counts run over EVERY statement,
+           renderable or not, because that is what the advice an MCP client reads was built from:
+           statement-level PlanWarnings plus all node warnings, proc/UDF bodies included.
+           StatementCount likewise matches the analysis output's total_statements rather than the
+           grid's renderable subset. */
         int warningCount = 0, criticalCount = 0;
-        foreach (var s in allStatements)
+        foreach (var entry in everyStatement)
         {
+            var s = entry.Statement;
             warningCount += s.PlanWarnings.Count;
             criticalCount += s.PlanWarnings.Count(w => w.Severity == PlanWarningSeverity.Critical);
             if (s.RootNode != null)
@@ -385,8 +400,8 @@ public partial class PlanViewerControl : UserControl
             Source = sessionSource,
             Plan = _currentPlan,
             QueryText = queryText,
-            StatementCount = allStatements.Count,
-            HasActualStats = allStatements.Any(s => s.QueryTimeStats != null),
+            StatementCount = everyStatement.Count,
+            HasActualStats = everyStatement.Any(e => e.Statement.QueryTimeStats != null),
             WarningCount = warningCount,
             CriticalWarningCount = criticalCount,
             MissingIndexCount = _currentPlan.AllMissingIndexes.Count

--- a/src/PlanViewer.App/Mcp/McpQueryStoreTools.cs
+++ b/src/PlanViewer.App/Mcp/McpQueryStoreTools.cs
@@ -311,8 +311,16 @@ public sealed class McpQueryStoreTools
         string connectionInfo)
     {
         var analysis = ResultMapper.Map(parsed, "query-store");
-        var allStatements = parsed.Batches.SelectMany(batch => batch.Statements).ToList();
-        var executableStatement = allStatements.FirstOrDefault(statement => statement.RootNode is not null);
+
+        /* #456 follow-up: the counts used to come from a second walk over batch.Statements while
+           the Analysis stored on this very session is mapped from PlanStatements.EnumerateAll —
+           stored procedure and UDF bodies included, node-level warnings counted — so a Query
+           Store EXEC plan registered statement_count 1 and warning_count 0 alongside an analysis
+           full of findings. The counts now come from that analysis's own summary: one source, and
+           nothing left to disagree with what an MCP client reads. */
+        var executableStatement = Core.Services.PlanStatements.EnumerateAll(parsed)
+            .FirstOrDefault(statement => statement.RootNode is not null);
+
         var session = new PlanSession
         {
             SessionId = sessionId,
@@ -324,12 +332,11 @@ public sealed class McpQueryStoreTools
             DatabaseName = executableStatement?.RootNode?.DatabaseName,
             QueryText = queryText,
             ConnectionInfo = connectionInfo,
-            StatementCount = allStatements.Count,
-            HasActualStats = false,
-            WarningCount = allStatements.Sum(statement => statement.PlanWarnings.Count),
-            CriticalWarningCount = allStatements.Sum(statement =>
-                statement.PlanWarnings.Count(warning => warning.Severity == Core.Models.PlanWarningSeverity.Critical)),
-            MissingIndexCount = parsed.AllMissingIndexes.Count
+            StatementCount = analysis.Summary.TotalStatements,
+            HasActualStats = analysis.Summary.HasActualStats,
+            WarningCount = analysis.Summary.TotalWarnings,
+            CriticalWarningCount = analysis.Summary.CriticalWarnings,
+            MissingIndexCount = analysis.Summary.MissingIndexes
         };
 
         parsed.RawXml = string.Empty;

--- a/src/PlanViewer.Core/Models/PlanModels.cs
+++ b/src/PlanViewer.Core/Models/PlanModels.cs
@@ -12,8 +12,14 @@ public class ParsedPlan
     public bool ClusteredMode { get; set; }
     public List<PlanBatch> Batches { get; set; } = new();
 
-    public List<MissingIndex> AllMissingIndexes => Batches
-        .SelectMany(b => b.Statements)
+    /* #456 follow-up: analysis output lists a missing index per statement, procedure and UDF
+       bodies included, so this rollup must descend the same way — it feeds the MissingIndexCount
+       the MCP session registrations report, and an EXEC <procedure> plan whose only missing-index
+       suggestions live in the body used to register as having none while the advice discussed
+       them. Uses the shared traversal rather than its own descent so it cannot drift from what
+       the analysis actually saw. */
+    public List<MissingIndex> AllMissingIndexes =>
+        Services.PlanStatements.EnumerateAll(this)
         .SelectMany(s => s.MissingIndexes)
         .ToList();
 }

--- a/src/PlanViewer.Core/Output/AnalysisJson.cs
+++ b/src/PlanViewer.Core/Output/AnalysisJson.cs
@@ -70,4 +70,34 @@ public static class AnalysisJson
         MaxDepth = MaxDepth,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
+
+    /// <summary>
+    /// The share wire format: default JSON in every respect except the depth ceiling.
+    ///
+    /// <para>#431 raised the ceiling for "every writer of this object", and the web share
+    /// endpoints turned out to be three more writers nobody listed: the upload serialized the
+    /// analysis with inline default options, and loading a share back parsed and deserialized it
+    /// at the default 64 again — so a deep-but-real plan (~30 nested operators) analyzed fine on
+    /// screen and then failed to Share, or shared and failed to open, with an "object cycle"
+    /// message pointing at the wrong cause. This is deliberately NOT one of the WithoutNulls
+    /// variants: shares already in the database were written with default formatting, and the fix
+    /// is the ceiling, not a wire-format change riding along with it. Used for both directions —
+    /// deserializers enforce MaxDepth too, and a share that was legal to write must be legal to
+    /// read back.</para>
+    /// </summary>
+    public static readonly JsonSerializerOptions Wire = new()
+    {
+        MaxDepth = MaxDepth,
+    };
+
+    /// <summary>
+    /// The same ceiling for <see cref="System.Text.Json.JsonDocument.Parse(string, JsonDocumentOptions)"/>
+    /// call sites: JsonDocumentOptions is a separate type with its own default MaxDepth of 64, so a
+    /// reader that picks a share apart with JsonDocument before deserializing — which is exactly
+    /// what loading a share does — hits the same wall the serializer options alone cannot fix.
+    /// </summary>
+    public static readonly JsonDocumentOptions Document = new()
+    {
+        MaxDepth = MaxDepth,
+    };
 }

--- a/src/PlanViewer.Core/Services/BenefitScorer.cs
+++ b/src/PlanViewer.Core/Services/BenefitScorer.cs
@@ -30,23 +30,26 @@ public static class BenefitScorer
 
     internal static void ScoreCancellable(ParsedPlan plan, CancellationToken cancellationToken)
     {
-        foreach (var batch in plan.Batches)
+        /* #456 made the analyzer descend into stored procedure and UDF bodies via
+           PlanStatements.EnumerateAll, but this walk was left on batch.Statements. The analyzer
+           then CREATED warnings on the body statements and the scorer never visited them, so their
+           MaxBenefitPercent stayed null and their wait stats were never scored or surfaced — the
+           UI sorts unquantified warnings below quantified ones, which quietly buried every finding
+           inside an EXEC <procedure> plan. Same shared traversal as the analyzer so the two passes
+           cannot see different statements again. */
+        foreach (var stmt in PlanStatements.EnumerateAll(plan))
         {
             cancellationToken.ThrowIfCancellationRequested();
-            foreach (var stmt in batch.Statements)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                ScoreStatementWarnings(stmt);
+            ScoreStatementWarnings(stmt);
 
-                if (stmt.RootNode != null)
-                    ScoreNodeTree(stmt.RootNode, stmt, cancellationToken);
+            if (stmt.RootNode != null)
+                ScoreNodeTree(stmt.RootNode, stmt, cancellationToken);
 
-                if (stmt.WaitStats.Count > 0 && stmt.QueryTimeStats != null)
-                    ScoreWaitStats(stmt);
+            if (stmt.WaitStats.Count > 0 && stmt.QueryTimeStats != null)
+                ScoreWaitStats(stmt);
 
-                if (stmt.WaitStats.Count > 0)
-                    EmitWaitStatWarnings(stmt);
-            }
+            if (stmt.WaitStats.Count > 0)
+                EmitWaitStatWarnings(stmt);
         }
     }
 

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.Helpers.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.Helpers.cs
@@ -30,18 +30,21 @@ public static partial class PlanAnalyzer
             MarkLegacyWarningsOnTree(child);
     }
 
+    /* #456 follow-up: the analyzer walks every statement — stored procedure and UDF bodies
+       included — through PlanStatements.EnumerateAll, but this pass still walked batch.Statements,
+       so a user's severity override applied to a warning on the outer batch and silently did not
+       apply to the identical warning inside an EXEC <procedure> body. (MarkLegacyWarnings does not
+       have this problem: it is called per-statement from inside the analyzer's EnumerateAll loop,
+       so it was carried along when that loop learned to descend.) */
     private static void ApplySeverityOverrides(ParsedPlan plan, AnalyzerConfig cfg)
     {
-        foreach (var batch in plan.Batches)
+        foreach (var stmt in PlanStatements.EnumerateAll(plan))
         {
-            foreach (var stmt in batch.Statements)
-            {
-                foreach (var w in stmt.PlanWarnings)
-                    TryOverrideSeverity(w, cfg);
+            foreach (var w in stmt.PlanWarnings)
+                TryOverrideSeverity(w, cfg);
 
-                if (stmt.RootNode != null)
-                    ApplyOverridesToTree(stmt.RootNode, cfg);
-            }
+            if (stmt.RootNode != null)
+                ApplyOverridesToTree(stmt.RootNode, cfg);
         }
     }
 

--- a/src/PlanViewer.Core/Services/PlanStatements.cs
+++ b/src/PlanViewer.Core/Services/PlanStatements.cs
@@ -34,35 +34,90 @@ public static class PlanStatements
     }
 
     /// <summary>
-    /// <paramref name="statements"/> and everything nested beneath them.
+    /// <paramref name="statements"/> and everything nested beneath them. Defined in terms of
+    /// <see cref="EnumerateAllWithContainer(IReadOnlyList{PlanStatement})"/> so the plain and the
+    /// context-carrying enumeration are literally the same walk — a consumer picking either one
+    /// gets the same statements in the same order, which is the whole point of this class.
+    /// </summary>
+    public static IEnumerable<PlanStatement> EnumerateAll(IReadOnlyList<PlanStatement> statements)
+    {
+        foreach (var entry in EnumerateAllWithContainer(statements))
+            yield return entry.Statement;
+    }
+
+    /// <summary>
+    /// Every statement in the plan with the name of the module whose body it came from, for
+    /// consumers that show statements to a person rather than just walking them.
+    ///
+    /// <para>Why the context matters (#456 follow-up): once the desktop statements grid started
+    /// listing procedure-body statements alongside the outer batch, five rows of bare SELECTs with
+    /// nothing saying which came from <c>EXEC dbo.Whatever</c> would be technically complete and
+    /// practically unreadable. The container name is part of the traversal rather than something
+    /// each UI reconstructs with its own walk, because two walks that must agree is exactly the
+    /// arrangement that produced #455.</para>
+    /// </summary>
+    public static IEnumerable<StatementWithContainer> EnumerateAllWithContainer(ParsedPlan plan)
+    {
+        foreach (var batch in plan.Batches)
+        {
+            foreach (var entry in EnumerateAllWithContainer(batch.Statements))
+                yield return entry;
+        }
+    }
+
+    /// <summary>
+    /// <paramref name="statements"/> and everything nested beneath them, each paired with the
+    /// module path it lives in (null for the outer batch).
     ///
     /// <para>An explicit stack rather than recursion, because procedure bodies nest — a procedure
     /// calling a procedure calling a function — and #430 was a crash caused by assuming a plan's
     /// shapes are shallow.</para>
     /// </summary>
-    public static IEnumerable<PlanStatement> EnumerateAll(IReadOnlyList<PlanStatement> statements)
+    public static IEnumerable<StatementWithContainer> EnumerateAllWithContainer(IReadOnlyList<PlanStatement> statements)
     {
-        var pending = new Stack<PlanStatement>();
+        var pending = new Stack<StatementWithContainer>();
         for (var i = statements.Count - 1; i >= 0; i--)
-            pending.Push(statements[i]);
+            pending.Push(new StatementWithContainer(statements[i], ContainerPath: null));
 
-        while (pending.TryPop(out var statement))
+        while (pending.TryPop(out var entry))
         {
-            yield return statement;
+            yield return entry;
 
             /* Pushed in reverse so the bodies come back out in source order, and pushed AFTER the
                statement is yielded so a body follows the EXEC that owns it rather than preceding it. */
+            var statement = entry.Statement;
             for (var i = statement.UdfPlans.Count - 1; i >= 0; i--)
-                PushAll(statement.UdfPlans[i].Statements, pending);
+                PushAll(statement.UdfPlans[i], entry.ContainerPath, pending);
 
             if (statement.StoredProcPlan is not null)
-                PushAll(statement.StoredProcPlan.Statements, pending);
+                PushAll(statement.StoredProcPlan, entry.ContainerPath, pending);
         }
     }
 
-    private static void PushAll(IReadOnlyList<PlanStatement> statements, Stack<PlanStatement> pending)
+    private static void PushAll(FunctionPlanInfo body, string? outerPath, Stack<StatementWithContainer> pending)
     {
-        for (var i = statements.Count - 1; i >= 0; i--)
-            pending.Push(statements[i]);
+        var path = AppendModule(outerPath, body.ProcName);
+        for (var i = body.Statements.Count - 1; i >= 0; i--)
+            pending.Push(new StatementWithContainer(body.Statements[i], path));
+    }
+
+    /// <summary>
+    /// Chains module names for nesting, so a statement two bodies deep reads
+    /// "dbo.Outer &gt; dbo.Inner" rather than pretending it sits directly in dbo.Inner's caller.
+    /// A module the plan left unnamed contributes nothing to the path — the traversal reports what
+    /// the plan said, not a placeholder — so its statements inherit the enclosing path (or none).
+    /// </summary>
+    private static string? AppendModule(string? outerPath, string procName)
+    {
+        if (string.IsNullOrEmpty(procName))
+            return outerPath;
+        return outerPath is null ? procName : outerPath + " > " + procName;
     }
 }
+
+/// <summary>
+/// One statement from <see cref="PlanStatements.EnumerateAllWithContainer(ParsedPlan)"/>:
+/// the statement itself, and the proc/UDF module path it came from — null for a statement in the
+/// outer batch, "dbo.Proc" for a procedure body, "dbo.Outer &gt; dbo.Inner" for nested bodies.
+/// </summary>
+public readonly record struct StatementWithContainer(PlanStatement Statement, string? ContainerPath);

--- a/src/PlanViewer.Web/Pages/Index.razor
+++ b/src/PlanViewer.Web/Pages/Index.razor
@@ -214,7 +214,14 @@ else
     private PlanNode? selectedNode;
 
     private StatementResult? ActiveStmt => result?.Statements.ElementAtOrDefault(activeStatement);
-    private PlanStatement? ActiveStmtPlan => parsedPlan?.Batches.SelectMany(b => b.Statements).ElementAtOrDefault(activeStatement);
+    /* activeStatement indexes result.Statements, which ResultMapper builds from
+       PlanStatements.EnumerateAll — since #456 that includes statements inside stored procedure
+       and UDF bodies. Mapping the same index into the outer-only batch list returned null for
+       every body statement, so clicking a body statement's tab showed its analysis with no
+       operator tree. The two lists must be walked by the same traversal to line up. */
+    private PlanStatement? ActiveStmtPlan => parsedPlan == null
+        ? null
+        : PlanStatements.EnumerateAll(parsedPlan).ElementAtOrDefault(activeStatement);
 
     private async Task AnalyzePasted()
     {

--- a/src/PlanViewer.Web/PlanViewer.Web.csproj
+++ b/src/PlanViewer.Web/PlanViewer.Web.csproj
@@ -38,6 +38,7 @@
     <Compile Include="..\PlanViewer.Core\Services\TimeDisplayHelper.cs" Link="Core\Services\TimeDisplayHelper.cs" />
     <Compile Include="..\PlanViewer.Core\Services\ParameterSubstitution.cs" Link="Core\Services\ParameterSubstitution.cs" />
     <Compile Include="..\PlanViewer.Core\Output\AnalysisResult.cs" Link="Core\Output\AnalysisResult.cs" />
+    <Compile Include="..\PlanViewer.Core\Output\AnalysisJson.cs" Link="Core\Output\AnalysisJson.cs" />
     <Compile Include="..\PlanViewer.Core\Output\ResultMapper.cs" Link="Core\Output\ResultMapper.cs" />
     <Compile Include="..\PlanViewer.Core\Output\TextFormatter.cs" Link="Core\Output\TextFormatter.cs" />
     <Compile Include="..\PlanViewer.Core\Output\HtmlExporter.cs" Link="Core\Output\HtmlExporter.cs" />

--- a/src/PlanViewer.Web/Services/PlanShareService.cs
+++ b/src/PlanViewer.Web/Services/PlanShareService.cs
@@ -46,12 +46,16 @@ public sealed class PlanShareService : IPlanShareService
 
     public async Task<PlanShareResult> ShareAsync(AnalysisResult result, string text, int ttlDays)
     {
+        /* AnalysisJson.Wire, not default options: this serializes an AnalysisResult, and #431's
+           depth ceiling exists for "every writer of this object". Default MaxDepth is 64, an
+           operator costs two JSON levels, so sharing a plan ~30 operators deep threw an "object
+           cycle" JsonException here while the same analysis rendered fine everywhere else. */
         var payload = JsonSerializer.Serialize(new
         {
             result = result,
             text = text,
             ttl_days = ttlDays
-        });
+        }, AnalysisJson.Wire);
         var content = new StringContent(payload, Encoding.UTF8, "application/json");
         var response = await _http.PostAsync($"{ApiBase}/api/share", content);
 
@@ -83,9 +87,13 @@ public sealed class PlanShareService : IPlanShareService
         }
 
         var json = await response.Content.ReadAsStringAsync();
-        using var doc = JsonDocument.Parse(json);
+        /* Reading a share hits the default 64 ceiling twice — JsonDocumentOptions and
+           JsonSerializerOptions each carry their own MaxDepth — so a deep plan that ShareAsync
+           could now write would still fail to load without both raised. A share must never be
+           writable but not readable. */
+        using var doc = JsonDocument.Parse(json, AnalysisJson.Document);
         var root = doc.RootElement;
-        var result = JsonSerializer.Deserialize<AnalysisResult>(root.GetProperty("result").GetRawText());
+        var result = JsonSerializer.Deserialize<AnalysisResult>(root.GetProperty("result").GetRawText(), AnalysisJson.Wire);
         var text = root.GetProperty("text").GetString();
         return new SharedPlan(result, text);
     }

--- a/tests/PlanViewer.Core.Tests/AnalysisJsonDepthTests.cs
+++ b/tests/PlanViewer.Core.Tests/AnalysisJsonDepthTests.cs
@@ -107,6 +107,11 @@ public class AnalysisJsonDepthTests
     /// Pins the headroom itself. 1024 is about 500 nested operators against the ~30 that used to fail;
     /// a future edit dropping it back toward the default would re-open #430 for large plans only, which
     /// is the shape of bug that reaches users rather than tests.
+    ///
+    /// <para>The Wire and Document pins matter beyond this assembly: server/PlanShare cannot
+    /// reference PlanViewer.Core and mirrors this number as a literal (a shared constant only
+    /// helps call sites that reference it), so this test is the tripwire that a change here means
+    /// changing the server too.</para>
     /// </summary>
     [Fact]
     public void TheCeilingIsFarAboveAnyRealPlan()
@@ -114,5 +119,50 @@ public class AnalysisJsonDepthTests
         Assert.Equal(1024, AnalysisJson.MaxDepth);
         Assert.Equal(AnalysisJson.MaxDepth, AnalysisJson.Indented.MaxDepth);
         Assert.True(AnalysisJson.Indented.WriteIndented, "advice output is read by people as well as models");
+        Assert.Equal(AnalysisJson.MaxDepth, AnalysisJson.Wire.MaxDepth);
+        Assert.Equal(AnalysisJson.MaxDepth, AnalysisJson.Document.MaxDepth);
+        Assert.False(AnalysisJson.Wire.WriteIndented,
+            "the share wire format has always been default-formatted JSON; only the ceiling changed");
+    }
+
+    /// <summary>
+    /// The three writers #431 missed, found in review: the web Share upload serialized the
+    /// analysis with inline default options, and loading a share back parsed AND deserialized it
+    /// at the default 64 again — so a deep plan analyzed fine on screen and then failed to Share,
+    /// or shared and failed to open. This walks the exact envelope shape the share path uses
+    /// ({result, text, ttl_days} → JsonDocument → GetRawText → Deserialize) through the shared
+    /// options, at 100 operators — past the old ceiling, far under the new one.
+    ///
+    /// <para>Scope, stated honestly: the actual call sites live in PlanViewer.Web (a Blazor WASM
+    /// project this suite does not reference) and server/PlanShare (which references nothing), so
+    /// they are verified by inspection to use these options / mirror this constant. What this test
+    /// pins is the contract those sites rely on — that the shared options round-trip the envelope
+    /// both directions.</para>
+    /// </summary>
+    [Fact]
+    public void TheShareEnvelopeRoundTripsADeepPlan()
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            result = WithOperatorChain(100),
+            text = "=== Summary ===",
+            ttl_days = 7
+        }, AnalysisJson.Wire);
+
+        /* Both proofs that the options are load-bearing: the default reader rejects what the
+           shared writer produced (ThrowsAny because document parsing surfaces the depth failure
+           as JsonReaderException, a JsonException subclass)... */
+        Assert.ThrowsAny<JsonException>(() => JsonDocument.Parse(payload));
+
+        /* ...and the shared reader carries it, all the way back to a typed result. */
+        using var doc = JsonDocument.Parse(payload, AnalysisJson.Document);
+        var result = JsonSerializer.Deserialize<AnalysisResult>(
+            doc.RootElement.GetProperty("result").GetRawText(), AnalysisJson.Wire);
+
+        Assert.NotNull(result);
+        var depth = 0;
+        for (var op = result!.Statements.Single().OperatorTree; op is not null; op = op.Children.FirstOrDefault())
+            depth++;
+        Assert.Equal(100, depth);
     }
 }

--- a/tests/PlanViewer.Core.Tests/PlanTestHelper.cs
+++ b/tests/PlanViewer.Core.Tests/PlanTestHelper.cs
@@ -38,6 +38,24 @@ public static class PlanTestHelper
     }
 
     /// <summary>
+    /// Same load + analyze + score, with an analyzer config (for rules-config behavior like
+    /// severity overrides). Named rather than overloaded so an existing
+    /// <c>LoadAndAnalyze(name, null)</c> call can never silently pick a different overload.
+    /// </summary>
+    public static ParsedPlan LoadAndAnalyzeWithConfig(string planFileName, AnalyzerConfig config)
+    {
+        var path = Path.Combine("Plans", planFileName);
+        Assert.True(File.Exists(path), $"Test plan not found: {path}");
+
+        var xml = File.ReadAllText(path);
+        xml = xml.Replace("encoding=\"utf-16\"", "encoding=\"utf-8\"");
+        var plan = ShowPlanParser.Parse(xml);
+        PlanAnalyzer.Analyze(plan, config);
+        BenefitScorer.Score(plan);
+        return plan;
+    }
+
+    /// <summary>
     /// Gets all warnings across all statements and all nodes in the plan.
     /// </summary>
     public static List<PlanWarning> AllWarnings(ParsedPlan plan)

--- a/tests/PlanViewer.Core.Tests/ProcBodyStatementsGridTests.cs
+++ b/tests/PlanViewer.Core.Tests/ProcBodyStatementsGridTests.cs
@@ -1,0 +1,78 @@
+using System.IO;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.LogicalTree;
+using PlanViewer.App.Controls;
+using PlanViewer.Core.Services;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #456 in the desktop app: analysis and Human/Robot Advice walk every statement through
+/// PlanStatements.EnumerateAll, but the statements grid and the MCP session registration were
+/// still built from the outer batch only. For an <c>EXEC &lt;procedure&gt;</c> plan that meant
+/// one grid row — the EXEC, on its synthetic root node — and near-zero registered counts, while
+/// the advice discussed warnings across the whole body that the grid could neither display nor
+/// navigate to.
+///
+/// <para>Drives the real control headlessly rather than testing a list-building helper, because
+/// the defect was precisely the distance between what the pipeline computed and what the control
+/// chose to show.</para>
+/// </summary>
+public class ProcBodyStatementsGridTests
+{
+    [Fact]
+    public void TheGridListsBodyStatementsAndRendersThem()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = Path.Combine("Plans", "exec_stored_procedure_plan.sqlplan");
+            Assert.True(File.Exists(path), $"Test plan not found: {path}");
+            var xml = File.ReadAllText(path).Replace("encoding=\"utf-16\"", "encoding=\"utf-8\"");
+
+            var viewer = new PlanViewerControl();
+            Assert.True(
+                viewer.LoadPlan(xml, "exec_stored_procedure_plan.sqlplan"),
+                $"an EXEC plan must load, not refuse: {viewer.LastLoadError}");
+
+            var window = new Window { Content = viewer, Width = 1400, Height = 900 };
+            window.Show();
+            window.UpdateLayout();
+
+            var grid = viewer.GetLogicalDescendants()
+                .OfType<DataGrid>().First(g => g.Name == "StatementsGrid");
+            var rows = ((System.Collections.IEnumerable)grid.ItemsSource!)
+                .Cast<StatementRow>().ToList();
+
+            /* The grid must agree with the traversal the analysis used: every statement that
+               carries a plan of its own, body statements included. (The parser synthesizes a
+               root node even for the EXEC and SET statements, so for this fixture that is all
+               six — and before this fix the grid showed exactly one row: the EXEC.) Counted
+               independently from a fresh parse so the assertion cannot be satisfied by the
+               control agreeing with itself. */
+            var expected = PlanStatements.EnumerateAll(ShowPlanParser.Parse(xml))
+                .Count(s => s.RootNode != null);
+
+            Assert.True(expected > 1, "fixture must carry multiple renderable body statements");
+            Assert.Equal(expected, rows.Count);
+
+            /* The outer EXEC keeps its bare text — it isn't inside anything — while every body
+               row names its module, which is the label a reader needs to tell five bare body
+               statements apart. Copy paths hand out the raw statement text; only the display is
+               prefixed. */
+            Assert.StartsWith("EXEC dbo.ReproProc", rows[0].QueryText);
+            Assert.All(rows.Skip(1), r => Assert.StartsWith("dbo.ReproProc > ", r.QueryText));
+
+            /* Selecting a body statement must draw its plan on the canvas. Row 0 was selected by
+               LoadPlan; move to the last row to force a re-render of a different body statement,
+               and fail loudly if rendering threw or produced nothing. */
+            var canvas = viewer.GetLogicalDescendants()
+                .OfType<Canvas>().First(c => c.Name == "PlanCanvas");
+            grid.SelectedIndex = rows.Count - 1;
+            window.UpdateLayout();
+
+            Assert.True(canvas.Children.Count > 0,
+                "selecting a procedure-body statement must render its operators");
+        });
+    }
+}

--- a/tests/PlanViewer.Core.Tests/StoredProcedurePlanTests.cs
+++ b/tests/PlanViewer.Core.Tests/StoredProcedurePlanTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using PlanViewer.Core.Models;
 using PlanViewer.Core.Output;
 using PlanViewer.Core.Services;
 
@@ -102,5 +103,130 @@ public class StoredProcedurePlanTests
         Assert.Equal(
             plan.Batches.SelectMany(b => b.Statements).Count(),
             PlanStatements.EnumerateAll(plan).Count());
+    }
+
+    /// <summary>
+    /// The half of #456 the review caught: the ANALYZER descended into the body, the SCORER did
+    /// not, so body warnings existed with MaxBenefitPercent forever null. The UI sorts
+    /// unquantified warnings below quantified ones, which buried every finding of an EXEC plan —
+    /// present in the list, missing its "up to X%", ranked last.
+    ///
+    /// <para>Non-SARGable Predicate is the probe because on an estimated plan it is scored
+    /// unconditionally (operator cost percent fallback), so the same warning on an outer
+    /// statement always carries a value — null on a body statement can only mean the scorer
+    /// never got there.</para>
+    /// </summary>
+    [Fact]
+    public void ProcedureBodyWarningsAreBenefitScored()
+    {
+        var plan = PlanTestHelper.LoadAndAnalyze("exec_stored_procedure_plan.sqlplan");
+
+        var bodyWarnings = PlanStatements.EnumerateAll(plan)
+            .Skip(1) // everything after the EXEC lives inside the procedure body
+            .SelectMany(PlanTestHelper.AllNodeWarnings)
+            .Where(w => w.WarningType == "Non-SARGable Predicate")
+            .ToList();
+
+        Assert.NotEmpty(bodyWarnings);
+        Assert.All(bodyWarnings, w => Assert.NotNull(w.MaxBenefitPercent));
+    }
+
+    /// <summary>
+    /// The wait-stats half of the same scorer gap, on a synthetic plan because the fixture is an
+    /// estimated plan and carries no wait stats: a body statement's waits were never scored and
+    /// never emitted as "Wait:" warnings, so an actual EXEC plan lost its wait analysis entirely.
+    /// Serial statement, 400ms of PAGEIOLATCH against 1000ms elapsed — the simple-ratio path —
+    /// so the expected 40% is arithmetic, not a golden value.
+    /// </summary>
+    [Fact]
+    public void ProcedureBodyWaitStatsAreScoredAndSurfaced()
+    {
+        var body = new PlanStatement
+        {
+            StatementText = "SELECT o.Id FROM dbo.Orders AS o;",
+            QueryTimeStats = new QueryTimeInfo { CpuTimeMs = 100, ElapsedTimeMs = 1_000 },
+            WaitStats = { new WaitStatInfo { WaitType = "PAGEIOLATCH_SH", WaitTimeMs = 400, WaitCount = 10 } }
+        };
+        var plan = new ParsedPlan
+        {
+            Batches =
+            {
+                new PlanBatch
+                {
+                    Statements =
+                    {
+                        new PlanStatement
+                        {
+                            StatementText = "EXEC dbo.Waits;",
+                            StoredProcPlan = new FunctionPlanInfo
+                            {
+                                ProcName = "dbo.Waits",
+                                Statements = { body }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        BenefitScorer.Score(plan);
+
+        var waitWarning = Assert.Single(body.PlanWarnings, w => w.WarningType == "Wait: PAGEIOLATCH_SH");
+        Assert.NotNull(waitWarning.MaxBenefitPercent);
+        Assert.Equal(40.0, waitWarning.MaxBenefitPercent!.Value, 1);
+    }
+
+    /// <summary>
+    /// The other pass the review caught walking batch.Statements: a user's severity override
+    /// applied to a warning on the outer batch and silently did not apply to the identical
+    /// warning inside the body. Rule 12 is Non-SARGable Predicate, which the body carries; its
+    /// default severity is asserted first so the Critical below can only have come from the
+    /// override being applied, not from the rule itself.
+    /// </summary>
+    [Fact]
+    public void SeverityOverridesReachProcedureBodyStatements()
+    {
+        static List<PlanWarning> BodyNonSargable(ParsedPlan plan) =>
+            PlanStatements.EnumerateAll(plan)
+                .Skip(1)
+                .SelectMany(PlanTestHelper.AllNodeWarnings)
+                .Where(w => w.WarningType == "Non-SARGable Predicate")
+                .ToList();
+
+        var byDefault = BodyNonSargable(PlanTestHelper.LoadAndAnalyze("exec_stored_procedure_plan.sqlplan"));
+        Assert.NotEmpty(byDefault);
+        Assert.All(byDefault, w => Assert.Equal(PlanWarningSeverity.Warning, w.Severity));
+
+        var config = new AnalyzerConfig
+        {
+            Rules = new RulesConfig { SeverityOverrides = { [12] = "Critical" } }
+        };
+        var overridden = BodyNonSargable(
+            PlanTestHelper.LoadAndAnalyzeWithConfig("exec_stored_procedure_plan.sqlplan", config));
+
+        Assert.NotEmpty(overridden);
+        Assert.All(overridden, w => Assert.Equal(PlanWarningSeverity.Critical, w.Severity));
+    }
+
+    /// <summary>
+    /// The context-carrying enumeration exists for UIs that list body statements to a person:
+    /// a row has to say which module its statement came from. It must be the SAME walk as
+    /// EnumerateAll — same statements, same order — because two traversals that must agree is
+    /// the arrangement that produced #455 in the first place.
+    /// </summary>
+    [Fact]
+    public void BodyStatementsKnowTheirContainingModule()
+    {
+        var plan = PlanTestHelper.LoadAndAnalyze("exec_stored_procedure_plan.sqlplan");
+
+        var entries = PlanStatements.EnumerateAllWithContainer(plan).ToList();
+
+        Assert.True(entries.Count > 1);
+        Assert.Null(entries[0].ContainerPath); // the EXEC itself lives in the outer batch
+        Assert.All(entries.Skip(1), e => Assert.Equal("dbo.ReproProc", e.ContainerPath));
+
+        Assert.Equal(
+            PlanStatements.EnumerateAll(plan),
+            entries.Select(e => e.Statement));
     }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the four analysis-integration findings from the 2026-09-02 adversarial review — #456 taught the parser and analyzer to descend into procedure/UDF bodies, but four consumers never followed:

- **BenefitScorer** walked `batch.Statements` only: body-statement warnings got no `MaxBenefitPercent` and no wait-stat scoring, so the UI's benefit sort quietly buried every finding inside an `EXEC` plan. Now walks `PlanStatements.EnumerateAll`.
- **Severity overrides** had the same blind spot — a user's override applied to an outer warning and silently not to the identical body warning. Same fix. (`MarkLegacyWarnings` was verified already-covered: it rides inside the analyzer's own descending loop.)
- **The desktop statements grid and MCP session counts** were outer-only while advice saw everything — an EXEC plan showed one row and near-zero counts while Human Advice discussed warnings the UI couldn't display. The grid now lists body statements labeled by module (`dbo.Proc > SELECT …`) via a new `EnumerateAllWithContainer` traversal (defined so the plain and context-carrying walks are literally one walk), and selecting a body statement renders its operators — verified on the exec-proc fixture in the headless harness. Adjacent mirrors fixed in-pass: MCP counts come from the stored analysis summary, `AllMissingIndexes` descends, and the web viewer's statement-tab index now maps through `EnumerateAll` (clicking a body statement's tab used to render no tree).
- **The web share path was three depth-ceiling writers #431 never listed**: serialize, parse, and deserialize all ran at default MaxDepth 64, so a ~30-operator plan analyzed fine and then failed to Share (or shared and failed to open) with a misleading "object cycle" error. `AnalysisJson` gains `Wire` (deliberately not the WithoutNulls variants — existing DB shares stay readable) and `Document` options; the server mirrors the constant with a comment naming the source of truth, since it deliberately takes no Core reference.

## How was this tested?

Six new tests (proc-body scoring/overrides, grid contents via the headless harness, and a share-envelope round-trip of a 100-operator chain that the default reader provably rejects). Full suite at dev tip + fix: 414 tests, 413 passed, 1 platform skip, 0 failed, on Windows.

**Deploy note: `server/PlanShare/Program.cs` changed — PlanShare deploys by hand (scp + systemctl on the Hetzner box), and a redeploy was already owed for the range's dependency bump.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvAv72Pwb8czsjDWsCCk7n