### PR TITLE
Pin the detached window's close-reentry latch too

### DIFF
--- a/tests/PlanViewer.Core.Tests/WindowCloseReentryTests.cs
+++ b/tests/PlanViewer.Core.Tests/WindowCloseReentryTests.cs
@@ -14,6 +14,12 @@ namespace PlanViewer.Core.Tests;
 /// used to start a second concurrent walk: duplicate prompts about the same tab, and a Cancel
 /// answered to one walk that the other never heard. Same reentrancy class as the About
 /// window's update link (#485 review), and the same walk-in-progress latch closes it.
+///
+/// <para><b>Both guards, not one.</b> <c>DetachedWindowHelper</c> carries its own copy of the
+/// latch for its own copy of the gap, and the two are separate code with separate state. Only
+/// the MainWindow half was pinned when the latch landed: deleting the detached
+/// <c>closeGuardPending</c> check outright left this class green, which is how a latch gets
+/// tidied away by someone who reasonably believes the tests are watching it.</para>
 /// </summary>
 public class WindowCloseReentryTests
 {
@@ -72,6 +78,80 @@ public class WindowCloseReentryTests
                     session?.MarkClean();
                     Dispatcher.UIThread.RunJobs();
                     window.Close(); // nothing dirty now, so this one goes through
+                    Dispatcher.UIThread.RunJobs();
+                }
+
+                File.Delete(path);
+            }
+        });
+    }
+
+    [Fact]
+    public void ASecondCloseOfADetachedWindowDoesNotStackASecondPrompt()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            MainWindow? window = null;
+            Window? detached = null;
+            QuerySessionControl? session = null;
+            try
+            {
+                window = new MainWindow();
+                window.Show();
+                window.LoadSqlFile(path);
+
+                var tab = window.MainTabControl.Items.OfType<TabItem>()
+                    .Last(t => t.Content is QuerySessionControl);
+                session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 2; -- unsaved work";
+
+                detached = window.DetachTabToWindow(tab)!;
+                Dispatcher.UIThread.RunJobs();
+
+                detached.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.True(detached.IsVisible, "the close is held while the question is up");
+                Assert.Single(detached.OwnedWindows);
+
+                /* The second X. The guard's prompt is modal to the detached window, but a Save As
+                   raised from that prompt is not, so this is reachable in the real app. */
+                detached.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.Single(detached.OwnedWindows);
+                Assert.True(detached.IsVisible);
+
+                /* Dismissing is Cancel: the window stays, and the latch has to clear with it or
+                   the X is dead for the rest of that window's life. */
+                detached.OwnedWindows.Single().Close();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.True(detached.IsVisible);
+                Assert.Empty(detached.OwnedWindows);
+
+                detached.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.Single(detached.OwnedWindows); // a fresh close starts a fresh question
+            }
+            finally
+            {
+                if (detached != null)
+                {
+                    foreach (var prompt in detached.OwnedWindows.ToList())
+                        prompt.Close();
+                    session?.MarkClean();
+                    Dispatcher.UIThread.RunJobs();
+                    detached.Close();
+                    Dispatcher.UIThread.RunJobs();
+                }
+
+                if (window != null)
+                {
+                    session?.MarkClean();
+                    window.Close();
                     Dispatcher.UIThread.RunJobs();
                 }
 


### PR DESCRIPTION
#488 closed a reentrancy gap in two places — `MainWindow.OnClosing` and `DetachedWindowHelper` each latch while their unsaved-work question is still up, because `_closeConfirmed` / `closeConfirmed` only latch after a *yes* and so do nothing about a second close arriving mid-walk.

Only the MainWindow half was pinned. I deleted the detached `closeGuardPending` check outright and the suite stayed green:

```
--- latch deleted
   WindowCloseReentryTests  Total: 1, Failed: 0
```

Two separate guards with separate state, one test. That is how a latch gets tidied away by someone who reasonably believes the tests are watching it.

This adds the twin, same shape as the existing one but against the detached window: close once and the question comes up, close again and no second prompt stacks, dismiss it and the window stays with the latch cleared, close once more and a fresh question starts. That last step matters as much as the others — a latch that never clears makes the X dead for the rest of the window's life.

Proved red first. With the latch removed:

```
   WindowCloseReentryTests.ASecondCloseOfADetachedWindowDoesNotStackASecondPrompt [FAIL]
   Total: 2, Failed: 1
```

Restored: 445 passed, 0 failed, 2 skipped.

Tests only — no production change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016a1AnKAHwcALrwdYVVrpgR
