### PR TITLE
Stop the test harness from mutating real machine state

### DIFF
--- a/src/PlanViewer.App/App.axaml.cs
+++ b/src/PlanViewer.App/App.axaml.cs
@@ -54,7 +54,11 @@ public partial class App : Application
         // Register the .sqlplan association (Windows/Linux) off the UI thread so it
         // never delays first paint. Best-effort; the OS then routes double-clicks to
         // the existing argv/pipe open path. No-op on macOS (handled by Info.plist).
-        Task.Run(FileAssociationService.RegisterForCurrentExecutable);
+        // Never in the test host: this writes HKCU\Software\Classes, and the harness
+        // booting the real App (#451) rewrote the machine's .sqlplan association and
+        // DefaultIcon to point at the test runner executable — confirmed live.
+        if (!AppRuntimeMode.IsTestHost)
+            Task.Run(FileAssociationService.RegisterForCurrentExecutable);
 
         base.OnFrameworkInitializationCompleted();
     }

--- a/src/PlanViewer.App/AppRuntimeMode.cs
+++ b/src/PlanViewer.App/AppRuntimeMode.cs
@@ -1,0 +1,25 @@
+namespace PlanViewer.App;
+
+/// <summary>
+/// Process-wide answer to "is this the real app or the test host?"
+///
+/// <para>The headless test harness (#451) boots the REAL <see cref="App"/> — deliberately,
+/// because MainWindow resolves styles from the application XAML — which means the real
+/// startup side effects run inside the test runner unless something says otherwise. That
+/// was not hypothetical: a local <c>dotnet test</c> rewrote HKCU's .sqlplan association to
+/// point at the test host executable, polluted the developer's Recent Plans with fixture
+/// paths, and destroyed the saved open-tab list, all confirmed live.</para>
+///
+/// <para>This is the one seam those side effects consult, rather than a scattering of
+/// environment sniffs. The harness sets it before the first App boots; nothing in the
+/// product ever sets it, so in the real app every check reads a constant false and
+/// behavior is unchanged.</para>
+/// </summary>
+internal static class AppRuntimeMode
+{
+    /// <summary>
+    /// True only inside the test host. Set once by the test harness's module initializer,
+    /// never by the app itself.
+    /// </summary>
+    internal static bool IsTestHost;
+}

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -47,6 +47,16 @@ public partial class MainWindow : Window
     /// </summary>
     internal bool IsShuttingDown { get; private set; }
 
+    /// <summary>
+    /// Whether this window's process-external startup services actually launched. Set by the
+    /// launch methods themselves rather than by the <see cref="AppRuntimeMode"/> gate, so the
+    /// test pinning that they stay off under the harness (#451) still fails if a future change
+    /// starts one through a new path. Never read by the app.
+    /// </summary>
+    internal bool PipeServerStarted { get; private set; }
+    internal bool StartupUpdateCheckStarted { get; private set; }
+    internal bool McpServerStartAttempted { get; private set; }
+
     public MainWindow()
     {
         _credentialService = CredentialServiceFactory.Create();
@@ -57,13 +67,20 @@ public partial class MainWindow : Window
         if (Enum.TryParse<TimeDisplayMode>(_appSettings.QueryStoreDefaultTimeDisplay, true, out var tdm))
             TimeDisplayHelper.Current = tdm;
 
-        // Listen for file paths from other instances (e.g. SSMS extension)
-        StartPipeServer();
+        // Listen for file paths from other instances (e.g. SSMS extension).
+        // Not in the test host (#451): every test window would grab the machine's single
+        // SQLPerformanceStudio_OpenFile pipe slot and never release it — OnClosed never
+        // runs there — racing any real Studio instance on the same box.
+        if (!AppRuntimeMode.IsTestHost)
+            StartPipeServer();
 
         InitializeComponent();
 
-        // Check for updates on startup (non-blocking)
-        _ = CheckForUpdatesOnStartupAsync();
+        // Check for updates on startup (non-blocking).
+        // Not in the test host (#451): one GitHub hit per constructed window meant ~36
+        // update checks per local test run.
+        if (!AppRuntimeMode.IsTestHost)
+            _ = CheckForUpdatesOnStartupAsync();
 
         // Build the Recent Plans submenu from saved state
         RebuildRecentPlansMenu();
@@ -158,12 +175,18 @@ public partial class MainWindow : Window
             RestoreOpenPlans();
         }
 
-        // Start MCP server if enabled in settings
-        StartMcpServer();
+        // Start MCP server if enabled in settings.
+        // Not in the test host (#451): this reads the user's real ~/.planview settings and,
+        // when enabled there, binds a real TCP port from inside the test runner. The menu
+        // item needs no fallback write — its XAML default is already "MCP Server: Off".
+        if (!AppRuntimeMode.IsTestHost)
+            StartMcpServer();
     }
 
     private void StartPipeServer()
     {
+        PipeServerStarted = true;
+
         var token = _pipeCts.Token;
         Task.Run(async () =>
         {
@@ -207,6 +230,10 @@ public partial class MainWindow : Window
 
     private void StartMcpServer()
     {
+        // Set before the settings read: reading the user's real ~/.planview file is itself
+        // part of what the test host must not do, so "attempted" starts here.
+        McpServerStartAttempted = true;
+
         var settings = McpSettings.Load();
         if (!settings.Enabled)
         {
@@ -709,6 +736,9 @@ public partial class MainWindow : Window
 
     private async Task CheckForUpdatesOnStartupAsync()
     {
+        // Before the first await, so the flag is visible to a caller synchronously.
+        StartupUpdateCheckStarted = true;
+
         try
         {
             await Task.Delay(5000); // Don't slow down startup

--- a/src/PlanViewer.App/Services/AppSettingsService.cs
+++ b/src/PlanViewer.App/Services/AppSettingsService.cs
@@ -14,9 +14,12 @@ namespace PlanViewer.App.Services;
 internal sealed class AppSettingsService
 {
     private const int MaxRecentPlans = 10;
-    private static readonly string SettingsDir;
-    private static readonly string SettingsPath;
-    private static readonly string OldFormatSettingsPath;
+
+    // Not readonly only because RedirectStorageForTestHost exists; nothing in the
+    // product assigns these outside the static constructor.
+    private static string SettingsDir;
+    private static string SettingsPath;
+    private static string OldFormatSettingsPath;
 
     private static AppSettings? _cached;
 
@@ -27,6 +30,34 @@ internal sealed class AppSettingsService
             "PerformanceStudio");
         SettingsPath = Path.Combine(SettingsDir, "appsettings.json");
         OldFormatSettingsPath = Path.Combine(SettingsDir, "perfstudio_format_settings.json");
+    }
+
+    /// <summary>
+    /// The file settings are read from and written to right now — the real per-user path
+    /// unless <see cref="RedirectStorageForTestHost"/> moved it. Exposed so the test suite
+    /// can pin that the redirection actually happened (#451) instead of trusting it.
+    /// </summary>
+    internal static string SettingsFilePath => SettingsPath;
+
+    /// <summary>
+    /// Points every settings read and write at <paramref name="directory"/> instead of the
+    /// real per-user profile. Exists for exactly one caller: the test harness (#451). Its
+    /// MainWindow-driving tests run the real settings code — RestoreOpenPlans clears and
+    /// saves the open-tab list, LoadPlanFile saves Recent Plans — and were doing all of it
+    /// against the developer's actual appsettings.json: fixture paths evicted real recent
+    /// entries and the saved session-restore list was destroyed, confirmed live. When this
+    /// is never called, the paths keep their static-constructor defaults byte for byte, so
+    /// the real app is untouched.
+    /// </summary>
+    internal static void RedirectStorageForTestHost(string directory)
+    {
+        SettingsDir = directory;
+        SettingsPath = Path.Combine(directory, "appsettings.json");
+        OldFormatSettingsPath = Path.Combine(directory, "perfstudio_format_settings.json");
+
+        // Anything cached was loaded from the old location; drop it so the first Load
+        // after the redirect reads the new one.
+        _cached = null;
     }
 
     private static readonly JsonSerializerOptions JsonOptions = new()

--- a/src/PlanViewer.App/Services/TextBoxClipboardGuard.cs
+++ b/src/PlanViewer.App/Services/TextBoxClipboardGuard.cs
@@ -14,8 +14,19 @@ namespace PlanViewer.App.Services;
 /// </summary>
 internal static class TextBoxClipboardGuard
 {
+    private static bool _registered;
+
     public static void Register()
     {
+        // Once per process. The real app calls this once at startup anyway, but the test
+        // harness (#451) boots a fresh App per test dispatch, and class handlers live on the
+        // static routed events — not the Application — so each boot was stacking another set
+        // of handlers onto every TextBox in the test host. The guard stays registered for
+        // any test that exercises clipboard behavior; it just stops accumulating.
+        if (_registered)
+            return;
+        _registered = true;
+
         TextBox.CopyingToClipboardEvent.AddClassHandler<TextBox>(OnCopying);
         TextBox.CuttingToClipboardEvent.AddClassHandler<TextBox>(OnCutting);
         TextBox.PastingFromClipboardEvent.AddClassHandler<TextBox>(OnPasting);

--- a/tests/PlanViewer.Core.Tests/HeadlessUi.cs
+++ b/tests/PlanViewer.Core.Tests/HeadlessUi.cs
@@ -1,10 +1,14 @@
 using System;
+using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Threading;
+using PlanViewer.App;
+using PlanViewer.App.Services;
 
 namespace PlanViewer.Core.Tests;
 
@@ -38,6 +42,44 @@ internal static class HeadlessUi
     private static readonly Lazy<HeadlessUnitTestSession> Session =
         new(() => HeadlessUnitTestSession.StartNew(typeof(PlanViewer.App.App)),
             System.Threading.LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <summary>
+    /// Where this run's redirected settings live, for the tests that pin the redirection.
+    /// </summary>
+    internal static string SettingsRedirectRoot { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Flips the process into test-host mode before anything else in this assembly runs.
+    ///
+    /// <para><b>Why booting the real App needs this at all (#451).</b> The session above
+    /// constructs the actual <see cref="PlanViewer.App.App"/>, so its real startup side
+    /// effects ran inside the test host on every local <c>dotnet test</c>: the .sqlplan
+    /// registry association was rewritten to point at the test runner, tests restored and
+    /// then destroyed the developer's saved open-tab list, and fixture paths evicted real
+    /// Recent Plans entries — all confirmed live. <see cref="AppRuntimeMode.IsTestHost"/>
+    /// is the one seam the app consults to keep the process-external effects (file
+    /// association, pipe server, update check, MCP server) from launching here.</para>
+    ///
+    /// <para><b>Why a module initializer rather than harness setup.</b> It has to run
+    /// before the first App boot AND before any test touches
+    /// <see cref="AppSettingsService"/>, including ones that never go through this class.
+    /// A module initializer is the only spot guaranteed to precede both.</para>
+    ///
+    /// <para><b>Why the settings directory is per RUN, not per test.</b> Tests like
+    /// RestoreQueryTabsTests deliberately exercise save/load continuity across windows
+    /// within a run; tests that need clean state already reset it themselves. A second
+    /// <c>dotnet test</c> gets a fresh directory, which is what keeps runs from leaking
+    /// into each other. The abandoned directories are a few hundred bytes each and left
+    /// to OS temp cleanup — sweeping siblings here could race a concurrent run.</para>
+    /// </summary>
+    [ModuleInitializer]
+    internal static void EnterTestHostMode()
+    {
+        AppRuntimeMode.IsTestHost = true;
+
+        SettingsRedirectRoot = Directory.CreateTempSubdirectory("PlanViewer.Core.Tests-").FullName;
+        AppSettingsService.RedirectStorageForTestHost(SettingsRedirectRoot);
+    }
 
     /// <summary>
     /// Runs <paramref name="body"/> on the Avalonia UI thread and rethrows anything it threw, so an

--- a/tests/PlanViewer.Core.Tests/TestHostIsolationTests.cs
+++ b/tests/PlanViewer.Core.Tests/TestHostIsolationTests.cs
@@ -1,0 +1,85 @@
+using PlanViewer.App;
+using PlanViewer.App.Services;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #451: the headless harness boots the REAL App, and before these seams existed the real
+/// startup side effects ran inside the test host — every local <c>dotnet test</c> rewrote
+/// HKCU's .sqlplan association to point at the test runner, restored and then destroyed the
+/// developer's saved open-tab list, evicted real Recent Plans entries with fixture paths,
+/// held the app's single named-pipe slot, and hit GitHub with an update check per
+/// constructed window. All confirmed live on a dev machine.
+///
+/// These tests pin the two seams that stop that — the settings redirection and the
+/// <see cref="AppRuntimeMode.IsTestHost"/> gate — so the next person's MainWindow test
+/// cannot silently reach back into the machine.
+/// </summary>
+public class TestHostIsolationTests
+{
+    /// <summary>
+    /// The guard against a test wiping real user state: with the harness active, the
+    /// effective settings path is under the run-scoped temp root, never the real profile,
+    /// and a save lands there.
+    ///
+    /// <para>Runs on the UI thread even though it shows nothing, because every other
+    /// mutation of the shared cached <see cref="AppSettings"/> happens there — serializing
+    /// it off-thread could race a seeding test's list mutation mid-write.</para>
+    /// </summary>
+    [Fact]
+    public void SettingsReadsAndWritesLandInTheRunScopedTempDirectory()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var realProfileDir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "PerformanceStudio");
+
+            Assert.NotEqual(string.Empty, HeadlessUi.SettingsRedirectRoot);
+            Assert.StartsWith(
+                HeadlessUi.SettingsRedirectRoot,
+                AppSettingsService.SettingsFilePath,
+                StringComparison.OrdinalIgnoreCase);
+            Assert.False(
+                AppSettingsService.SettingsFilePath.StartsWith(realProfileDir, StringComparison.OrdinalIgnoreCase),
+                "the test host must never read or write the real appsettings.json");
+
+            /* Save(Load()) rather than Save(new AppSettings()): Save caches the instance it
+               is given, and swapping in a fresh one would yank state out from under a test
+               that had just seeded the shared cached instance. This is the write that used
+               to land in the developer's real profile. */
+            AppSettingsService.Save(AppSettingsService.Load());
+            Assert.True(
+                File.Exists(AppSettingsService.SettingsFilePath),
+                "a save under the harness must land in the redirected file");
+        });
+    }
+
+    /// <summary>
+    /// A MainWindow built under the harness launches none of the process-external startup
+    /// services. The flags are set by the launch methods themselves, not by the gate, so
+    /// this fails honestly if a future change starts one of them through a new path.
+    /// </summary>
+    [Fact]
+    public void AWindowBuiltUnderTheHarnessLaunchesNoStartupServices()
+    {
+        HeadlessUi.Run(() =>
+        {
+            // Pins the ordering the whole design leans on: the module initializer flipped
+            // the gate before the first App (and this window) booted.
+            Assert.True(AppRuntimeMode.IsTestHost);
+
+            var window = new MainWindow();
+
+            Assert.False(
+                window.PipeServerStarted,
+                "the pipe server would hold the machine-wide SQLPerformanceStudio_OpenFile slot and never release it");
+            Assert.False(
+                window.StartupUpdateCheckStarted,
+                "the update check would hit GitHub once per constructed window");
+            Assert.False(
+                window.McpServerStartAttempted,
+                "starting MCP would read the user's real ~/.planview settings and could bind a real port");
+        });
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the confirmed-live finding from the 2026-09-02 adversarial review: the #451 headless harness boots the real `App`, so every local `dotnet test` run fired real startup side effects inside the test host — it rewrote HKCU's .sqlplan association and DefaultIcon to the test executable, loaded/cleared/polluted the developer's real `appsettings.json` (fixture paths evicted real Recent Plans entries; the saved open-tab list was destroyed), started ~36 never-stopped named-pipe servers and GitHub update checks per run, and could bind the real MCP port.

One seam, not scattered env sniffs: `AppRuntimeMode.IsTestHost`, set by a `[ModuleInitializer]` in the test assembly before the first App boot (and before any test can touch settings, harness user or not). Under it: the association write, pipe server, startup update check, and MCP start are skipped (each with a comment naming the side effect it prevents), the clipboard guard latches once per process instead of stacking per test dispatch, and `AppSettingsService` redirects to a per-run temp directory. Nothing in the product sets the gate or calls the redirect — with it unset, every path keeps its static-constructor default byte for byte.

The pinning test asserts flags set by the launch methods themselves, not by the gate, so a future launch path that sidesteps the gate still fails the test.

## How was this tested?

Full suite twice in a row (per-run isolation proof): identical green results, each run creating its own temp settings dir while the real `appsettings.json` mtime never moved and the registry was not rewritten. At dev tip: 425 tests, 424 passed, 1 platform skip, 0 failed. No existing test needed its assumptions changed — the suite was already clean-profile shaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvAv72Pwb8czsjDWsCCk7n