### PR TITLE
Sweep the review's minor findings: analyzer honesty, error display, lifecycle warts

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.Interaction.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.Interaction.cs
@@ -360,7 +360,11 @@ public partial class PlanViewerControl : UserControl
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"SavePlan failed: {ex.Message}");
-                CostText.Text = $"Save failed: {(ex.Message.Length > 60 ? ex.Message[..60] + "..." : ex.Message)}";
+                /* #452's mirror, the sixth site (spotted during the review sweep): pre-cutting to
+                   60 characters threw away exactly the part of an I/O error that says what to fix.
+                   Full message out; the tooltip carries whatever the label clips. */
+                CostText.Text = $"Save failed: {ex.Message}";
+                ToolTip.SetTip(CostText, ex.Message);
             }
         }
     }

--- a/src/PlanViewer.App/Controls/QuerySessionControl.Plans.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.Plans.cs
@@ -224,11 +224,13 @@ public partial class QuerySessionControl : UserControl
     /// app could already do.
     ///
     /// <para>Called by the <see cref="TabContentWatcher"/> wired to this session's sub-tabs, and by
-    /// nothing else. It used to be called by hand at the five places that add or remove a plan tab,
-    /// which is why the paths that instead fill in an existing tab — every executed query — never
-    /// reached it.</para>
+    /// <see cref="MainWindow.DetachTabToWindow"/> when this session leaves the tab strip — the
+    /// watcher only fires on sub-tab changes, and detaching changes none, so without that call the
+    /// button froze at whatever the window-wide count last said until the next plan landed. It used
+    /// to be called by hand at the five places that add or remove a plan tab, which is why the
+    /// paths that instead fill in an existing tab — every executed query — never reached it.</para>
     /// </summary>
-    private void UpdateCompareButtonState()
+    internal void UpdateCompareButtonState()
     {
         /* Logical tree, not TopLevel.GetTopLevel. A TabControl realises the selected tab's content
            and nothing else, so a session sitting in a background tab has no visual root and cannot

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -37,6 +38,18 @@ public partial class QuerySessionControl : UserControl
     /// Full path on disk when the query was loaded from, or last saved to, a file.
     /// </summary>
     public string? SourceFilePath { get; set; }
+
+    /// <summary>
+    /// The encoding the file behind <see cref="SourceFilePath"/> declared with its byte order
+    /// mark, or null for a BOM-less file and for a scratch session — both of which save as
+    /// UTF-8 without a BOM, which is what every save wrote before this existed.
+    ///
+    /// <para>Captured at open so a save writes the bytes the file arrived with. SSMS writes
+    /// .sql files as UTF-16 with a BOM; opening one read fine (File.ReadAllText honors the
+    /// mark) and then the first Ctrl+S silently transcoded the whole file to UTF-8 — every
+    /// byte changed, the BOM gone, without the user asking for any of it.</para>
+    /// </summary>
+    public Encoding? SourceFileEncoding { get; set; }
 
     /// <summary>
     /// The editor text as of the last load or save. A new session starts empty, so a

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.Fetch.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.Fetch.cs
@@ -57,7 +57,10 @@ public partial class QueryStoreGridControl : UserControl
         }
         catch (Exception ex)
         {
-            StatusText.Text = ex.Message.Length > 80 ? ex.Message[..80] + "..." : ex.Message;
+            /* #452's mirror: pre-cutting to 80 characters threw away text the strip would have
+               shown and the tooltip (wired in the constructor) would have recovered. The full
+               message goes out; where it gets clipped is the display's business. */
+            StatusText.Text = ex.Message;
         }
         finally
         {
@@ -107,7 +110,8 @@ public partial class QueryStoreGridControl : UserControl
         }
         catch (Exception ex)
         {
-            StatusText.Text = ex.Message.Length > 80 ? ex.Message[..80] + "..." : ex.Message;
+            // Same #452 mirror as Fetch_Click above: full message out, tooltip carries the rest.
+            StatusText.Text = ex.Message;
         }
         finally
         {

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.Sort.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.Sort.cs
@@ -68,7 +68,8 @@ public partial class QueryStoreGridControl : UserControl
         catch (OperationCanceledException) { }
         catch (Exception ex)
         {
-            StatusText.Text = ex.Message.Length > 80 ? ex.Message[..80] + "..." : ex.Message;
+            // #452's mirror: full message out, the status tooltip carries what the strip clips.
+            StatusText.Text = ex.Message;
         }
         finally
         {

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.WaitStats.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.WaitStats.cs
@@ -41,7 +41,8 @@ public partial class QueryStoreGridControl : UserControl
         catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
-            StatusText.Text = $"Slicer: {(ex.Message.Length > 60 ? ex.Message[..60] + "..." : ex.Message)}";
+            // #452's mirror: full message out, the status tooltip carries what the strip clips.
+            StatusText.Text = $"Slicer: {ex.Message}";
         }
     }
 

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
@@ -84,6 +84,19 @@ public partial class QueryStoreGridControl : UserControl
         ServerFilterExpander.Expanded += ServerFilterExpander_StateChanged;
         ServerFilterExpander.Collapsed += ServerFilterExpander_StateChanged;
 
+        /* #452's pattern, carried to this surface: the status strip is one line, so a long
+           message — an error, usually — is readable on hover or not at all. QuerySessionControl
+           funnels every status through SetStatus, which mirrors the text into the tooltip; this
+           control writes StatusText.Text from a dozen sites across five partials, so the mirror
+           is one subscription rather than a funnel every future site would have to remember —
+           and a tooltip set at just the error sites would go stale the moment "Fetching plans..."
+           was written over the text but not the tip. */
+        StatusText.PropertyChanged += (_, e) =>
+        {
+            if (e.Property == TextBlock.TextProperty)
+                ToolTip.SetTip(StatusText, string.IsNullOrEmpty(StatusText.Text) ? null : StatusText.Text);
+        };
+
         ResultsGrid.ItemsSource = _filteredRows;
         Helpers.DataGridBehaviors.Attach(ResultsGrid);
         Helpers.DataGridBehaviors.AttachCopyGuard(ResultsGrid,
@@ -159,7 +172,11 @@ public partial class QueryStoreGridControl : UserControl
         }
         catch (Exception ex)
         {
-            StatusText.Text = ex.Message.Length > 60 ? ex.Message[..60] + "..." : ex.Message;
+            /* Was cut to 60 characters + "..." before display. Trimming to the space available
+               is the display layer's job — the strip clips at its own edge — and pre-cutting
+               here also destroyed the only recovery path: the tooltip the constructor mirrors
+               onto StatusText now carries the full message on hover. Same family as #452. */
+            StatusText.Text = ex.Message;
             QsDatabaseBox.SelectedItem = _database; // revert
             return;
         }

--- a/src/PlanViewer.App/Helpers/DetachedWindowHelper.cs
+++ b/src/PlanViewer.App/Helpers/DetachedWindowHelper.cs
@@ -87,6 +87,14 @@ internal static class DetachedWindowHelper
 		// Set once the guard has answered, so the re-issued close is not questioned again.
 		bool closeConfirmed = false;
 
+		/* Set while a guard is still ASKING, which closeConfirmed cannot cover — it only
+		   latches after a yes. The guard's prompt is modal to this window, but a Save As
+		   picked from that prompt is not, so a second X during the picker used to reach the
+		   guard again and stack a second prompt over the first. Same walk-in-progress latch
+		   MainWindow.OnClosing carries, for the same reentrancy (#485 review's update-link
+		   class). */
+		bool closeGuardPending = false;
+
 		redockBtn.Click += (_, _) =>
 		{
 			if (redocked) return;
@@ -104,16 +112,25 @@ internal static class DetachedWindowHelper
 		// latch that stops the second pass asking all over again.
 		async Task ReissueCloseIfConfirmed(Task<bool> pending)
 		{
-			if (!await pending)
-				return;
+			try
+			{
+				if (!await pending)
+					return;
 
-			closeConfirmed = true;
+				closeConfirmed = true;
 
-			// Posted rather than called: a guard that answers without ever actually waiting
-			// would otherwise land Close() in the middle of the Closing handler that called
-			// it. Safe to post because the guard returns null during app shutdown, so nothing
-			// is ever queued against a dispatcher that is going away.
-			Dispatcher.UIThread.Post(detachedWindow.Close);
+				// Posted rather than called: a guard that answers without ever actually waiting
+				// would otherwise land Close() in the middle of the Closing handler that called
+				// it. Safe to post because the guard returns null during app shutdown, so nothing
+				// is ever queued against a dispatcher that is going away.
+				Dispatcher.UIThread.Post(detachedWindow.Close);
+			}
+			finally
+			{
+				// Cleared on every ending — refused, confirmed, or thrown — so a kept-open
+				// window can be asked about again the next time someone tries to close it.
+				closeGuardPending = false;
+			}
 		}
 
 		detachedWindow.Closing += (_, e) =>
@@ -123,9 +140,18 @@ internal static class DetachedWindowHelper
 
 			if (!closeConfirmed && closeGuard != null)
 			{
+				if (closeGuardPending)
+				{
+					// A guard is already asking about this window; a second close request
+					// joins that question rather than raising its own copy of it.
+					e.Cancel = true;
+					return;
+				}
+
 				var pending = closeGuard(content, detachedWindow);
 				if (pending != null)
 				{
+					closeGuardPending = true;
 					e.Cancel = true;
 					_ = ReissueCloseIfConfirmed(pending);
 					return;

--- a/src/PlanViewer.App/MainWindow.FileOps.cs
+++ b/src/PlanViewer.App/MainWindow.FileOps.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -180,7 +181,12 @@ public partial class MainWindow : Window
                lands in the catch below with the session still dirty. The rename gives the file
                the temp's attributes and inherited ACLs rather than preserving the original's —
                the trade every editor that saves this way makes. */
-            AtomicFile.WriteAllText(path, session.QueryEditor.Text);
+            /* In the encoding the file was opened with, when it declared one: a .sql from SSMS
+               is UTF-16 with a BOM, and writing it back as the default UTF-8 was a silent
+               transcode of the user's only copy — reading honored the BOM, saving discarded
+               it. A scratch session (and a BOM-less file) has null here and keeps the default
+               UTF-8-without-BOM this always wrote. */
+            AtomicFile.WriteAllText(path, session.QueryEditor.Text, session.SourceFileEncoding);
             session.SourceFilePath = path;
             // Only a write that actually happened settles the dirty state; the catch below
             // deliberately leaves the session modified so the work is still guarded.
@@ -278,6 +284,8 @@ public partial class MainWindow : Window
             var session = new QuerySessionControl(_credentialService, _connectionStore);
             session.QueryEditor.Text = text;
             session.SourceFilePath = filePath;
+            // What the file declared is what a save must write back — see SourceFileEncoding.
+            session.SourceFileEncoding = DetectBomEncoding(filePath);
             // What was just loaded is what is on disk — the baseline every later edit is measured against.
             session.MarkClean();
 
@@ -290,6 +298,38 @@ public partial class MainWindow : Window
         {
             ShowFileError("Error Opening File", $"Failed to open: {Path.GetFileName(filePath)}", ex.Message);
         }
+    }
+
+    /// <summary>
+    /// The encoding a file's byte order mark declares, or null when it has none.
+    ///
+    /// <para>Deliberately a sniff of the mark rather than StreamReader.CurrentEncoding after a
+    /// read: CurrentEncoding only moves off its default for UTF-16/32 marks, so it cannot tell
+    /// a UTF-8-with-BOM file from a plain one — and the default instance it reports EMITS a
+    /// mark on write, so handing it to the save would stamp BOMs onto files that never had
+    /// one, a silent change in the opposite direction from the one being fixed. The mark is
+    /// the fact being preserved, so the mark is what gets read.</para>
+    /// </summary>
+    private static Encoding? DetectBomEncoding(string filePath)
+    {
+        Span<byte> mark = stackalloc byte[4];
+        int read;
+        using (var stream = File.OpenRead(filePath))
+            read = stream.Read(mark);
+
+        // UTF-32 LE opens with UTF-16 LE's mark plus two zero bytes, so it is checked first.
+        if (read >= 4 && mark[0] == 0xFF && mark[1] == 0xFE && mark[2] == 0x00 && mark[3] == 0x00)
+            return new UTF32Encoding(bigEndian: false, byteOrderMark: true);
+        if (read >= 4 && mark[0] == 0x00 && mark[1] == 0x00 && mark[2] == 0xFE && mark[3] == 0xFF)
+            return new UTF32Encoding(bigEndian: true, byteOrderMark: true);
+        if (read >= 3 && mark[0] == 0xEF && mark[1] == 0xBB && mark[2] == 0xBF)
+            return new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+        if (read >= 2 && mark[0] == 0xFF && mark[1] == 0xFE)
+            return Encoding.Unicode;
+        if (read >= 2 && mark[0] == 0xFE && mark[1] == 0xFF)
+            return Encoding.BigEndianUnicode;
+
+        return null;
     }
 
     /// <summary>

--- a/src/PlanViewer.App/MainWindow.Tabs.cs
+++ b/src/PlanViewer.App/MainWindow.Tabs.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -36,6 +37,17 @@ public partial class MainWindow : Window
             return s;
         return "Tab";
     }
+
+    /* The glyph refresher CreateTab subscribes onto a query session, keyed by the tab it was
+       built for, so DetachTabToWindow can take exactly its own subscription off again. The
+       session OUTLIVES its tab on the detach path — the tab is discarded, the session moves
+       into the detached window still holding a handler that closes over the dead tab's close
+       button — and redock re-subscribes through CreateTab, so every detach/redock cycle used
+       to pin one more dead TabItem (visual tree and all) to the session for the session's
+       lifetime. A ConditionalWeakTable rather than a Dictionary so the bookkeeping cannot
+       become its own leak: a tab closed normally dies together with its session, and its
+       entry evaporates with the key. */
+    private readonly ConditionalWeakTable<TabItem, Action> _tabDirtyGlyphUnhooks = new();
 
     private TabItem CreateTab(string label, Control content)
     {
@@ -83,7 +95,14 @@ public partial class MainWindow : Window
             void RefreshCloseGlyph() =>
                 closeBtn.Content = CloseButtonGlyph(querySession.IsDirty, closeBtn.IsPointerOver);
 
-            querySession.DirtyStateChanged += (_, _) => RefreshCloseGlyph();
+            /* Named and written down rather than subscribed inline: of everything wired up
+               here, this is the one subscription that lands on an object that can outlive the
+               tab, so it is the one detach has to be able to undo — see _tabDirtyGlyphUnhooks.
+               The pointer handlers below live and die with the button itself. */
+            EventHandler refreshOnDirtyChange = (_, _) => RefreshCloseGlyph();
+            querySession.DirtyStateChanged += refreshOnDirtyChange;
+            _tabDirtyGlyphUnhooks.Add(tab, () => querySession.DirtyStateChanged -= refreshOnDirtyChange);
+
             closeBtn.PointerEntered += (_, _) => RefreshCloseGlyph();
             closeBtn.PointerExited += (_, _) => RefreshCloseGlyph();
 
@@ -303,6 +322,16 @@ public partial class MainWindow : Window
 
         var label = GetTabLabel(tab);
 
+        /* The session is about to leave this tab behind. Take the glyph subscription off it
+           first: the handler is the one reference that would keep the discarded TabItem alive
+           from the still-living session (see _tabDirtyGlyphUnhooks), and redock subscribes
+           afresh through CreateTab. */
+        if (_tabDirtyGlyphUnhooks.TryGetValue(tab, out var unhookDirtyGlyph))
+        {
+            unhookDirtyGlyph();
+            _tabDirtyGlyphUnhooks.Remove(tab);
+        }
+
         // Remove the tab
         MainTabControl.Items.Remove(tab);
         tab.Content = null;
@@ -338,6 +367,17 @@ public partial class MainWindow : Window
             closeGuard: DetachedQueryCloseGuard);
 
         RememberDetachedQuerySession(detachedWindow, content);
+
+        /* #447 made Compare a window-wide count, and this session just left the window: the
+           count it is showing is about tabs it can no longer reach. Nothing else recomputes it
+           here — the session's sub-tab watcher fires on sub-tab changes only, and detaching
+           changes none — so the pre-detach state stuck until the next plan landed. Recompute
+           now; with no MainWindow above it any more, the method's own fallback counts the
+           session's plans, which inside a detached window is the only honest answer. Redock
+           needs no twin call: adding the tab back fires MainWindow's collection watcher. */
+        if (content is QuerySessionControl detachedSession)
+            detachedSession.UpdateCompareButtonState();
+
         return detachedWindow;
     }
 }

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -164,16 +164,7 @@ public partial class MainWindow : Window
         }, RoutingStrategies.Tunnel);
 
         // Accept command-line argument or restore previously open plans
-        var args = Environment.GetCommandLineArgs();
-        if (args.Length > 1 && File.Exists(args[1]))
-        {
-            LoadPlanFile(args[1]);
-        }
-        else
-        {
-            // Restore plans that were open in the previous session
-            RestoreOpenPlans();
-        }
+        OpenFromStartupArgs(Environment.GetCommandLineArgs());
 
         // Start MCP server if enabled in settings.
         // Not in the test host (#451): this reads the user's real ~/.planview settings and,
@@ -181,6 +172,32 @@ public partial class MainWindow : Window
         // item needs no fallback write — its XAML default is already "MCP Server: Off".
         if (!AppRuntimeMode.IsTestHost)
             StartMcpServer();
+    }
+
+    /// <summary>
+    /// Routes the file handed over on the command line — a double-clicked file association, or
+    /// "PerformanceStudio.exe path" from a shell. Split from the constructor so the routing can
+    /// be tested with an argv of the test's choosing.
+    ///
+    /// <para>Routed by extension, not straight to LoadPlanFile: every other way a path reaches
+    /// this window (the pipe from a second instance, drag-and-drop, session restore) already
+    /// goes through <see cref="OpenFileByExtension"/>, and RestoreOpenPlans' own doc comment
+    /// describes exactly what skipping it does — "Sending a .sql file to LoadPlanFile would
+    /// greet the user with 'the XML is not valid' where their query used to be." That greeting
+    /// is precisely what "PerformanceStudio.exe query.sql" produced. Cold start was the one
+    /// path left hard-wired to the plan loader.</para>
+    /// </summary>
+    internal void OpenFromStartupArgs(string[] args)
+    {
+        if (args.Length > 1 && File.Exists(args[1]))
+        {
+            OpenFileByExtension(args[1]);
+        }
+        else
+        {
+            // Restore plans that were open in the previous session
+            RestoreOpenPlans();
+        }
     }
 
     private void StartPipeServer()

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -314,6 +314,15 @@ public partial class MainWindow : Window
     /// </summary>
     private bool _closeConfirmed;
 
+    /* _closeConfirmed only latches AFTER the walk answers yes, so it does nothing about a
+       second close request arriving WHILE the walk is still asking — a double-clicked X, or
+       another Close() between two of the walk's dialogs (each prompt is modal, but the window
+       is briefly its own again between them, and for the whole of a Save As picker). Each
+       such request used to start a second concurrent walk: duplicate prompts about the same
+       tabs, and a Cancel to one walk that the other never heard about. Same reentrancy class,
+       and same one-latch answer, as the About window's update link (#485 review). */
+    private bool _closeWalkInProgress;
+
     private const string CloseGlyph = "\u2715";   // ✕
     private const string ModifiedGlyph = "\u25CF"; // ●
 
@@ -566,8 +575,20 @@ public partial class MainWindow : Window
     {
         if (!_closeConfirmed && CloseNeedsConfirmation())
         {
+            /* The cancel is unconditional — a close arriving mid-walk must not fall through
+               to base and succeed while the walk is still asking — but only the FIRST one may
+               start a walk. The latch check lives inside this branch on purpose: the walk's
+               own Close() at the end re-enters here with _closeWalkInProgress still true, and
+               it has to sail through on _closeConfirmed above, not be swallowed as a
+               duplicate. */
             e.Cancel = true;
-            _ = ConfirmWindowCloseAsync();
+
+            if (!_closeWalkInProgress)
+            {
+                _closeWalkInProgress = true;
+                _ = ConfirmWindowCloseAsync();
+            }
+
             return;
         }
 
@@ -576,11 +597,20 @@ public partial class MainWindow : Window
 
     private async Task ConfirmWindowCloseAsync()
     {
-        if (!await ConfirmAllUnsavedWorkAsync())
-            return; // one Cancel cancels the shutdown
+        try
+        {
+            if (!await ConfirmAllUnsavedWorkAsync())
+                return; // one Cancel cancels the shutdown
 
-        _closeConfirmed = true;
-        Close();
+            _closeConfirmed = true;
+            Close();
+        }
+        finally
+        {
+            /* Cleared however the walk ends — confirmed, cancelled, or a prompt that threw —
+               so a cancelled shutdown leaves the X able to start a fresh walk. */
+            _closeWalkInProgress = false;
+        }
     }
 
     /// <summary>

--- a/src/PlanViewer.App/Services/AtomicFile.cs
+++ b/src/PlanViewer.App/Services/AtomicFile.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Text;
 
 namespace PlanViewer.App.Services;
 
@@ -15,10 +16,20 @@ internal static class AtomicFile
     /// <paramref name="path"/> keeps its previous contents and a stray
     /// <c>.tmp</c> sibling is left behind (cleaned up on the next call).
     /// </summary>
-    public static void WriteAllText(string path, string contents)
+    /// <param name="encoding">
+    /// Bytes to write the text as; null keeps File.WriteAllText's default, UTF-8
+    /// without a BOM. Callers saving over a file the user opened pass the encoding
+    /// that file arrived with, so a save-in-place is not also a silent transcode.
+    /// </param>
+    public static void WriteAllText(string path, string contents, Encoding? encoding = null)
     {
         var tmp = path + ".tmp";
-        File.WriteAllText(tmp, contents);
+
+        if (encoding != null)
+            File.WriteAllText(tmp, contents, encoding);
+        else
+            File.WriteAllText(tmp, contents);
+
         // File.Move with overwrite:true maps to MoveFileEx(MOVEFILE_REPLACE_EXISTING)
         // on Windows and rename(2) on Unix — both atomic when source and destination
         // live on the same filesystem, which is always the case here.

--- a/src/PlanViewer.Core/Services/ParameterSubstitution.cs
+++ b/src/PlanViewer.Core/Services/ParameterSubstitution.cs
@@ -275,6 +275,14 @@ public static class ParameterSubstitution
     /// Whether the statement's leading keyword chain reaches EXEC or EXECUTE, in which case an
     /// <c>=</c> can only ever mean assignment — the return-status variable or a named argument.
     ///
+    /// <para>Why that holds statement-wide rather than per argument: T-SQL restricts an EXEC
+    /// argument's VALUE to a literal, a variable, NULL, or DEFAULT. An expression — a CASE, a
+    /// subquery, arithmetic — is a compile error there (<c>Incorrect syntax</c>), so no legal
+    /// compiled statement can put a read like <c>CASE WHEN @x = 1 …</c> to the right of a named
+    /// argument. The only <c>@name =</c> pairs that can exist in the region this flag governs are
+    /// assignments. A hand-crafted plan file can of course contain anything, but its author already
+    /// controls the whole statement text, so precision against it protects nothing.</para>
+    ///
     /// <para>The chain is EXEC itself, or the INSERT … EXEC prelude: INSERT, an optional INTO, the
     /// target's possibly bracketed and dotted name, an optional parenthesized column list. The walk
     /// is forward from the start and gives up at the first character that cannot belong to such a

--- a/src/PlanViewer.Core/Services/ParameterSubstitution.cs
+++ b/src/PlanViewer.Core/Services/ParameterSubstitution.cs
@@ -47,6 +47,14 @@ public static class ParameterSubstitution
         if (values.Count == 0)
             return new ParameterSubstitutionResult(statementText, 0);
 
+        /* One fact about the whole statement, settled up front: inside an EXEC statement, every
+           token sitting to the left of an "=" is an assignment target — the return-status variable
+           or a named argument's name — because EXEC grammar has no other use for "=" at all. A
+           per-token back-scan cannot see this for the FIRST named argument (what precedes it is
+           the procedure name, not a keyword), which is how "EXEC dbo.p @debug = @debug" got its
+           left-hand side substituted into "EXEC dbo.p 1 = @debug". */
+        var assignsThroughEquals = StatementLeadsWithExec(statementText);
+
         var sb = new StringBuilder(statementText.Length);
         var substitutions = 0;
         var i = 0;
@@ -94,7 +102,7 @@ public static class ParameterSubstitution
 
                 var token = statementText[i..end];
                 if (values.TryGetValue(token, out var value)
-                    && !IsAssignmentTarget(statementText, i, end))
+                    && !IsAssignmentTarget(statementText, i, end, assignsThroughEquals))
                 {
                     sb.Append(value);
                     substitutions++;
@@ -128,23 +136,41 @@ public static class ParameterSubstitution
     /// mattered less while substitution was something you asked for on the clipboard; #482 makes it
     /// what the advice, the exports and the MCP tools show by default.</para>
     ///
-    /// <para>The three lead-ins below are the ones T-SQL assigns through — <c>SELECT @a = …</c>,
-    /// <c>SET @a = …</c>, and the second and later items of either list. A parameter on the right of
-    /// an <c>=</c> is a read and is left to be substituted, and so is one followed by <c>&gt;=</c>,
+    /// <para>The lead-ins recognised: <c>SELECT @a = …</c> and <c>SET @a = …</c>, with one balanced
+    /// parenthesized group tolerated between the keyword and the target so <c>SELECT TOP (1) @a =
+    /// …</c> is the assignment it is; the second and later items of either list, via the comma; any
+    /// token in front of an <c>=</c> when the statement is an EXEC
+    /// (<paramref name="assignsThroughEquals"/> — see <see cref="StatementLeadsWithExec"/>); and
+    /// <c>FETCH … INTO @a, @b</c>, which assigns with no <c>=</c> anywhere. A parameter on the right
+    /// of an <c>=</c> is a read and is left to be substituted, and so is one followed by <c>&gt;=</c>,
     /// <c>&lt;=</c>, <c>&lt;&gt;</c> or <c>!=</c>, since the scan forward from the token meets that
     /// operator's first character rather than the <c>=</c>.</para>
     /// </summary>
-    private static bool IsAssignmentTarget(string text, int start, int end)
+    private static bool IsAssignmentTarget(string text, int start, int end, bool assignsThroughEquals)
     {
         var forward = end;
         while (forward < text.Length && char.IsWhiteSpace(text[forward]))
             forward++;
 
-        if (forward >= text.Length || text[forward] != '=')
-            return false;
+        var followedByLoneEquals =
+            forward < text.Length
+            && text[forward] == '='
+            && !(forward + 1 < text.Length && text[forward + 1] == '=');
 
-        if (forward + 1 < text.Length && text[forward + 1] == '=')
-            return false;
+        /* FETCH ... INTO @a, @b assigns without any "=": what follows the token is a comma or the
+           end of the statement, so the forward scan has nothing to find and the question is
+           answered entirely by what leads the list. Checked only on the no-equals path — "INTO
+           @a =" is not a shape T-SQL has — which keeps every "=" case on the scans below. */
+        if (!followedByLoneEquals)
+            return IsFetchIntoTarget(text, start);
+
+        /* EXEC @rc = dbo.proc, and the FIRST named argument of EXEC dbo.p @debug = @debug. The
+           back-scan below cannot see either (what precedes them is a procedure name, not SELECT
+           or SET), but EXEC grammar has no reads-then-"=" shape at all, so inside one the "="
+           alone settles it. Later named arguments were already caught by the comma rule; this
+           makes the first one match its siblings. */
+        if (assignsThroughEquals)
+            return true;
 
         var back = start - 1;
         while (back >= 0 && char.IsWhiteSpace(text[back]))
@@ -157,13 +183,193 @@ public static class ParameterSubstitution
         if (text[back] == ',')
             return true;
 
+        /* SELECT TOP (1) @a = col: the token before the target is TOP's balanced group, which the
+           old scan met as ")" and gave up on — it extracted an empty word and substituted @a into
+           "NULL = col". Skip exactly ONE balanced group backwards and judge what precedes it;
+           nothing but TOP puts a group in an assignment lead-in, so anything else still answers
+           no. TOP (@n) rides along for free — the group's content is opaque to this walk, and @n
+           itself is a read whose own forward scan meets ")" rather than "=". */
+        if (text[back] == ')')
+        {
+            var depth = 0;
+            while (back >= 0)
+            {
+                if (text[back] == ')')
+                {
+                    depth++;
+                }
+                else if (text[back] == '(' && --depth == 0)
+                {
+                    back--;
+                    break;
+                }
+
+                back--;
+            }
+
+            /* Unbalanced means truncated statement text. With no way to tell what leads in, stay
+               on the substitute side, which is where the empty-word scan always landed. */
+            if (depth != 0)
+                return false;
+
+            while (back >= 0 && char.IsWhiteSpace(text[back]))
+                back--;
+        }
+
+        var word = ReadWordEndingAt(text, ref back);
+
+        /* TOP sits between SELECT and its group, so the decider is the word before it. */
+        if (word.Equals("TOP", StringComparison.OrdinalIgnoreCase))
+        {
+            while (back >= 0 && char.IsWhiteSpace(text[back]))
+                back--;
+            word = ReadWordEndingAt(text, ref back);
+        }
+
+        return word.Equals("SELECT", StringComparison.OrdinalIgnoreCase)
+            || word.Equals("SET", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// True when the token at <paramref name="start"/> sits in an INTO list — <c>FETCH … INTO @a,
+    /// @b</c> — which assigns into its variables with no <c>=</c> in sight.
+    ///
+    /// <para>The walk hops backwards over "<c>, @name</c>" pairs so every member of the list is
+    /// protected, not just the first. The hop insists each prior list item is itself an @token,
+    /// which is how the commas of an IN list, a VALUES row, or a positional EXEC argument list —
+    /// all places a parameter is read — fall out: at the first non-variable item, or at the "("
+    /// that opens them. <c>INSERT INTO @tv</c> lands here too, and "assignment target" is the
+    /// right answer there as well — a table variable's NAME is never a value to write over.</para>
+    /// </summary>
+    private static bool IsFetchIntoTarget(string text, int start)
+    {
+        var back = start - 1;
+
+        while (true)
+        {
+            while (back >= 0 && char.IsWhiteSpace(text[back]))
+                back--;
+
+            if (back < 0)
+                return false;
+
+            if (text[back] == ',')
+            {
+                back--;
+                while (back >= 0 && char.IsWhiteSpace(text[back]))
+                    back--;
+
+                var previousItem = ReadWordEndingAt(text, ref back);
+                if (previousItem.Length == 0 || previousItem[0] != '@')
+                    return false;
+
+                continue;
+            }
+
+            return ReadWordEndingAt(text, ref back)
+                .Equals("INTO", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    /// <summary>
+    /// Whether the statement's leading keyword chain reaches EXEC or EXECUTE, in which case an
+    /// <c>=</c> can only ever mean assignment — the return-status variable or a named argument.
+    ///
+    /// <para>The chain is EXEC itself, or the INSERT … EXEC prelude: INSERT, an optional INTO, the
+    /// target's possibly bracketed and dotted name, an optional parenthesized column list. The walk
+    /// is forward from the start and gives up at the first character that cannot belong to such a
+    /// prelude — an operator, a quote, a semicolon — so a SELECT or UPDATE never gets anywhere near
+    /// a false positive: it hits its own <c>=</c> or <c>*</c> within a few tokens. Bracketed name
+    /// parts are skipped opaquely so a procedure named [exec] cannot read as the keyword, and
+    /// EXEC('…') is no counterexample — the string stays opaque to Apply's main loop, so nothing
+    /// inside it is substituted regardless of what this answers. Leading comments are not chased;
+    /// a statement that opens with one keeps the old per-token behavior.</para>
+    /// </summary>
+    private static bool StatementLeadsWithExec(string text)
+    {
+        var i = 0;
+
+        /* A handful of tokens is all the INSERT ... EXEC prelude can hold. The bound is a fuse
+           against pathological text, not part of the grammar. */
+        for (var tokens = 0; tokens < 8; tokens++)
+        {
+            while (i < text.Length && char.IsWhiteSpace(text[i]))
+                i++;
+
+            if (i >= text.Length)
+                return false;
+
+            var c = text[i];
+
+            // The INSERT target's column list, skipped as one balanced unit.
+            if (c == '(')
+            {
+                var depth = 0;
+                while (i < text.Length)
+                {
+                    if (text[i] == '(')
+                    {
+                        depth++;
+                    }
+                    else if (text[i] == ')' && --depth == 0)
+                    {
+                        i++;
+                        break;
+                    }
+
+                    i++;
+                }
+
+                if (depth != 0)
+                    return false;
+
+                continue;
+            }
+
+            // A delimited name part, skipped opaquely; dots just join parts.
+            if (c == '[' || c == '"')
+            {
+                var close = text.IndexOf(c == '[' ? ']' : '"', i + 1);
+                if (close < 0)
+                    return false;
+
+                i = close + 1;
+                continue;
+            }
+
+            if (c == '.')
+            {
+                i++;
+                continue;
+            }
+
+            if (!IsIdentifierPart(c))
+                return false;
+
+            var wordStart = i;
+            while (i < text.Length && IsIdentifierPart(text[i]))
+                i++;
+
+            var word = text[wordStart..i];
+            if (word.Equals("EXEC", StringComparison.OrdinalIgnoreCase)
+                || word.Equals("EXECUTE", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The identifier run ending at <paramref name="back"/>, or the empty string when the character
+    /// there is not part of one. Leaves <paramref name="back"/> on the character before the run.
+    /// </summary>
+    private static string ReadWordEndingAt(string text, ref int back)
+    {
         var wordEnd = back + 1;
         while (back >= 0 && IsIdentifierPart(text[back]))
             back--;
 
-        var word = text[(back + 1)..wordEnd];
-        return word.Equals("SELECT", StringComparison.OrdinalIgnoreCase)
-            || word.Equals("SET", StringComparison.OrdinalIgnoreCase);
+        return text[(back + 1)..wordEnd];
     }
 
     /// <summary>

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.Detection.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.Detection.cs
@@ -211,8 +211,12 @@ public static partial class PlanAnalyzer
     /// why this reads the CONVERT_IMPLICIT argument list rather than splitting on the comparison
     /// operator the way <see cref="IsFunctionOnColumnSide"/> does. The first argument is the target
     /// type and carries no brackets; a column reference in the remainder is the conversion input.</para>
+    ///
+    /// <para>Internal so the column-vs-variable line can be tested against raw predicate strings in
+    /// showplan shape — the table-variable case ([@tv].[col] IS a column) has no committed plan
+    /// fixture, and the distinction lives entirely in this method and the regex it shares.</para>
     /// </summary>
-    private static bool ConvertImplicitWrapsColumn(string predicate)
+    internal static bool ConvertImplicitWrapsColumn(string predicate)
     {
         foreach (Match match in ConvertImplicitRegex.Matches(predicate))
         {

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.Helpers.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.Helpers.cs
@@ -8,11 +8,20 @@ namespace PlanViewer.Core.Services;
 
 public static partial class PlanAnalyzer
 {
+    /* Both passes below match on WarningType alone, and a type name is not unique to us:
+       "Implicit Conversion" is rule 29's legacy-listed type AND what the parser stamps on the
+       engine's own PlanAffectingConvert element (Source = SqlServer). Matching by name only
+       therefore branded the ENGINE's record "[SQL Server] [legacy]" — a badge that exists to
+       flag our un-migrated rules on a warning that is not ours at all — and TryOverrideSeverity
+       routed a user's rule-number override onto engine warnings the rule never produced (the
+       Contains matching makes it worse: every engine Spill variant lands on rule 7, "Memory
+       Grant" on rule 9). Legacy status and rule severity are facts about OUR rules, so anything
+       the engine said is skipped by both. */
     private static void MarkLegacyWarnings(PlanStatement stmt)
     {
         foreach (var w in stmt.PlanWarnings)
         {
-            if (LegacyWarningTypes.Contains(w.WarningType))
+            if (w.Source != PlanWarningSource.SqlServer && LegacyWarningTypes.Contains(w.WarningType))
                 w.IsLegacy = true;
         }
         if (stmt.RootNode != null)
@@ -23,7 +32,7 @@ public static partial class PlanAnalyzer
     {
         foreach (var w in node.Warnings)
         {
-            if (LegacyWarningTypes.Contains(w.WarningType))
+            if (w.Source != PlanWarningSource.SqlServer && LegacyWarningTypes.Contains(w.WarningType))
                 w.IsLegacy = true;
         }
         foreach (var child in node.Children)
@@ -58,6 +67,11 @@ public static partial class PlanAnalyzer
 
     private static void TryOverrideSeverity(PlanWarning warning, AnalyzerConfig cfg)
     {
+        /* The engine's warnings carry no rule number because no rule of ours produced them; see
+           the comment on MarkLegacyWarnings for what the name-only matching did to them here. */
+        if (warning.Source == PlanWarningSource.SqlServer)
+            return;
+
         // Find the rule number for this warning type (partial match for flexibility)
         int? ruleNumber = null;
         foreach (var (rule, type) in RuleWarningTypes)

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.cs
@@ -28,11 +28,15 @@ public static partial class PlanAnalyzer
         @"\bCONVERT_IMPLICIT\s*\(",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-    // A column reference in a ScalarString is multi-part bracket-qualified ([schema].[table]).
-    // A variable is a single bracket pair with an @ prefix ([@0]), so excluding @ from the first
-    // part is what separates the two.
+    /* A column reference in a ScalarString is multi-part bracket-qualified ([schema].[table]).
+       A variable is a single bracket pair with an @ prefix ([@0]) and no dotted part after it —
+       the "].[" sequence is what separates the two, NOT the @. The first cut of this pattern also
+       excluded @ from the first part, which read as belt-and-braces but was actually a hole: a
+       TABLE-variable column renders as [@tv].[col], so a genuine column-side CONVERT_IMPLICIT on
+       one failed the match and the Non-SARGable warning silently vanished. A bare [@p] still
+       cannot match, because nothing dotted follows it. */
     private static readonly Regex ColumnReferenceRegex = new(
-        @"\[[^\]@]+\]\.\[",
+        @"\[[^\]]+\]\.\[",
         RegexOptions.Compiled);
 
     public static void Analyze(ParsedPlan plan, AnalyzerConfig? config = null, ServerMetadata? serverMetadata = null) =>

--- a/tests/PlanViewer.Core.Tests/ComparePlansAvailabilityTests.cs
+++ b/tests/PlanViewer.Core.Tests/ComparePlansAvailabilityTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Avalonia.Threading;
 using PlanViewer.App;
 using PlanViewer.App.Controls;
 using PlanViewer.Core.Models;
@@ -202,6 +203,78 @@ public class ComparePlansAvailabilityTests
                 "the session existed before the second plan did, and must still notice it"));
         });
     }
+
+    /// <summary>
+    /// A session that leaves for its own window leaves the window-wide count behind: detached,
+    /// it can only ever compare its own plans, and the sub-tab watcher that keeps the button
+    /// honest fires on sub-tab changes — of which a detach makes none. The button used to keep
+    /// its pre-detach answer until the next plan landed, offering a comparison whose second
+    /// plan was in a window it could no longer reach.
+    /// </summary>
+    [Fact]
+    public void DetachingASessionRecomputesCompareFromItsOwnPlans()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new MainWindow();
+
+            window.LoadPlanFile(PlanPath("row_goal_plan.sqlplan"));
+            var session = NewSession(window);
+            RunQuery(session, "key_lookup_plan.sqlplan", "Plan 1");
+
+            Assert.True(CompareButton(session).IsEnabled,
+                "docked, the window's plan and the session's own make a pair");
+
+            var tab = window.FindControl<TabControl>("MainTabControl")!.Items
+                .OfType<TabItem>().First(t => t.Content == session);
+            var detached = window.DetachTabToWindow(tab)!;
+
+            Assert.False(CompareButton(session).IsEnabled,
+                "detached, the session holds one plan and the window's other one is out of reach");
+
+            /* And coming back is noticed without any hand-written call: re-docking adds a tab,
+               which is exactly what the window's collection watcher listens for. */
+            RedockButton(detached).RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(CompareButton(session).IsEnabled, "docked again, the pair is back");
+        });
+    }
+
+    /// <summary>
+    /// The other direction of the same recompute: a session that owns a pair keeps its button
+    /// through a detach, because the honest own-plans answer is still yes.
+    /// </summary>
+    [Fact]
+    public void ADetachedSessionWithTwoOwnPlansKeepsCompare()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new MainWindow();
+            var session = NewSession(window);
+            RunQuery(session, "row_goal_plan.sqlplan", "Plan 1");
+            RunQuery(session, "key_lookup_plan.sqlplan", "Plan 2");
+
+            var tab = window.FindControl<TabControl>("MainTabControl")!.Items
+                .OfType<TabItem>().First(t => t.Content == session);
+            var detached = window.DetachTabToWindow(tab)!;
+            try
+            {
+                Assert.True(CompareButton(session).IsEnabled,
+                    "both plans travelled with the session, so there is still a pair to offer");
+            }
+            finally
+            {
+                // Nothing dirty, so the close takes the silent first-pass path.
+                detached.Close();
+                Dispatcher.UIThread.RunJobs();
+            }
+        });
+    }
+
+    private static Button RedockButton(Window detached) =>
+        ((DockPanel)detached.Content!).Children.OfType<StackPanel>().Single()
+            .Children.OfType<Button>().Single();
 
     /// <summary>
     /// Runs a query in a session as far as a test without a SQL Server can.

--- a/tests/PlanViewer.Core.Tests/DetachedUnsavedChangesTests.cs
+++ b/tests/PlanViewer.Core.Tests/DetachedUnsavedChangesTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
@@ -216,6 +218,78 @@ public class DetachedUnsavedChangesTests
                 File.Delete(path);
             }
         });
+    }
+
+    /// <summary>
+    /// CreateTab subscribes a glyph refresher onto the session, and the session outlives its
+    /// tab on the detach path — so the subscription used to outlive it too, a closure over the
+    /// dead tab's close button that pinned the whole discarded TabItem to the session, once
+    /// per detach/redock cycle. The counts below read the event's invocation list because the
+    /// leak IS the subscription: nothing observable on screen changes until the memory is
+    /// gone.
+    /// </summary>
+    [Fact]
+    public void DetachTakesTheGlyphSubscriptionOffAndRedockRewiresIt()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            Window? detached = null;
+            QuerySessionControl? session = null;
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                var tab = LastQueryTab(window);
+                session = (QuerySessionControl)tab.Content!;
+
+                Assert.Equal(1, DirtyStateSubscriberCount(session));
+
+                detached = window.DetachTabToWindow(tab)!;
+
+                Assert.Equal(0, DirtyStateSubscriberCount(session));
+
+                RedockButton(detached).RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                Dispatcher.UIThread.RunJobs();
+                detached = null; // re-dock closed it
+
+                /* One again — not two, which is what the cycle used to leave behind. */
+                Assert.Equal(1, DirtyStateSubscriberCount(session));
+
+                /* And the fresh subscription works: the redocked tab's close button still
+                   turns into the modified dot when the session goes dirty, and back. */
+                var redockedTab = LastQueryTab(window);
+                var closeBtn = ((StackPanel)redockedTab.Header!).Children.OfType<Button>().Last();
+
+                session.QueryEditor.Text = "SELECT 2; -- edited";
+                Dispatcher.UIThread.RunJobs();
+                Assert.Equal("●", (string?)closeBtn.Content); // the modified dot
+
+                session.MarkClean();
+                Dispatcher.UIThread.RunJobs();
+                Assert.Equal("✕", (string?)closeBtn.Content); // back to the close cross
+            }
+            finally
+            {
+                PutAway(detached, session);
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The one subscription CreateTab makes on the session itself, counted off the compiler's
+    /// backing delegate. Reflection is the honest tool here: the event is the leak's surface,
+    /// and exposing a count on the product type just to avoid it would be API for a test.
+    /// </summary>
+    private static int DirtyStateSubscriberCount(QuerySessionControl session)
+    {
+        var backingField = typeof(QuerySessionControl).GetField(
+            nameof(QuerySessionControl.DirtyStateChanged),
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        return ((Delegate?)backingField.GetValue(session))?.GetInvocationList().Length ?? 0;
     }
 
     [Fact]

--- a/tests/PlanViewer.Core.Tests/OpenSaveQueryTests.cs
+++ b/tests/PlanViewer.Core.Tests/OpenSaveQueryTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using System.Text;
 using Avalonia.Controls;
 using PlanViewer.App;
 using PlanViewer.App.Controls;
@@ -204,12 +205,143 @@ public class OpenSaveQueryTests
         });
     }
 
+    /// <summary>
+    /// The cold-start argv route, exactly as the constructor takes it. This was the one path
+    /// still hard-wired to LoadPlanFile — the pipe from a second instance, drag-and-drop, and
+    /// session restore all routed by extension — so "PerformanceStudio.exe query.sql" (a shell
+    /// open, a double-clicked association) greeted the user with "The XML is not valid" where
+    /// their query should have been.
+    /// </summary>
+    [Fact]
+    public void ACommandLineSqlFileLandsInAQuerySessionNotThePlanLoader()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1 AS from_argv;");
+            try
+            {
+                var window = new MainWindow();
+                var queryTabsBefore = QueryTabs(window).Count();
+
+                window.OpenFromStartupArgs(new[] { "PerformanceStudio.exe", path });
+
+                Assert.Equal(queryTabsBefore + 1, QueryTabs(window).Count());
+
+                var session = (QuerySessionControl)QueryTabs(window).Last().Content!;
+                Assert.Equal("SELECT 1 AS from_argv;", session.QueryEditor.Text);
+                Assert.Equal(path, session.SourceFilePath);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The route the constructor was hard-wired for still works through the extension router:
+    /// a plan on the command line is still a plan tab.
+    /// </summary>
+    [Fact]
+    public void ACommandLinePlanFileStillOpensAsAPlan()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var planPath = Path.Combine(System.AppContext.BaseDirectory, "Plans", "row_goal_plan.sqlplan");
+
+            var window = new MainWindow();
+            var planTabsBefore = PlanTabs(window).Count();
+
+            window.OpenFromStartupArgs(new[] { "PerformanceStudio.exe", planPath });
+
+            Assert.Equal(planTabsBefore + 1, PlanTabs(window).Count());
+        });
+    }
+
+    /// <summary>
+    /// SSMS writes .sql files as UTF-16 LE with a BOM. Opening one always read correctly —
+    /// File.ReadAllText honors the mark — but SaveQueryToPath wrote UTF-8 without one, so the
+    /// first save-in-place silently transcoded the user's file: every byte changed, the mark
+    /// gone, nothing asked. The encoding captured at open now rides the session to the save.
+    /// </summary>
+    [Fact]
+    public void AUtf16FileIsStillUtf16AfterASaveInPlace()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+            File.WriteAllText(path, "SELECT 1;", Encoding.Unicode);
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                var tab = QueryTabs(window).Last();
+                var session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 2 AS edited;";
+
+                Assert.True(window.SaveQueryToPath(tab, session, path));
+
+                var bytes = File.ReadAllBytes(path);
+                Assert.Equal(new byte[] { 0xFF, 0xFE }, bytes.Take(2).ToArray());
+                Assert.Equal("SELECT 2 AS edited;", File.ReadAllText(path));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The preservation must not cut the other way: a BOM-less file stays BOM-less, and a
+    /// scratch query saves as the UTF-8-without-BOM every save always wrote. Stamping marks
+    /// onto files that never had one would be the same silent-alteration bug in reverse.
+    /// </summary>
+    [Fact]
+    public void BomlessFilesAndScratchQueriesStillSaveWithoutABom()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var bomless = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+            File.WriteAllText(bomless, "SELECT 1;", new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            var scratch = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+            try
+            {
+                var window = new MainWindow();
+
+                window.LoadSqlFile(bomless);
+                var tab = QueryTabs(window).Last();
+                var session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 2 AS edited;";
+                Assert.True(window.SaveQueryToPath(tab, session, bomless));
+                Assert.NotEqual(0xEF, File.ReadAllBytes(bomless)[0]);
+
+                window.NewQuery_Click(window, new Avalonia.Interactivity.RoutedEventArgs());
+                var scratchTab = QueryTabs(window).Last();
+                var scratchSession = (QuerySessionControl)scratchTab.Content!;
+                scratchSession.QueryEditor.Text = "SELECT 3;";
+                Assert.True(window.SaveQueryToPath(scratchTab, scratchSession, scratch));
+                Assert.NotEqual(0xEF, File.ReadAllBytes(scratch)[0]);
+            }
+            finally
+            {
+                File.Delete(bomless);
+                if (File.Exists(scratch))
+                    File.Delete(scratch);
+            }
+        });
+    }
+
     private static string TempSql(string text)
     {
         var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
         File.WriteAllText(path, text);
         return path;
     }
+
+    private static System.Collections.Generic.IEnumerable<TabItem> PlanTabs(MainWindow window) =>
+        window.MainTabControl.Items.OfType<TabItem>().Where(t => t.Content is DockPanel);
 
     private static System.Collections.Generic.IEnumerable<TabItem> QueryTabs(MainWindow window) =>
         window.MainTabControl.Items.OfType<TabItem>().Where(t => t.Content is QuerySessionControl);

--- a/tests/PlanViewer.Core.Tests/ParameterSubstitutionTests.cs
+++ b/tests/PlanViewer.Core.Tests/ParameterSubstitutionTests.cs
@@ -90,6 +90,101 @@ public class ParameterSubstitutionTests
     }
 
     [Fact]
+    public void TopClauseAssignment_IsNotOverwritten()
+    {
+        /* SELECT TOP (1) @a = col: the back-scan from @a used to meet TOP's ")" and extract an
+           empty word, so the #482 guard never engaged and the copied SQL read "TOP (1) NULL =
+           SomeCol". The guard now steps over exactly one balanced group; @n inside TOP's own
+           group is still a read and still gets its value, which is what makes the copy runnable. */
+        var result = ParameterSubstitution.Apply(
+            "SELECT TOP (1) @a = SomeCol FROM t ORDER BY SomeCol",
+            new List<PlanParameter> { Param("@a", "NULL") });
+
+        Assert.Equal("SELECT TOP (1) @a = SomeCol FROM t ORDER BY SomeCol", result.Text);
+        Assert.Equal(0, result.SubstitutionCount);
+    }
+
+    [Fact]
+    public void TopClauseParameter_IsStillSubstituted()
+    {
+        /* The mirror image: @n is TOP's row count, a read, and the assignment target next to it
+           must not drag it under the guard. */
+        var result = ParameterSubstitution.Apply(
+            "SELECT TOP (@n) @a = SomeCol FROM t",
+            new List<PlanParameter> { Param("@n", "(5)"), Param("@a", "NULL") });
+
+        Assert.Equal("SELECT TOP (5) @a = SomeCol FROM t", result.Text);
+        Assert.Equal(1, result.SubstitutionCount);
+    }
+
+    [Fact]
+    public void ExecReturnStatusAndFirstNamedArgument_AreNotOverwritten()
+    {
+        /* Two shapes the back-scan cannot see, because what precedes each is a procedure name
+           rather than SELECT or SET. Inside an EXEC statement "=" has no other meaning, so both
+           the return-status variable and the FIRST named argument are targets — the second and
+           later named arguments were already protected by the list-comma rule, and must stay so. */
+        var result = ParameterSubstitution.Apply(
+            "EXEC @rc = dbo.proc @debug = @debug, @limit = @limit",
+            new List<PlanParameter>
+            {
+                Param("@rc", "(0)"), Param("@debug", "(1)"), Param("@limit", "(50)")
+            });
+
+        /* The names survive on the left; the values land on the right, which is the whole point
+           of substituting an EXEC — a runnable call with this execution's arguments. */
+        Assert.Equal("EXEC @rc = dbo.proc @debug = 1, @limit = 50", result.Text);
+        Assert.Equal(2, result.SubstitutionCount);
+    }
+
+    [Fact]
+    public void FetchIntoTargets_AreNotOverwritten()
+    {
+        /* FETCH assigns with no "=" anywhere, so the forward scan finds nothing and the answer
+           has to come from the INTO leading the list — for every member of it, not just the
+           first. */
+        var result = ParameterSubstitution.Apply(
+            "FETCH NEXT FROM cur INTO @a, @b",
+            new List<PlanParameter> { Param("@a", "(1)"), Param("@b", "(2)") });
+
+        Assert.Equal("FETCH NEXT FROM cur INTO @a, @b", result.Text);
+        Assert.Equal(0, result.SubstitutionCount);
+    }
+
+    [Fact]
+    public void UpdateSetAgainstAColumn_IsStillSubstituted()
+    {
+        /* SET here is UPDATE's, assigning INTO the column FROM the parameter — a read of @p.
+           The keyword rule only guards a parameter directly in front of the "=", and @p is on
+           the other side of it. */
+        var result = ParameterSubstitution.Apply(
+            "UPDATE t SET col = @p WHERE id = @id",
+            new List<PlanParameter> { Param("@p", "(7)"), Param("@id", "(3)") });
+
+        Assert.Equal("UPDATE t SET col = 7 WHERE id = 3", result.Text);
+        Assert.Equal(2, result.SubstitutionCount);
+    }
+
+    [Fact]
+    public void PositionalExecArgumentsAndInLists_AreStillSubstituted()
+    {
+        /* Comma-separated reads, either side of the INTO hop's reasoning: positional EXEC
+           arguments have a procedure name at the head of their list, an IN list has "(" — and
+           neither is INTO, so both keep their values. */
+        var exec = ParameterSubstitution.Apply(
+            "EXEC dbo.p @a, @b",
+            new List<PlanParameter> { Param("@a", "(1)"), Param("@b", "(2)") });
+
+        Assert.Equal("EXEC dbo.p 1, 2", exec.Text);
+
+        var inList = ParameterSubstitution.Apply(
+            "WHERE x IN (@a, @b)",
+            new List<PlanParameter> { Param("@a", "(1)"), Param("@b", "(2)") });
+
+        Assert.Equal("WHERE x IN (1, 2)", inList.Text);
+    }
+
+    [Fact]
     public void ComparisonOperatorsThatEndInEquals_AreStillSubstituted()
     {
         /* The parameter on the LEFT, which is the only side where the assignment check has anything

--- a/tests/PlanViewer.Core.Tests/PlanAnalyzerTests.cs
+++ b/tests/PlanViewer.Core.Tests/PlanAnalyzerTests.cs
@@ -306,6 +306,36 @@ public class PlanAnalyzerTests
     }
 
     // ---------------------------------------------------------------
+    // Rule 12: Non-SARGable Predicate — table-variable columns
+    // ---------------------------------------------------------------
+
+    /// <summary>
+    /// A table-variable COLUMN renders as [@tv].[col] in a ScalarString — the @ belongs to the
+    /// table's name, not to a scalar variable. The old column pattern excluded @ from the first
+    /// bracket part to keep [@p] out, which also kept [@tv].[col] out: a genuine column-side
+    /// CONVERT_IMPLICIT on one lost its Non-SARGable warning. The "].[" sequence is what a bare
+    /// variable can never have, so it alone draws the line.
+    /// </summary>
+    [Fact]
+    public void Rule12f_NonSargable_TableVariableColumnConversion_IsFlagged()
+    {
+        Assert.True(PlanAnalyzer.ConvertImplicitWrapsColumn(
+            "CONVERT_IMPLICIT(nvarchar(40),[@tv].[col],0)=[@p]"));
+    }
+
+    /// <summary>
+    /// The parameter-side mirror of the case above, and the #436 rule restated: converting the
+    /// parameter up to the column's type costs nothing, table variable or not, so widening the
+    /// column pattern must not start flagging it.
+    /// </summary>
+    [Fact]
+    public void Rule12f_NonSargable_TableVariableParameterSideConversion_IsNotFlagged()
+    {
+        Assert.False(PlanAnalyzer.ConvertImplicitWrapsColumn(
+            "[@tv].[col]=CONVERT_IMPLICIT(nvarchar(40),[@p],0)"));
+    }
+
+    // ---------------------------------------------------------------
     // Rule 12: Non-SARGable Predicate — Function Call
     // ---------------------------------------------------------------
 

--- a/tests/PlanViewer.Core.Tests/QueryStoreErrorDisplayTests.cs
+++ b/tests/PlanViewer.Core.Tests/QueryStoreErrorDisplayTests.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using Avalonia.Controls;
+using PlanViewer.App.Controls;
+using PlanViewer.Core.Interfaces;
+using PlanViewer.Core.Models;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #452's pattern on the Query Store grid: five catch sites cut exception text to 60-80
+/// characters + "..." before handing it to a one-line status strip, throwing away the part of
+/// a SQL error that says what actually went wrong (the interesting half of a login or firewall
+/// message is rarely in its first 60 characters). The sites now pass the full message, and the
+/// strip mirrors whatever it shows into its tooltip — trimming belongs to the display, and the
+/// hover is the only way a one-line strip can ever surrender the rest.
+///
+/// <para>What is pinned here is the mirror, driven through StatusText the way every one of the
+/// five sites drives it. The sites themselves are SQL failure paths, and a test that
+/// manufactures a real connection failure inherits the machine's SQL state and SqlClient's
+/// timeouts — the wrong trade for a display contract.</para>
+/// </summary>
+public class QueryStoreErrorDisplayTests
+{
+    [Fact]
+    public void TheStatusStripMirrorsItsFullTextIntoTheTooltip()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var grid = new QueryStoreGridControl(
+                new ServerConnection { ServerName = "tcp:127.0.0.1,1", DisplayName = "unit test" },
+                new NoCredentials(),
+                initialDatabase: "master",
+                databases: new List<string> { "master" });
+
+            var status = grid.FindControl<TextBlock>("StatusText")!;
+
+            /* Longer than either of the old cut-offs, so a reintroduced pre-truncation at any
+               site would be visible as a tooltip that no longer matches what the site sent. */
+            var fullError = "A network-related or instance-specific error occurred while "
+                + "establishing a connection to SQL Server. The server was not found or was not "
+                + "accessible. Verify that the instance name is correct and that SQL Server is "
+                + "configured to allow remote connections. (provider: TCP Provider, error: 0)";
+
+            status.Text = fullError;
+            Assert.Equal(fullError, ToolTip.GetTip(status));
+
+            /* And an empty status must not leave a stale error hovering over nothing. */
+            status.Text = "";
+            Assert.Null(ToolTip.GetTip(status));
+        });
+    }
+
+    /// <summary>
+    /// Windows-auth credentials so the constructor's connection-string build asks for nothing;
+    /// no test here ever opens the connection.
+    /// </summary>
+    private sealed class NoCredentials : ICredentialService
+    {
+        public bool SaveCredential(string serverId, string username, string password) => false;
+        public (string Username, string Password)? GetCredential(string serverId) => null;
+        public bool DeleteCredential(string serverId) => false;
+        public bool CredentialExists(string serverId) => false;
+        public bool UpdateCredential(string serverId, string username, string password) => false;
+    }
+}

--- a/tests/PlanViewer.Core.Tests/WarningSourceTests.cs
+++ b/tests/PlanViewer.Core.Tests/WarningSourceTests.cs
@@ -80,6 +80,59 @@ public class WarningSourceTests
         Assert.DoesNotContain("Non-SARGable Predicate [SQL Server]", text);
     }
 
+    /// <summary>
+    /// The [legacy] badge exists to mark OUR rules that predate the benefit-scoring framework
+    /// (#215) — a migration status for inferences of ours. "Implicit Conversion" is rule 29's
+    /// entry on that list AND the type the parser stamps on the engine's own PlanAffectingConvert
+    /// record, and the legacy pass matched by type name alone — so the engine's statement of fact
+    /// rendered "[SQL Server] [legacy]", as if the engine's record were an un-migrated rule
+    /// awaiting rework. Legacy status is a fact about our rules; nothing the engine said can
+    /// have it.
+    /// </summary>
+    [Fact]
+    public void TheEnginesWarningsAreNeverMarkedLegacy()
+    {
+        var plan = PlanTestHelper.LoadAndAnalyze("convert_implicit_plan.sqlplan");
+
+        var engineWarnings = PlanTestHelper.AllWarnings(plan)
+            .Where(w => w.Source == PlanWarningSource.SqlServer)
+            .ToList();
+
+        Assert.NotEmpty(engineWarnings);
+        Assert.All(engineWarnings, w => Assert.False(w.IsLegacy,
+            $"\"{w.WarningType}\" is the engine's record, not an un-migrated rule of ours"));
+    }
+
+    /// <summary>
+    /// The same name collision, other pass: TryOverrideSeverity finds rule numbers by type-name
+    /// matching, so a user's rule 29 override re-badged the ENGINE's conversion record — and the
+    /// Contains matching spread it further (every engine Spill variant matched rule 7, "Memory
+    /// Grant" rule 9). A rule severity override is an opinion about our inference; what the engine
+    /// recorded keeps the severity the parser gave it.
+    /// </summary>
+    [Fact]
+    public void ASeverityOverrideForRule29DoesNotRebadgeTheEnginesWarnings()
+    {
+        var untouched = PlanTestHelper.LoadAndAnalyze("convert_implicit_plan.sqlplan");
+        var overridden = PlanTestHelper.LoadAndAnalyzeWithConfig(
+            "convert_implicit_plan.sqlplan",
+            new AnalyzerConfig
+            {
+                /* Info: the parser only ever gives these Warning or Critical, so a pre-fix
+                   misroute is a visible severity change whichever kind the fixture carries. */
+                Rules = new RulesConfig { SeverityOverrides = { [29] = "Info" } }
+            });
+
+        var engineBefore = PlanTestHelper.WarningsOfType(untouched, "Implicit Conversion");
+        var engineAfter = PlanTestHelper.WarningsOfType(overridden, "Implicit Conversion");
+
+        Assert.NotEmpty(engineAfter);
+        Assert.All(engineAfter, w => Assert.Equal(PlanWarningSource.SqlServer, w.Source));
+        Assert.Equal(
+            engineBefore.Select(w => w.Severity),
+            engineAfter.Select(w => w.Severity));
+    }
+
     /// <summary>The JSON and MCP consumers get it as a field rather than having to parse the tag out.</summary>
     [Fact]
     public void TheJsonOutputCarriesTheSource()

--- a/tests/PlanViewer.Core.Tests/WindowCloseReentryTests.cs
+++ b/tests/PlanViewer.Core.Tests/WindowCloseReentryTests.cs
@@ -1,0 +1,89 @@
+using System.IO;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using PlanViewer.App;
+using PlanViewer.App.Controls;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// MainWindow.OnClosing cancels the close and runs the unsaved-work walk asynchronously, and
+/// _closeConfirmed only latches once that walk says yes — so a second close request arriving
+/// WHILE the walk was still asking (a double-clicked X, an Alt+F4 behind a Save As picker)
+/// used to start a second concurrent walk: duplicate prompts about the same tab, and a Cancel
+/// answered to one walk that the other never heard. Same reentrancy class as the About
+/// window's update link (#485 review), and the same walk-in-progress latch closes it.
+/// </summary>
+public class WindowCloseReentryTests
+{
+    [Fact]
+    public void ASecondCloseDuringTheWalkDoesNotStartASecondWalk()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            MainWindow? window = null;
+            QuerySessionControl? session = null;
+            try
+            {
+                window = new MainWindow();
+                window.Show(); // the prompt's ShowDialog needs a visible owner, headless or not
+                window.LoadSqlFile(path);
+
+                var tab = window.MainTabControl.Items.OfType<TabItem>()
+                    .Last(t => t.Content is QuerySessionControl);
+                session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 2; -- unsaved work";
+
+                window.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.True(window.IsVisible, "the close is held while the question is up");
+                Assert.Single(window.OwnedWindows);
+
+                /* The double-clicked X. Programmatic Close is the same entry: modality only
+                   blocks input, not the API, so OnClosing runs again mid-walk. */
+                window.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.Single(window.OwnedWindows);
+                Assert.True(window.IsVisible);
+
+                /* Dismissing the prompt is Cancel: the walk ends refused, the window stays —
+                   and the latch has to clear with it, or the X is dead for good. */
+                window.OwnedWindows.Single().Close();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.True(window.IsVisible);
+                Assert.Empty(window.OwnedWindows);
+
+                window.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.Single(window.OwnedWindows); // a fresh close starts a fresh walk
+            }
+            finally
+            {
+                if (window != null)
+                {
+                    foreach (var prompt in window.OwnedWindows.ToList())
+                        prompt.Close();
+                    session?.MarkClean();
+                    Dispatcher.UIThread.RunJobs();
+                    window.Close(); // nothing dirty now, so this one goes through
+                    Dispatcher.UIThread.RunJobs();
+                }
+
+                File.Delete(path);
+            }
+        });
+    }
+
+    private static string TempSql(string text)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+        File.WriteAllText(path, text);
+        return path;
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Closes the nine Minor findings from the 2026-09-02 adversarial review, in four commits:

- **Analyzer/substitution correctness**: engine-sourced warnings no longer get tagged `[legacy]` or captured by user severity overrides (the type-name collision also misrouted engine Spill/Memory Grant warnings onto rules 7/9 — the Source-skip covers all of it); `[@tv].[col]` now reads as the column reference it is, restoring Non-SARGable detection on table-variable columns; and `IsAssignmentTarget` learns the three verified misses — `SELECT TOP (1) @a = col` (skip one balanced group backwards), `EXEC @rc = proc` / first named EXEC argument (inside EXEC, `=` only ever assigns), and `FETCH … INTO @a, @b` — while every read shape still substitutes.
- **Query Store error display**: the five remaining pre-truncation sites get #452's shipped treatment (full message reaches the display layer, tooltip mirror pinned by test).
- **Cold-start argv + encoding**: `PerformanceStudio.exe query.sql` now routes by extension instead of greeting the user with "The XML is not valid" (extracted to a testable `OpenFromStartupArgs`), and a file's encoding survives open→save round-trips via BOM sniff (UTF-16 stays UTF-16; BOM-less and scratch stay UTF-8-no-BOM).
- **Window-lifecycle warts**: detach recomputes the detached session's Compare button honestly; the main close walk gets an in-progress latch (double-clicked X no longer runs two concurrent walks) with the same guard mirrored in DetachedWindowHelper where the hazard was verified real; and the per-tab `DirtyStateChanged` subscription comes off at detach instead of leaking a dead TabItem per detach/redock cycle.

All nine came from the review; three fixes were verified red against pre-fix code by revert-and-rerun. Conflict note: the cherry-pick onto dev was resolved so #487's test-host gates stay at the constructor call sites while `OpenFromStartupArgs` carries only the routing.

## How was this tested?

Nineteen new test executions across `WindowCloseReentryTests` (new), `QueryStoreErrorDisplayTests` (new), and extensions to the analyzer, substitution, compare-availability, detached-unsaved, and open/save suites — items 6/7/8 all got real headless tests, not inspection. Full suite at dev tip: 444 tests, 443 passed, 1 platform skip, 0 failed, on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvAv72Pwb8czsjDWsCCk7n