### PR TITLE
Surface the running instance on a bare second launch instead of clobbering settings

### DIFF
--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -30,8 +30,6 @@ namespace PlanViewer.App;
 
 public partial class MainWindow : Window
 {
-    private const string PipeName = "SQLPerformanceStudio_OpenFile";
-
     private readonly ICredentialService _credentialService;
     private readonly ConnectionStore _connectionStore;
     private readonly CancellationTokenSource _pipeCts = new();
@@ -67,7 +65,9 @@ public partial class MainWindow : Window
         if (Enum.TryParse<TimeDisplayMode>(_appSettings.QueryStoreDefaultTimeDisplay, true, out var tdm))
             TimeDisplayHelper.Current = tdm;
 
-        // Listen for file paths from other instances (e.g. SSMS extension).
+        // Listen for file paths from other launches (SSMS extension, a second Studio
+        // launch handing over its file) and for the #489 surface-yourself sentinel a bare
+        // second launch sends instead of running a full instance.
         // Not in the test host (#451): every test window would grab the machine's single
         // SQLPerformanceStudio_OpenFile pipe slot and never release it — OnClosed never
         // runs there — racing any real Studio instance on the same box.
@@ -189,6 +189,15 @@ public partial class MainWindow : Window
     /// </summary>
     internal void OpenFromStartupArgs(string[] args)
     {
+        /* #489: --new-instance is a launcher directive, not a file, and it is scrubbed
+           HERE as well as in Program.Main because this method consumes the raw
+           Environment.GetCommandLineArgs() — Program's scrubbed copy never reaches it.
+           Without this, "PerformanceStudio.exe --new-instance file.sqlplan" would find the
+           flag at args[1]: it happens to fail the File.Exists guard below, but the user's
+           file behind it would still be skipped and the launch would silently
+           session-restore instead. */
+        args = SingleInstance.StripNewInstanceFlag(args);
+
         if (args.Length > 1 && File.Exists(args[1]))
         {
             OpenFileByExtension(args[1]);
@@ -212,21 +221,22 @@ public partial class MainWindow : Window
                 try
                 {
                     using var server = new NamedPipeServerStream(
-                        PipeName, PipeDirection.In, 1,
+                        SingleInstance.PipeName, PipeDirection.In, 1,
                         PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
 
                     await server.WaitForConnectionAsync(token);
 
                     using var reader = new StreamReader(server);
-                    var filePath = await reader.ReadLineAsync();
+                    var line = await reader.ReadLineAsync();
 
-                    if (!string.IsNullOrWhiteSpace(filePath) && File.Exists(filePath))
+                    /* Classified out here rather than inside the UI dispatch on purpose:
+                       Classify calls File.Exists, and a dead UNC path can block for
+                       seconds — that wait belongs on this pipe task, not the dispatcher. */
+                    var kind = SingleInstance.Classify(line);
+                    if (kind != SingleInstance.PipeMessage.Ignore)
                     {
                         await Dispatcher.UIThread.InvokeAsync(() =>
-                        {
-                            OpenFileByExtension(filePath);
-                            Activate();
-                        });
+                            DispatchPipeMessage(kind, line!));
                     }
                 }
                 catch (OperationCanceledException)
@@ -243,6 +253,49 @@ public partial class MainWindow : Window
                 }
             }
         }, token);
+    }
+
+    /// <summary>
+    /// Acts on one classified pipe line, on the UI thread. Split from the pipe loop so the
+    /// dispatch can be pinned by tests without a pipe (#489).
+    ///
+    /// <para>The classification is the compatibility contract with every sender version:
+    /// an existing file path opens — what the SSMS extension and any Studio build have
+    /// always sent, unchanged — the activation sentinel surfaces the window (what a bare
+    /// second launch sends since #489), and anything else, including a path that stopped
+    /// existing between send and receive, was already dropped silently before the
+    /// classifier existed and still is.</para>
+    /// </summary>
+    internal void DispatchPipeMessage(SingleInstance.PipeMessage kind, string line)
+    {
+        switch (kind)
+        {
+            case SingleInstance.PipeMessage.OpenFile:
+                OpenFileByExtension(line);
+                SurfaceWindow();
+                break;
+
+            case SingleInstance.PipeMessage.Activate:
+                SurfaceWindow();
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Brings the main window back to the user after a second launch handed its work to
+    /// this one (#489): restore from minimized, then activate. Deliberately minimal next
+    /// to Lite's surface path — Studio never hides to a tray, so there is nothing to
+    /// re-show.
+    ///
+    /// <para>The file-open message uses it too, where the old handler only called
+    /// Activate(): a plan sent from SSMS to a minimized window used to load into a window
+    /// that stayed in the taskbar.</para>
+    /// </summary>
+    internal void SurfaceWindow()
+    {
+        if (WindowState == WindowState.Minimized)
+            WindowState = WindowState.Normal;
+        Activate();
     }
 
     private void StartMcpServer()

--- a/src/PlanViewer.App/Program.cs
+++ b/src/PlanViewer.App/Program.cs
@@ -142,11 +142,24 @@ class Program
             mutex.Dispose();
             return false;
         }
-        catch
+        catch (Exception ex)
         {
             /* Mutex machinery unavailable — an ACL mismatch on the name, a restrictive
-               sandbox. Claiming ownership is the conservative answer: this instance runs
-               fully, which is exactly the pre-#489 behavior for every launch. */
+               sandbox, or a platform where the named-mutex shim misbehaves (on Unix these
+               are file-backed under /tmp; PlatformNotSupportedException would land here
+               too). Claiming ownership is the conservative answer: this instance runs
+               fully, which is exactly the pre-#489 behavior for every launch.
+
+               Said out loud rather than swallowed, because the degradation is otherwise
+               invisible: if this fires on every launch, single-instancing has quietly
+               no-oped and #489's settings clobber is back with no symptom pointing here.
+               stderr is the right channel — a Windows GUI launch has no console and loses
+               it harmlessly, while the Unix platforms this is most likely to fire on are
+               exactly where launching from a terminal is common. A unit test exercises
+               the named-mutex machinery per platform in CI so a shim that throws fails
+               loudly there first. */
+            Console.Error.WriteLine(
+                $"PerformanceStudio: single-instance detection unavailable ({ex.GetType().Name}); running as a full instance.");
             return true;
         }
     }

--- a/src/PlanViewer.App/Program.cs
+++ b/src/PlanViewer.App/Program.cs
@@ -61,11 +61,21 @@ class Program
 
         if (!newInstanceRequested)
         {
-            // The pre-#489 forwarding, kept first and unchanged: a with-file launch tries
-            // the pipe before anything else. Beyond being the common case, probing before
-            // the mutex is version-skew-proof — an already-running build that predates the
-            // mutex answers its pipe but holds no mutex, and a mutex-first flow would run a
-            // second full window beside it instead of handing the file over.
+            /* The pre-#489 forwarding, kept first and unchanged: a with-file launch tries
+               the pipe before anything else. Beyond being the common case, probing before
+               the mutex makes the WITH-FILE path version-skew-proof — an already-running
+               build that predates the mutex answers its pipe but holds no mutex, and a
+               mutex-first flow would run a second full window beside it instead of handing
+               the file over.
+
+               A BARE launch during that same skew is the one #489 case deliberately left
+               open: it cannot probe first, because an old receiver silently drops the
+               sentinel (File.Exists guard) while delivery still reports success — the
+               launch would exit having surfaced nothing, which is worse than a second
+               instance. So a bare launch beside a pre-mutex build claims the free mutex
+               and runs fully: the pre-#489 status quo, for one transient upgrade window
+               that ends when the old instance exits. Documented rather than solved; a
+               real fix needs an acknowledged (duplex) surfacing protocol. */
             if (effectiveArgs.Length > 0 && TrySendToRunningInstance(effectiveArgs[0], maxAttempts: 1))
                 return;
 

--- a/src/PlanViewer.App/Program.cs
+++ b/src/PlanViewer.App/Program.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using System;
 using System.IO;
 using System.IO.Pipes;
+using System.Threading;
 using System.Threading.Tasks;
 using PlanViewer.App.Services;
 using Velopack;
@@ -10,7 +11,14 @@ namespace PlanViewer.App;
 
 class Program
 {
-    private const string PipeName = "SQLPerformanceStudio_OpenFile";
+    /// <summary>
+    /// Held — never released — by the instance that owns the single-instance slot (#489).
+    /// The OS tears the mutex down when the process exits, crash included, so there is no
+    /// release path to get wrong; a static field keeps the handle rooted for the whole run
+    /// (the previous mutex attempt died precisely because its handle was disposed the
+    /// moment the acquiring method returned, so no instance ever actually held it).
+    /// </summary>
+    private static Mutex? _singleInstanceMutex;
 
     [STAThread]
     public static void Main(string[] args)
@@ -36,12 +44,62 @@ class Program
         }
         velopack.Run();
 
-        // If another instance is running, send the file path to it and exit
-        if (args.Length > 0 && TrySendToRunningInstance(args[0]))
-            return;
+        /* #489: every instance holds a whole-file AppSettings snapshot and Save writes the
+           whole file, so a second instance makes the settings file last-write-wins — the
+           instance that exits second silently clobbers the other's open_tabs and every
+           other setting (AtomicFile prevents torn writes, not lost updates). File-argument
+           launches already forwarded to the running instance over the pipe; a BARE second
+           launch ran a full instance and was exactly the clobber case. So unless the user
+           explicitly asks for a second instance, a launch that finds one running hands it
+           its work — a file path, or a bare "surface yourself" — and exits. */
+        var newInstanceRequested = SingleInstance.NewInstanceRequested(args);
+
+        // The flag is a launcher directive, not a file: strip it so nothing downstream can
+        // mistake it for a path ("PerformanceStudio.exe --new-instance file.sqlplan" must
+        // still open the file). MainWindow re-reads the raw argv and scrubs it again itself.
+        var effectiveArgs = SingleInstance.StripNewInstanceFlag(args);
+
+        if (!newInstanceRequested)
+        {
+            // The pre-#489 forwarding, kept first and unchanged: a with-file launch tries
+            // the pipe before anything else. Beyond being the common case, probing before
+            // the mutex is version-skew-proof — an already-running build that predates the
+            // mutex answers its pipe but holds no mutex, and a mutex-first flow would run a
+            // second full window beside it instead of handing the file over.
+            if (effectiveArgs.Length > 0 && TrySendToRunningInstance(effectiveArgs[0], maxAttempts: 1))
+                return;
+
+            if (!TryBecomeSingleInstanceOwner())
+            {
+                /* Another instance owns the slot but hasn't answered its pipe yet — bare
+                   launches never probed above, and a with-file probe may have raced the
+                   owner's boot (the pipe server starts in the MainWindow constructor,
+                   which on a cold start is seconds after its Main). Retry for ~2s before
+                   giving up on delivery. */
+                var message = effectiveArgs.Length > 0
+                    ? effectiveArgs[0]
+                    : SingleInstance.ActivateSentinel;
+                if (TrySendToRunningInstance(message, maxAttempts: 4))
+                    return;
+
+                /* Delivery failed after retries: the owner is wedged, exiting, or still
+                   booting slowly. Losing the user's action — their double-clicked file, or
+                   the app simply appearing at all — is worse than a rare second instance,
+                   so fall through and run fully. This is also the honest residue of the
+                   startup race: two simultaneous bare launches can BOTH end up proceeding
+                   when the loser's retries run out before the winner's pipe exists. The
+                   mutex closes most of that window; what remains falls back to the
+                   pre-#489 last-write-wins behavior, which is the accepted floor. */
+            }
+        }
 
         BuildAvaloniaApp()
-            .StartWithClassicDesktopLifetime(args);
+            .StartWithClassicDesktopLifetime(effectiveArgs);
+
+        // Reached only at app shutdown. Statics are GC roots, so the field alone keeps the
+        // owner's mutex handle alive; this read exists to say out loud that the handle's
+        // LIFETIME is the point (and to keep the field from reading as write-only).
+        GC.KeepAlive(_singleInstanceMutex);
     }
 
     // Avalonia configuration, don't remove; also used by visual designer.
@@ -52,32 +110,74 @@ class Program
             .LogToTrace();
 
     /// <summary>
-    /// Tries to hand the file path to an already-running instance over its named pipe.
-    /// A failed/timed-out connect means no instance is listening, so the caller should
-    /// launch normally. Returns true only if the path was actually delivered.
+    /// Tries to claim the single-instance slot (#489). True means this process is the
+    /// owner and should run; false means another instance holds the slot and this launch
+    /// should hand its work over instead.
     /// </summary>
-    /// <remarks>
-    /// Detection is via the pipe itself rather than a named mutex: the previous mutex
-    /// was disposed as soon as this method returned, so no instance ever held it and
-    /// the forwarding path was never taken.
-    /// </remarks>
-    private static bool TrySendToRunningInstance(string filePath)
+    private static bool TryBecomeSingleInstanceOwner()
     {
         try
         {
-            using var client = new NamedPipeClientStream(".", PipeName, PipeDirection.Out);
-            // Short timeout: a running instance's listener is idle and connects
-            // immediately; when none is running this is the only added launch delay.
-            client.Connect(500);
-            using var writer = new StreamWriter(client);
-            writer.WriteLine(filePath);
-            writer.Flush();
-            return true;
+            var mutex = new Mutex(initiallyOwned: true, SingleInstance.MutexName, out var createdNew);
+            if (createdNew)
+            {
+                _singleInstanceMutex = mutex;
+                return true;
+            }
+
+            /* Another process owns it. Close our handle right away: if this launch ends up
+               running anyway (the pipe fallback above), a lingering handle would keep the
+               kernel object alive after the real owner exits, and a THIRD launch would then
+               see the name taken with nobody serving the pipe behind it. */
+            mutex.Dispose();
+            return false;
         }
         catch
         {
-            // No instance listening (or pipe busy) — fall through to launch normally.
-            return false;
+            /* Mutex machinery unavailable — an ACL mismatch on the name, a restrictive
+               sandbox. Claiming ownership is the conservative answer: this instance runs
+               fully, which is exactly the pre-#489 behavior for every launch. */
+            return true;
         }
+    }
+
+    /// <summary>
+    /// Tries to hand one line — a file path, or the activation sentinel — to an
+    /// already-running instance over its named pipe. Returns true only if the line was
+    /// actually delivered; the caller decides what a failed delivery costs.
+    /// </summary>
+    private static bool TrySendToRunningInstance(string message, int maxAttempts)
+    {
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            if (attempt > 1)
+            {
+                // Between attempts only: the owner is presumably mid-boot, so give its
+                // pipe server a beat to come up rather than burning connects back-to-back.
+                Thread.Sleep(100);
+            }
+
+            try
+            {
+                using var client = new NamedPipeClientStream(".", SingleInstance.PipeName, PipeDirection.Out);
+                // 500ms per attempt: a running instance's listener is idle and connects
+                // immediately, while Connect burns the full timeout when nothing is
+                // listening — so the single-attempt probe on a with-file launch adds at
+                // most the same half second it always has, and the 4-attempt retry path
+                // totals roughly the ~2s boot grace it exists for.
+                client.Connect(500);
+                using var writer = new StreamWriter(client);
+                writer.WriteLine(message);
+                writer.Flush();
+                return true;
+            }
+            catch
+            {
+                // Not listening yet, or the single server slot was mid-conversation with
+                // another client — retry if the budget allows, otherwise report undelivered.
+            }
+        }
+
+        return false;
     }
 }

--- a/src/PlanViewer.App/SingleInstance.cs
+++ b/src/PlanViewer.App/SingleInstance.cs
@@ -1,0 +1,124 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace PlanViewer.App;
+
+/// <summary>
+/// The names and message grammar shared by both halves of single-instance startup (#489):
+/// the launcher side in <see cref="Program"/> that decides whether to run or to hand its
+/// work to an already-running instance, and the receiver side in <see cref="MainWindow"/>'s
+/// pipe server that acts on what arrives.
+///
+/// <para><b>Why single-instance at all.</b> Every instance holds a whole-file
+/// <c>AppSettings</c> snapshot and Save writes the whole file, so two instances make the
+/// settings file last-write-wins: whichever exits second silently clobbers the other's
+/// open_tabs and every other setting. AtomicFile prevents torn files, not lost updates.
+/// A launch with a file argument already forwarded to the running instance over the named
+/// pipe; a bare launch ran a full second instance and was exactly the clobber case.</para>
+///
+/// <para><b>Why the grammar is this shape.</b> The pipe protocol is one line per
+/// connection, historically always a file path, and two other sender/receiver pairs speak
+/// it: the SSMS extension's AppLauncher (sends plain paths, cannot be updated in lockstep
+/// with the app) and any older Studio build still running across an upgrade. So the
+/// activation message is not a version field or a framed header — it is a single reserved
+/// line that an OLD receiver safely ignores: the pre-#489 handler's only guard is
+/// <c>File.Exists(line)</c>, and <see cref="ActivateSentinel"/> contains characters that
+/// are illegal in Windows file names, so it can never name an existing file there. An old
+/// receiver reads it, finds no such file, drops it, and keeps serving — the worst-case
+/// skew is a bare second launch that exits without surfacing anything, not a crash or a
+/// junk tab.</para>
+/// </summary>
+internal static class SingleInstance
+{
+    /// <summary>
+    /// The pipe every Studio sender and receiver has always shared — also written by the
+    /// SSMS extension's AppLauncher, which is why the name can never change casually.
+    /// </summary>
+    internal const string PipeName = "SQLPerformanceStudio_OpenFile";
+
+    /// <summary>
+    /// Unprefixed, so it lands in the default per-user-session <c>Local\</c> namespace on
+    /// Windows — two users (or two RDP sessions) each get their own instance, which is the
+    /// scope the settings file conflict actually has. Distinct from Lite's
+    /// <c>PerformanceMonitorLite_SingleInstance</c>; the two apps must never see each other.
+    /// </summary>
+    internal const string MutexName = "SQLPerformanceStudio_SingleInstance";
+
+    /// <summary>
+    /// Escape hatch (#489): skip the single-instance check and run a full second instance.
+    /// A user who runs two on purpose accepts settings last-write-wins as their informed
+    /// choice. Stripped from argv before any file-open logic sees it.
+    /// </summary>
+    internal const string NewInstanceFlag = "--new-instance";
+
+    /// <summary>
+    /// The line a bare second launch sends to mean "surface your main window". The
+    /// double-colons make it unrepresentable as a Windows file name on purpose — see the
+    /// class comment for why that property is the entire backward-compatibility story.
+    /// </summary>
+    internal const string ActivateSentinel = "::activate::";
+
+    /// <summary>What one received pipe line means. See <see cref="Classify"/>.</summary>
+    internal enum PipeMessage
+    {
+        /// <summary>Blank, or a path that doesn't exist — dropped silently, exactly as the pre-#489 receiver did.</summary>
+        Ignore,
+
+        /// <summary>The <see cref="ActivateSentinel"/> — a bare second launch asking this window to surface.</summary>
+        Activate,
+
+        /// <summary>An existing file — the SSMS extension or a second launch handing over a path to open.</summary>
+        OpenFile,
+    }
+
+    /// <summary>
+    /// The receiver's dispatch decision for one pipe line, extracted from the pipe loop so
+    /// it can be pinned by tests without a pipe.
+    ///
+    /// <para>The sentinel is checked before <c>File.Exists</c>, not after: on Windows the
+    /// order can't matter (the sentinel is an illegal file name), but on Linux a file named
+    /// <c>::activate::</c> is representable, and the reserved meaning must win over any
+    /// such file. <c>File.Exists</c> on a garbage line returns false rather than throwing,
+    /// which is what made the old receiver's guard safe and keeps this one safe too.</para>
+    /// </summary>
+    internal static PipeMessage Classify(string? line)
+    {
+        if (string.IsNullOrWhiteSpace(line))
+            return PipeMessage.Ignore;
+
+        if (string.Equals(line, ActivateSentinel, StringComparison.Ordinal))
+            return PipeMessage.Activate;
+
+        if (File.Exists(line))
+            return PipeMessage.OpenFile;
+
+        return PipeMessage.Ignore;
+    }
+
+    /// <summary>True when argv carries <see cref="NewInstanceFlag"/> anywhere.</summary>
+    internal static bool NewInstanceRequested(string[] args) =>
+        args.Any(IsNewInstanceFlag);
+
+    /// <summary>
+    /// Argv minus every <see cref="NewInstanceFlag"/>, order otherwise preserved. Applied
+    /// in BOTH places argv is consumed: <see cref="Program.Main"/> (so the forwarded path
+    /// and the args handed to Avalonia are clean) and
+    /// <see cref="MainWindow.OpenFromStartupArgs"/> (which reads the raw
+    /// <c>Environment.GetCommandLineArgs()</c> itself, so Program's scrubbed copy never
+    /// reaches it). Without the second scrub, "PerformanceStudio.exe --new-instance
+    /// file.sqlplan" would see the flag at args[1] instead of the file. The flag happens to
+    /// fail that path's <c>File.Exists</c> guard today, but the file arg behind it would
+    /// still be skipped — being explicit here is what makes the flag invisible rather than
+    /// merely unlucky.
+    /// </summary>
+    internal static string[] StripNewInstanceFlag(string[] args) =>
+        args.Where(a => !IsNewInstanceFlag(a)).ToArray();
+
+    /// <summary>
+    /// Case-insensitive, because Windows users type flags in whatever case survived their
+    /// muscle memory and there is no second flag for this one to collide with.
+    /// </summary>
+    private static bool IsNewInstanceFlag(string arg) =>
+        string.Equals(arg, NewInstanceFlag, StringComparison.OrdinalIgnoreCase);
+}

--- a/tests/PlanViewer.Core.Tests/SingleInstanceTests.cs
+++ b/tests/PlanViewer.Core.Tests/SingleInstanceTests.cs
@@ -1,0 +1,216 @@
+using System.IO;
+using System.Linq;
+using Avalonia.Controls;
+using PlanViewer.App;
+using PlanViewer.App.Controls;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #489: two Studio instances each hold a whole-file AppSettings snapshot and Save writes
+/// the whole file, so the instance that exits second silently clobbers the other's
+/// open_tabs and every other setting. The fix makes a bare second launch hand a
+/// "surface yourself" sentinel to the running instance over the existing OpenFile pipe
+/// (with-file launches already forwarded), with <c>--new-instance</c> as the deliberate
+/// escape hatch.
+///
+/// <para>The process-level halves — the named mutex in Program.Main and the exit of the
+/// non-owning launch — cannot run under this harness, which boots App directly and never
+/// enters Main; they are verified by inspection and commented in Program.cs. What CAN be
+/// pinned, and is here, are the two seams everything else leans on: the receiver's message
+/// grammar (sentinel vs file path vs garbage, including the property that makes the
+/// sentinel safe to send to a pre-#489 receiver) and the argv scrubbing that keeps the
+/// flag from shadowing a real file argument.</para>
+/// </summary>
+public class SingleInstanceTests
+{
+    /* ---- Classify: the receiver's message grammar ---------------------------------- */
+
+    [Fact]
+    public void TheActivationSentinelClassifiesAsActivate()
+    {
+        Assert.Equal(
+            SingleInstance.PipeMessage.Activate,
+            SingleInstance.Classify(SingleInstance.ActivateSentinel));
+    }
+
+    [Fact]
+    public void AnExistingFileClassifiesAsOpenFile()
+    {
+        var path = TempSql("SELECT 1;");
+        try
+        {
+            Assert.Equal(SingleInstance.PipeMessage.OpenFile, SingleInstance.Classify(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// A path that stopped existing between send and receive was dropped silently before
+    /// #489 and must still be — the receiver has no way to open it and no business
+    /// guessing.
+    /// </summary>
+    [Fact]
+    public void AMissingPathClassifiesAsIgnore()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), "never_written.sqlplan");
+        Assert.Equal(SingleInstance.PipeMessage.Ignore, SingleInstance.Classify(missing));
+    }
+
+    [Fact]
+    public void BlankLinesClassifyAsIgnore()
+    {
+        Assert.Equal(SingleInstance.PipeMessage.Ignore, SingleInstance.Classify(null));
+        Assert.Equal(SingleInstance.PipeMessage.Ignore, SingleInstance.Classify(string.Empty));
+        Assert.Equal(SingleInstance.PipeMessage.Ignore, SingleInstance.Classify("   "));
+    }
+
+    /// <summary>
+    /// The entire backward-compatibility story of the sentinel, pinned: a pre-#489
+    /// receiver's only guard is <c>File.Exists(line)</c>, so the sentinel is safe to send
+    /// to an old running build exactly as long as it can never name an existing file. The
+    /// double-colons are illegal in Windows file names by design; if someone ever
+    /// "tidies" the token into something path-representable, this fails and points here.
+    /// </summary>
+    [Fact]
+    public void TheSentinelCanNeverBeMistakenForAFileByAnOldReceiver()
+    {
+        Assert.False(
+            File.Exists(SingleInstance.ActivateSentinel),
+            "an old receiver File.Exists-guards every pipe line, so the sentinel must never resolve to a real file");
+    }
+
+    /* ---- StripNewInstanceFlag: argv scrubbing -------------------------------------- */
+
+    /// <summary>
+    /// "PerformanceStudio.exe --new-instance file.sqlplan" must still open the file: the
+    /// flag disappears and the path keeps its place as the first real argument, because
+    /// OpenFromStartupArgs only ever looks at args[1].
+    /// </summary>
+    [Fact]
+    public void TheNewInstanceFlagIsRemovedAndTheFileArgSurvives()
+    {
+        var raw = new[] { "PerformanceStudio.exe", "--new-instance", @"C:\plans\slow.sqlplan" };
+
+        var scrubbed = SingleInstance.StripNewInstanceFlag(raw);
+
+        Assert.Equal(new[] { "PerformanceStudio.exe", @"C:\plans\slow.sqlplan" }, scrubbed);
+        Assert.True(SingleInstance.NewInstanceRequested(raw));
+    }
+
+    [Fact]
+    public void TheFlagIsRecognizedInAnyCase()
+    {
+        var raw = new[] { "PerformanceStudio.exe", "--NEW-INSTANCE" };
+
+        Assert.True(SingleInstance.NewInstanceRequested(raw));
+        Assert.Equal(new[] { "PerformanceStudio.exe" }, SingleInstance.StripNewInstanceFlag(raw));
+    }
+
+    /// <summary>
+    /// The overwhelmingly common argv has no flag in it, and scrubbing must be invisible
+    /// there — same contents, same order, nothing else filtered.
+    /// </summary>
+    [Fact]
+    public void ArgvWithoutTheFlagPassesThroughUntouched()
+    {
+        var raw = new[] { "PerformanceStudio.exe", @"C:\plans\slow.sqlplan" };
+
+        Assert.Equal(raw, SingleInstance.StripNewInstanceFlag(raw));
+        Assert.False(SingleInstance.NewInstanceRequested(raw));
+    }
+
+    /* ---- The window-side dispatch -------------------------------------------------- */
+
+    /// <summary>
+    /// What a bare second launch's sentinel actually buys the user: the running window
+    /// comes back from minimized. Activate() is also called but has nothing observable
+    /// headlessly; the state restore is the part that can silently regress.
+    /// </summary>
+    [Fact]
+    public void ASentinelDispatchRestoresAMinimizedWindow()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new MainWindow();
+            window.WindowState = WindowState.Minimized;
+
+            window.DispatchPipeMessage(
+                SingleInstance.PipeMessage.Activate, SingleInstance.ActivateSentinel);
+
+            Assert.Equal(WindowState.Normal, window.WindowState);
+        });
+    }
+
+    /// <summary>
+    /// The path every existing sender relies on — the SSMS extension and a second launch
+    /// handing over its file — still lands the file in a tab, and now also surfaces a
+    /// minimized window instead of loading into one that stays in the taskbar.
+    /// </summary>
+    [Fact]
+    public void AFileDispatchOpensTheFileAndRestoresAMinimizedWindow()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1 AS from_pipe;");
+            try
+            {
+                var window = new MainWindow();
+                window.WindowState = WindowState.Minimized;
+                var queryTabsBefore = QueryTabs(window).Count();
+
+                window.DispatchPipeMessage(SingleInstance.PipeMessage.OpenFile, path);
+
+                Assert.Equal(queryTabsBefore + 1, QueryTabs(window).Count());
+                Assert.Equal(path, ((QuerySessionControl)QueryTabs(window).Last().Content!).SourceFilePath);
+                Assert.Equal(WindowState.Normal, window.WindowState);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The end-to-end argv property, through the real startup router: the constructor
+    /// consumes raw <c>Environment.GetCommandLineArgs()</c>, so OpenFromStartupArgs must
+    /// scrub the flag itself — Program.Main's scrubbed copy never reaches it. With the
+    /// flag sitting where the file used to be, the file behind it still opens.
+    /// </summary>
+    [Fact]
+    public void OpenFromStartupArgsOpensTheFileBehindTheNewInstanceFlag()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1 AS behind_the_flag;");
+            try
+            {
+                var window = new MainWindow();
+                var queryTabsBefore = QueryTabs(window).Count();
+
+                window.OpenFromStartupArgs(new[] { "PerformanceStudio.exe", "--new-instance", path });
+
+                Assert.Equal(queryTabsBefore + 1, QueryTabs(window).Count());
+                Assert.Equal(path, ((QuerySessionControl)QueryTabs(window).Last().Content!).SourceFilePath);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    private static string TempSql(string text)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+        File.WriteAllText(path, text);
+        return path;
+    }
+
+    private static System.Collections.Generic.IEnumerable<TabItem> QueryTabs(MainWindow window) =>
+        window.MainTabControl.Items.OfType<TabItem>().Where(t => t.Content is QuerySessionControl);
+}

--- a/tests/PlanViewer.Core.Tests/SingleInstanceTests.cs
+++ b/tests/PlanViewer.Core.Tests/SingleInstanceTests.cs
@@ -71,16 +71,33 @@ public class SingleInstanceTests
     /// <summary>
     /// The entire backward-compatibility story of the sentinel, pinned: a pre-#489
     /// receiver's only guard is <c>File.Exists(line)</c>, so the sentinel is safe to send
-    /// to an old running build exactly as long as it can never name an existing file. The
-    /// double-colons are illegal in Windows file names by design; if someone ever
-    /// "tidies" the token into something path-representable, this fails and points here.
+    /// to an old running build exactly as long as it can never name an existing file.
+    ///
+    /// <para>Pinned as a STRING property, not with File.Exists — the gate review caught
+    /// that a File.Exists assertion is vacuous on the ubuntu CI runner, where ':' is a
+    /// legal filename character and the check only proves no such file sits in the test
+    /// CWD. What actually guarantees old-Windows-receiver safety is the colon, which
+    /// Windows rejects in file names; asserting the characters directly means "tidying"
+    /// the token into a path-representable word fails this test on every platform. An old
+    /// LINUX receiver next to an adversarially created "::activate::" file remains the
+    /// accepted floor (new receivers classify the sentinel before File.Exists, so only
+    /// pre-#489 builds are exposed, and only until they restart).</para>
     /// </summary>
     [Fact]
-    public void TheSentinelCanNeverBeMistakenForAFileByAnOldReceiver()
+    public void TheSentinelCanNeverBeMistakenForAFileByAnOldWindowsReceiver()
     {
-        Assert.False(
-            File.Exists(SingleInstance.ActivateSentinel),
-            "an old receiver File.Exists-guards every pipe line, so the sentinel must never resolve to a real file");
+        Assert.Contains(':', SingleInstance.ActivateSentinel);
+        Assert.StartsWith("::", SingleInstance.ActivateSentinel, StringComparison.Ordinal);
+        Assert.EndsWith("::", SingleInstance.ActivateSentinel, StringComparison.Ordinal);
+
+        /* Belt and braces for the platform where the guarantee lives: on Windows the
+           token must actually be rejected by the file-name rules, not just assumed to be. */
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Contains(
+                SingleInstance.ActivateSentinel,
+                c => Path.GetInvalidFileNameChars().Contains(c));
+        }
     }
 
     /* ---- StripNewInstanceFlag: argv scrubbing -------------------------------------- */

--- a/tests/PlanViewer.Core.Tests/SingleInstanceTests.cs
+++ b/tests/PlanViewer.Core.Tests/SingleInstanceTests.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.IO;
 using System.Linq;
 using Avalonia.Controls;
@@ -219,6 +220,34 @@ public class SingleInstanceTests
                 File.Delete(path);
             }
         });
+    }
+
+    /// <summary>
+    /// The named-mutex machinery itself, exercised on whatever platform the suite runs on.
+    ///
+    /// <para>The gate review's point: Program.Main's catch-all degrades a throwing mutex to
+    /// "run fully" — the right call, but if named mutexes ever break wholesale on a platform
+    /// (the Unix shim backs them with files under /tmp, and PlatformNotSupportedException is
+    /// the classic wholesale failure), single-instancing would silently no-op there and the
+    /// #489 clobber would be back with no symptom. This runs on the ubuntu CI runner on every
+    /// push, so a platform where creating or re-opening a named mutex throws fails HERE,
+    /// loudly, instead of degrading invisibly in the field. In-process rather than
+    /// cross-process (the harness cannot spawn app instances), which still traverses the
+    /// named create and second-open paths the shim has to serve; macOS has no CI leg, so the
+    /// one-time bare-double-launch smoke there is a release-checklist item, not a test.</para>
+    /// </summary>
+    [Fact]
+    public void NamedMutexMachineryWorksOnThisPlatform()
+    {
+        // A unique name per run: colliding with a real Studio instance on a dev machine
+        // (or a parallel test run) would turn this into a flake about unrelated state.
+        var name = $"{SingleInstance.MutexName}_selftest_{Guid.NewGuid():N}";
+
+        using var first = new Mutex(initiallyOwned: true, name, out var createdFirst);
+        Assert.True(createdFirst, "a fresh name must be created, not found");
+
+        using var second = new Mutex(initiallyOwned: true, name, out var createdSecond);
+        Assert.False(createdSecond, "a second open of the same name must see the existing mutex");
     }
 
     private static string TempSql(string text)


### PR DESCRIPTION
## What does this PR do?

Fixes #489.

A bare second launch ran a full second instance; both held whole-file AppSettings snapshots and Save writes the whole file, so whichever instance exited last silently clobbered the other's open_tabs and every other setting (AtomicFile prevents torn files, not lost updates). File-argument launches already forwarded over the pipe; the bare launch was exactly the clobber case.

- **Single-instance via named mutex** (default `Local\` scope, distinct from Lite's), acquired in Program.Main before Avalonia. The owner roots the handle in a static for the process lifetime — the commit documents the historical bug where a prior mutex attempt disposed its handle immediately and never actually held it. Mutex machinery failure degrades to pre-#489 full-launch behavior.
- **Version-skew-proof ordering**: the with-file pipe probe stays FIRST — a running pre-mutex build answers its pipe but holds no mutex, and mutex-first would boot a second window beside it instead of handing the file over.
- **Surfacing sentinel** `::activate::` on the existing pipe. Compatibility verified in both directions by reading the shipped handler: an old receiver's `File.Exists` guard drops the sentinel harmlessly (double-colons are illegal in Windows file names — pinned by a test), and the new receiver classifies the sentinel BEFORE `File.Exists` and handles plain paths exactly as today, so the SSMS extension is untouched.
- **`--new-instance` escape hatch** for deliberate second instances (informed last-write-wins), scrubbed both in Program.Main and inside `OpenFromStartupArgs` — MainWindow reads raw argv, so `--new-instance file.sqlplan` still opens the file.
- **Delivery over loss**: a non-owner that cannot reach the owner's pipe retries ~2s then runs fully — losing the user's double-clicked file (or the app appearing at all) is worse than a rare second instance. The residual two-simultaneous-bare-launches race is documented as the accepted floor.
- Classification runs on the pipe task, not the dispatcher, because a dead UNC path can block `File.Exists` for seconds.

## How was this tested?

Eleven new tests in `SingleInstanceTests` pinning the dispatch seam (sentinel activates, path opens, nonexistent path ignored), the sentinel's cannot-be-a-file property, and argv scrubbing driven through the real `OpenFromStartupArgs` router. The mutex/exit flow in Program.Main is process-level and verified by inspection (the harness boots App directly), with the reasoning in comments. Full suite: 456 tests, 455 passed, 1 platform skip, 0 failed; App builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvAv72Pwb8czsjDWsCCk7n
