### PR TITLE
Persist the session continuously so restore survives the exits it exists for

### DIFF
--- a/src/PlanViewer.App/MainWindow.FileOps.cs
+++ b/src/PlanViewer.App/MainWindow.FileOps.cs
@@ -188,6 +188,13 @@ public partial class MainWindow : Window
                UTF-8-without-BOM this always wrote. */
             AtomicFile.WriteAllText(path, session.QueryEditor.Text, session.SourceFileEncoding);
             session.SourceFilePath = path;
+            /* #490: the one way a tab's place in the session-restore list changes while tab
+               membership stays constant — a scratch gaining its first file, or Save As moving
+               an existing one. The tab watcher sees neither (no tab was added, removed, or
+               swapped), so the persist trigger lives at the assignment. Detached sessions save
+               through here too (tab == null); their register entry serves up the new path the
+               same way. */
+            RequestSessionPersist();
             // Only a write that actually happened settles the dirty state; the catch below
             // deliberately leaves the session modified so the work is still guarded.
             session.MarkClean();
@@ -461,12 +468,21 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
-    /// The file behind every open tab that has one, in tab order. Plans and queries both,
-    /// since <see cref="GetTabFilePath"/> answers for either shape.
+    /// The file behind every open tab that has one, in tab order, then the file behind every
+    /// detached window that has one, in detach order. Plans and queries both, since
+    /// <see cref="GetContentFilePath"/> answers for either shape.
     /// </summary>
     /// <remarks>
-    /// Separate from <see cref="SaveOpenPlans"/> so a test can assert what would be persisted
-    /// without writing over the user's real settings file.
+    /// <para>Separate from <see cref="SaveOpenPlans"/> so a test can assert what would be
+    /// persisted without writing over the user's real settings file.</para>
+    ///
+    /// <para>#490's detached half: this used to walk MainTabControl alone, so a file-backed
+    /// plan or query detached into its own window at exit was never written down and never
+    /// came back. Detached entries are appended AFTER the docked tabs — docked order is the
+    /// order the user arranged and keeps it; detach order is best-effort. On the next start
+    /// they all come back as ordinary docked tabs, not re-detached windows: remembering THAT
+    /// a file was open is the data-loss fix, remembering window geometry is a different
+    /// feature, deliberately not built here.</para>
     /// </remarks>
     internal List<string> CollectOpenTabPaths()
     {
@@ -481,11 +497,19 @@ public partial class MainWindow : Window
                 paths.Add(path);
         }
 
+        foreach (var content in _detachedTabContents)
+        {
+            var path = GetContentFilePath(content);
+            if (!string.IsNullOrEmpty(path))
+                paths.Add(path);
+        }
+
         return paths;
     }
 
     /// <summary>
-    /// Saves the file paths of all currently open file-based tabs, plans and queries alike.
+    /// Saves the file paths of all currently open file-based tabs, plans and queries alike,
+    /// docked and detached alike (#490).
     /// </summary>
     private void SaveOpenPlans()
     {
@@ -495,12 +519,95 @@ public partial class MainWindow : Window
         AppSettingsService.Save(_appSettings);
     }
 
+    // ── Continuous session persistence (#490) ─────────────────────────────
+
+    /* #468 wrote the list once, at clean close, and #490 is what that cost: any abnormal exit
+       — a crash, a task kill, an OS "shut down anyway" past the dirty-tab prompt — restored
+       zero tabs, because the only writer never ran. Membership changes now write the list as
+       they happen, debounced so a burst (session restore, Close All) lands as one write. The
+       triggers are wired centrally, not per call site — see the TabContentWatcher hookup in
+       the constructor for why. */
+
+    /// <summary>How long the writer waits for a burst of membership changes to settle.</summary>
+    private static readonly TimeSpan SessionPersistDebounce = TimeSpan.FromSeconds(1);
+
+    /// <summary>Trailing-edge debounce for <see cref="SaveOpenPlans"/>; every request restarts it.</summary>
+    private DispatcherTimer? _sessionPersistTimer;
+
+    /// <summary>
+    /// Whether a membership change is waiting to be written. Under the test host this flag is
+    /// the whole mechanism — see <see cref="RequestSessionPersist"/>.
+    /// </summary>
+    private bool _sessionPersistPending;
+
+    /// <summary>
+    /// Notes that tab membership changed — a tab opened, closed, detached, redocked, or gained
+    /// a file path — and schedules the debounced write. Called by the tab watcher for
+    /// everything visible on the strip, and explicitly by the detached register and
+    /// <see cref="SaveQueryToPath"/> for the two changes the strip cannot show.
+    /// </summary>
+    private void RequestSessionPersist()
+    {
+        /* OnClosed is already writing the final authoritative list (and force-closing the
+           detached windows, whose Forget calls land right back here). Nothing may re-arm the
+           timer against a window being torn down. */
+        if (IsShuttingDown)
+            return;
+
+        _sessionPersistPending = true;
+
+        /* No real timer under the test host, in #451's pattern: the suite shares one
+           dispatcher across every test, so a timer armed here would tick during some LATER
+           test's RunJobs and write THIS window's tab list over whatever that test had staged
+           in the redirected settings file — exactly the cross-test bleed the redirect exists
+           to stop. Tests drive the flush deterministically through
+           <see cref="FlushPendingSessionPersistForTests"/> instead. */
+        if (AppRuntimeMode.IsTestHost)
+            return;
+
+        if (_sessionPersistTimer == null)
+        {
+            _sessionPersistTimer = new DispatcherTimer { Interval = SessionPersistDebounce };
+            _sessionPersistTimer.Tick += (_, _) => FlushSessionPersist();
+        }
+
+        // Stop-then-start restarts the interval, which is what makes it a debounce.
+        _sessionPersistTimer.Stop();
+        _sessionPersistTimer.Start();
+    }
+
+    /// <summary>
+    /// Writes a pending membership change down now. The timer's tick, the end of
+    /// <see cref="RestoreOpenPlans"/>, and the test seam all land here; a flush with nothing
+    /// pending is free.
+    /// </summary>
+    private void FlushSessionPersist()
+    {
+        _sessionPersistTimer?.Stop();
+
+        if (!_sessionPersistPending || IsShuttingDown)
+            return;
+
+        _sessionPersistPending = false;
+        SaveOpenPlans();
+    }
+
+    /// <summary>
+    /// The deterministic stand-in for the debounce timer's tick — tests call this where the
+    /// real app waits out <see cref="SessionPersistDebounce"/>. A seam rather than a sleep
+    /// because the harness shares one dispatcher across the whole suite; see
+    /// <see cref="RequestSessionPersist"/> for what a real timer does to that arrangement.
+    /// </summary>
+    internal void FlushPendingSessionPersistForTests() => FlushSessionPersist();
+
     /// <summary>
     /// Writes the open-tab list down for the session that comes back after a Velopack
     /// restart. <see cref="OnClosed"/> does this on every ordinary shutdown, but
     /// ApplyUpdatesAndRestart exits the process without closing the window — and
     /// <see cref="RestoreOpenPlans"/> already cleared the saved list at startup, so without
-    /// this the updated app relaunched with nothing.
+    /// this the updated app relaunched with nothing. #490's continuous writer usually has the
+    /// list current by now anyway, but "usually" is a debounce interval wide; this write is
+    /// what makes the restart exact.
     /// </summary>
     internal void PersistSessionForRestart() => SaveOpenPlans();
 
@@ -511,12 +618,38 @@ public partial class MainWindow : Window
     /// <para>The saved list holds queries as well as plans, so it routes on extension the
     /// same way an ordinary file open does. Sending a .sql file to LoadPlanFile would greet
     /// the user with "the XML is not valid" where their query used to be.</para>
+    ///
+    /// <para><b>The crash-loop defense (#490).</b> The list is cleared and saved EMPTY before
+    /// the first file is opened, so a file that crashes the app during its own load is already
+    /// off the list when the next start reads it — a poisoned entry can never wedge the app
+    /// into crashing at every launch. (The clear used to run after the loop, which only
+    /// defended against crashes AFTER restore finished; a file that crashed DURING it left
+    /// the list intact and looped forever.) Every file that opens successfully re-enters the
+    /// list through the debounced writer, so the net behavior is strictly better than the old
+    /// all-or-nothing: the poison never persists, and everything that actually opened
+    /// does.</para>
+    ///
+    /// <para>Honestly, "everything that opened" holds for a crash after restore, not during
+    /// it. The re-adds are debounced and this loop runs synchronously on the UI thread, so a
+    /// crash while file B loads means file A's pending re-add never flushed and A is lost for
+    /// that start too. Accepted: the invariant being defended is that the poison never
+    /// persists, not that every good tab survives a mid-restore crash. The flush at the end
+    /// is the other half of the deal — once restore completes, the rebuilt list is on disk
+    /// immediately rather than a debounce-interval later, so the common case (restore fine,
+    /// crash any time afterwards) loses nothing.</para>
     /// </summary>
     private void RestoreOpenPlans()
     {
+        /* Snapshot first: SaveOpenPlans and this method share the live list, and the clear
+           below would otherwise empty the very thing being iterated. */
+        var savedTabs = _appSettings.OpenTabs.ToList();
+
+        _appSettings.OpenTabs.Clear();
+        AppSettingsService.Save(_appSettings);
+
         var restored = false;
 
-        foreach (var path in _appSettings.OpenTabs)
+        foreach (var path in savedTabs)
         {
             if (File.Exists(path))
             {
@@ -525,9 +658,9 @@ public partial class MainWindow : Window
             }
         }
 
-        // Clear the restored list now that its tabs are back on screen
-        _appSettings.OpenTabs.Clear();
-        AppSettingsService.Save(_appSettings);
+        /* Each successful open armed the debounced writer through the tab watcher; write it
+           down NOW so a crash a moment after startup still finds the session on disk. */
+        FlushSessionPersist();
 
         if (!restored)
         {

--- a/src/PlanViewer.App/MainWindow.Tabs.cs
+++ b/src/PlanViewer.App/MainWindow.Tabs.cs
@@ -224,10 +224,17 @@ public partial class MainWindow : Window
     /// session, and whether <b>Copy Path</b> appears on the tab's context menu. A shape it does
     /// not know about loses both without saying anything.</para>
     /// </summary>
-    private static string? GetTabFilePath(TabItem tab)
+    private static string? GetTabFilePath(TabItem tab) => GetContentFilePath(tab.Content as Control);
+
+    /// <summary>
+    /// The same answer keyed on the content itself, because since #490 the question is also
+    /// asked about content with no tab behind it: a detached window holds the control that WAS
+    /// a tab's content, and what file backs it is a fact about the control, not the strip.
+    /// </summary>
+    private static string? GetContentFilePath(Control? content)
     {
         // Plans opened from file are wrapped in a DockPanel with the viewer as the last child
-        if (tab.Content is DockPanel dp)
+        if (content is DockPanel dp)
         {
             foreach (var child in dp.Children)
             {
@@ -237,7 +244,7 @@ public partial class MainWindow : Window
         }
 
         // Queries are the session control itself, with no wrapper around it
-        if (tab.Content is QuerySessionControl session)
+        if (content is QuerySessionControl session)
             return session.SourceFilePath;
 
         return null;
@@ -347,7 +354,7 @@ public partial class MainWindow : Window
             backgroundBrush: (Avalonia.Media.IBrush?)this.FindResource("BackgroundBrush"),
             onRedock: c =>
             {
-                ForgetDetachedQuerySession(c);
+                ForgetDetachedTabContent(c);
 
                 if (!IsShuttingDown)
                 {
@@ -359,14 +366,14 @@ public partial class MainWindow : Window
             },
             onClosing: c =>
             {
-                ForgetDetachedQuerySession(c);
+                ForgetDetachedTabContent(c);
 
                 if (c is QueryStoreHistoryControl hc)
                     hc.CancelFetch();
             },
             closeGuard: DetachedQueryCloseGuard);
 
-        RememberDetachedQuerySession(detachedWindow, content);
+        RememberDetachedTabContent(detachedWindow, content);
 
         /* #447 made Compare a window-wide count, and this session just left the window: the
            count it is showing is about tabs it can no longer reach. Nothing else recomputes it

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -100,8 +100,22 @@ public partial class MainWindow : Window
 
            Watching content replacement as well as the collection is the part the first attempt at
            this got wrong: Get Actual Plan opens a tab holding a spinner and later swaps in the plan,
-           so the tab that gains a plan is one this window already had. */
-        TabContentWatcher.Watch(MainTabControl, RefreshComparePlanAvailability);
+           so the tab that gains a plan is one this window already had.
+
+           #490 hangs session persistence on the same watcher, for exactly the reason above: the
+           open-tab list used to be written only at clean close (#468's original scope), so any
+           abnormal exit — crash, task kill, an OS "shut down anyway" past the dirty-tab prompt —
+           restored zero tabs. Requesting a persist at each place that opens or closes a tab is
+           the same sixteen-call-sites trap #447 named; the watcher is the one place that sees
+           them all. The two changes it cannot see get explicit calls instead: detached windows
+           (off the tab strip — see RememberDetachedTabContent / ForgetDetachedTabContent) and a
+           tab whose PATH changes while its membership does not (SaveQueryToPath, where a scratch
+           gains a file). */
+        TabContentWatcher.Watch(MainTabControl, () =>
+        {
+            RefreshComparePlanAvailability();
+            RequestSessionPersist();
+        });
 
         // Global hotkeys via tunnel routing so they fire before AvaloniaEdit consumes them
         AddHandler(KeyDownEvent, (_, e) =>
@@ -272,7 +286,16 @@ public partial class MainWindow : Window
         {
             IsShuttingDown = true;
 
-            // Save the list of currently open file-based plans for session restore
+            /* The debounced writer (#490) is finished: stop its timer so a pending tick cannot
+               fire into a window being torn down, and let the write below be the last word.
+               It stays the authoritative final write — mostly redundant now that membership
+               changes persist continuously, but it covers anything the debounce had not flushed
+               yet, and it runs while the detached windows below are still open and registered,
+               so their paths are in it. */
+            _sessionPersistTimer?.Stop();
+            _sessionPersistPending = false;
+
+            // Save the list of currently open file-based tabs for session restore
             SaveOpenPlans();
 
             _pipeCts.Cancel();
@@ -371,16 +394,56 @@ public partial class MainWindow : Window
     internal IReadOnlyList<(Window Window, QuerySessionControl Session)> DetachedQuerySessions =>
         _detachedQuerySessions;
 
-    internal void RememberDetachedQuerySession(Window window, Control content)
+    /// <summary>
+    /// EVERY top-level tab content currently detached, in detach order — plans and Query Store
+    /// windows included, not just the query sessions above.
+    ///
+    /// <para>#490's second register, kept next to #473's because they answer different
+    /// questions. The prompt register above only cares about content that can lose an edit;
+    /// session persistence cares about content that came from a FILE, and a detached plan is
+    /// exactly that — file-backed, read-only, and invisible to a save list built by walking
+    /// MainTabControl. Sub-tab detaches (a plan torn out of a query session's sub-tab strip)
+    /// stay off both registers on purpose: their session's own tab is still docked and already
+    /// carries the path.</para>
+    /// </summary>
+    private readonly List<Control> _detachedTabContents = new();
+
+    /// <summary>
+    /// Books a detached top-level tab's content into both registers. Named for the content
+    /// rather than the session since #490: persistence needs every detached tab remembered,
+    /// and only the #473 prompt half is query-session-only.
+    /// </summary>
+    internal void RememberDetachedTabContent(Window window, Control content)
     {
+        _detachedTabContents.Add(content);
+
         if (content is QuerySessionControl session)
             _detachedQuerySessions.Add((window, session));
+
+        /* This register is half of what CollectOpenTabPaths reads (the tab strip is the other
+           half), so a change to it is a membership change the tab watcher cannot see. Detach
+           itself also removed a tab — the watcher fired — but by the time the debounced write
+           flushes, this entry exists; the debounce is quietly doing ordering work here, since
+           a synchronous write at the watcher's moment would have landed in the gap between
+           Items.Remove and this call and dropped the detached file. */
+        RequestSessionPersist();
     }
 
-    internal void ForgetDetachedQuerySession(Control content)
+    /// <summary>
+    /// Takes a detached tab's content back off both registers — on redock, and on the detached
+    /// window actually closing.
+    /// </summary>
+    internal void ForgetDetachedTabContent(Control content)
     {
+        _detachedTabContents.Remove(content);
+
         if (content is QuerySessionControl session)
             _detachedQuerySessions.RemoveAll(d => d.Session == session);
+
+        /* Redock re-adds a tab and the watcher sees that; a detached window closed by its own
+           X changes no tab at all, and this is the only place that knows the file left the
+           app. One debounced write covers both. */
+        RequestSessionPersist();
     }
 
     /// <summary>

--- a/tests/PlanViewer.Core.Tests/RestoreQueryTabsTests.cs
+++ b/tests/PlanViewer.Core.Tests/RestoreQueryTabsTests.cs
@@ -85,6 +85,7 @@ public class RestoreQueryTabsTests
             }
             finally
             {
+                Unseed();
                 File.Delete(path);
             }
         });
@@ -100,12 +101,21 @@ public class RestoreQueryTabsTests
         HeadlessUi.Run(() =>
         {
             var path = Path.Combine(System.AppContext.BaseDirectory, "Plans", "row_goal_plan.sqlplan");
-            Seed(path);
+            try
+            {
+                Seed(path);
 
-            var window = new MainWindow();
+                var window = new MainWindow();
 
-            Assert.Contains(path, window.CollectOpenTabPaths());
-            Assert.Contains(Viewers(window), v => v.SourceFilePath == path);
+                Assert.Contains(path, window.CollectOpenTabPaths());
+                Assert.Contains(Viewers(window), v => v.SourceFilePath == path);
+            }
+            finally
+            {
+                /* This one seeds a fixture that is never deleted, so without the unseed every
+                   later MainWindow in the run would restore a phantom plan tab. */
+                Unseed();
+            }
         });
     }
 
@@ -192,14 +202,25 @@ public class RestoreQueryTabsTests
 
     /// <summary>
     /// Puts one path where the next MainWindow will look for the previous session's tabs.
-    /// Load returns the process-wide cached instance, which is the same object the window reads,
-    /// and restore clears it again on the way out — so this does not leak into other tests.
+    /// Load returns the process-wide cached instance, which is the same object the window reads.
+    /// Since #490, restore REWRITES the list with whatever it successfully opened — that is the
+    /// crash-safety — so a seeding test has to blank the list again on its way out
+    /// (<see cref="Unseed"/>) or the next MainWindow constructed anywhere in the run restores
+    /// this test's file.
     /// </summary>
     private static void Seed(string path)
     {
         var settings = AppSettingsService.Load();
         settings.OpenTabs.Clear();
         settings.OpenTabs.Add(path);
+    }
+
+    /// <summary>The other half of <see cref="Seed"/>, for a finally block.</summary>
+    private static void Unseed()
+    {
+        var settings = AppSettingsService.Load();
+        settings.OpenTabs.Clear();
+        AppSettingsService.Save(settings);
     }
 
     private static MenuItem ContextMenuItem(TabItem tab, string header) =>

--- a/tests/PlanViewer.Core.Tests/SessionPersistenceTests.cs
+++ b/tests/PlanViewer.Core.Tests/SessionPersistenceTests.cs
@@ -1,0 +1,370 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using PlanViewer.App;
+using PlanViewer.App.Controls;
+using PlanViewer.App.Services;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #490: session restore knew only what a clean close wrote down. The list was written once,
+/// in OnClosed, so a crash, a task kill, or an OS "shut down anyway" restored zero tabs; and
+/// the writer walked MainTabControl alone, so a file detached into its own window was never
+/// written down at all. Membership changes now persist continuously (debounced), and detached
+/// windows are part of the collected set.
+///
+/// <para>Every assertion here reads the settings FILE, not the in-memory list — the whole
+/// point of continuous persistence is what is on disk when the process dies without warning,
+/// so the disk is what gets checked. The file is the redirected per-run one (#451), which is
+/// what makes asserting real writes safe. The debounce is driven through
+/// <see cref="MainWindow.FlushPendingSessionPersistForTests"/> rather than waited out: the
+/// harness shares one dispatcher across the suite, so a real one-second timer would tick
+/// during some unrelated later test — see RequestSessionPersist for the full story.</para>
+///
+/// <para>Tests that leave real paths in the persisted list blank it on the way out
+/// (<see cref="ResetPersistedState"/>, same hygiene as UpdateRestartGuardTests), because the
+/// next MainWindow constructed anywhere in the run restores whatever it finds there.</para>
+/// </summary>
+public class SessionPersistenceTests
+{
+    [Fact]
+    public void OpeningATabIsPersistedWithoutClosingTheApp()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1 AS persisted_live;");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                /* The open armed the debounced writer through the tab watcher; the seam
+                   stands in for the timer's tick. Before #490 nothing short of closing the
+                   app wrote this down. */
+                window.FlushPendingSessionPersistForTests();
+
+                Assert.Contains(path, PersistedOpenTabs());
+            }
+            finally
+            {
+                ResetPersistedState();
+                File.Delete(path);
+            }
+        });
+    }
+
+    [Fact]
+    public void ClosingATabRemovesItFromThePersistedList()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var stays = TempSql("SELECT 1 AS stays;");
+            var goes = TempSql("SELECT 2 AS goes;");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(stays);
+                window.LoadSqlFile(goes);
+                window.FlushPendingSessionPersistForTests();
+                Assert.Contains(goes, PersistedOpenTabs());
+
+                /* Through the real close button, not Items.Remove, so the whole path is the
+                   one a user takes. The session is clean, so no prompt holds the close. */
+                CloseButton(QueryTab(window, goes)).RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                Dispatcher.UIThread.RunJobs();
+
+                window.FlushPendingSessionPersistForTests();
+
+                var persisted = PersistedOpenTabs();
+                Assert.DoesNotContain(goes, persisted);
+                Assert.Contains(stays, persisted);
+            }
+            finally
+            {
+                ResetPersistedState();
+                File.Delete(stays);
+                File.Delete(goes);
+            }
+        });
+    }
+
+    [Fact]
+    public void ADetachedQueryStaysOnThePersistedListAndRedockKeepsIt()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1 AS detached;");
+            Window? detached = null;
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                detached = window.DetachTabToWindow(QueryTab(window, path))!;
+                window.FlushPendingSessionPersistForTests();
+
+                /* The first gap #490 names: off the tab strip is not out of the app. Before
+                   this, detaching a file was indistinguishable from closing it as far as the
+                   next session was concerned. */
+                Assert.Contains(path, PersistedOpenTabs());
+
+                RedockButton(detached).RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                Dispatcher.UIThread.RunJobs();
+                window.FlushPendingSessionPersistForTests();
+
+                /* And exactly once — redock has to move the entry back to the docked half of
+                   the collection, not leave a stale twin on the detached half. */
+                Assert.Single(PersistedOpenTabs(), p => p == path);
+            }
+            finally
+            {
+                PutAway(detached);
+                ResetPersistedState();
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The register #473 built for unsaved-changes prompts is query-sessions-only, because
+    /// only an edit can be lost. Persistence needs every FILE-backed detached window, and a
+    /// detached plan is exactly the read-only case that register ignores — which is why #490
+    /// keeps its own register instead of borrowing that one.
+    /// </summary>
+    [Fact]
+    public void ADetachedPlanIsPersistedToo()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = Path.Combine(System.AppContext.BaseDirectory, "Plans", "row_goal_plan.sqlplan");
+            Window? detached = null;
+            try
+            {
+                var window = new MainWindow();
+                window.LoadPlanFile(path);
+
+                var planTab = window.MainTabControl.Items.OfType<TabItem>()
+                    .Last(t => t.Content is DockPanel);
+                detached = window.DetachTabToWindow(planTab)!;
+                window.FlushPendingSessionPersistForTests();
+
+                Assert.Contains(path, PersistedOpenTabs());
+            }
+            finally
+            {
+                PutAway(detached);
+                ResetPersistedState();
+            }
+        });
+    }
+
+    [Fact]
+    public void ClosingADetachedWindowTakesItsFileOffThePersistedList()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1 AS closed_detached;");
+            Window? detached = null;
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                detached = window.DetachTabToWindow(QueryTab(window, path))!;
+                window.FlushPendingSessionPersistForTests();
+                Assert.Contains(path, PersistedOpenTabs());
+
+                /* A detached window closing changes nothing on the tab strip, so this is the
+                   one leave-the-app path the tab watcher cannot see — the trigger rides on the
+                   detached register instead. Clean session, so the close guard waves it
+                   through on the first pass. */
+                detached.Close();
+                Dispatcher.UIThread.RunJobs();
+                window.FlushPendingSessionPersistForTests();
+
+                Assert.DoesNotContain(path, PersistedOpenTabs());
+            }
+            finally
+            {
+                PutAway(detached);
+                ResetPersistedState();
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// A scratch buffer joins the list the moment it becomes a file. Tab membership never
+    /// changes across a save, so this is the trigger that lives at SaveQueryToPath rather
+    /// than on the watcher.
+    /// </summary>
+    [Fact]
+    public void AScratchGainingAFileJoinsThePersistedList()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var savedAs = Path.Combine(Path.GetTempPath(), $"saved_{Path.GetRandomFileName()}.sql");
+            try
+            {
+                var window = new MainWindow();
+                window.NewQuery_Click(window, new RoutedEventArgs());
+
+                var tab = window.MainTabControl.Items.OfType<TabItem>()
+                    .Last(t => t.Content is QuerySessionControl);
+                var session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 1 AS first_save;";
+
+                window.FlushPendingSessionPersistForTests();
+                Assert.DoesNotContain(savedAs, PersistedOpenTabs());
+
+                Assert.True(window.SaveQueryToPath(tab, session, savedAs));
+                window.FlushPendingSessionPersistForTests();
+
+                Assert.Contains(savedAs, PersistedOpenTabs());
+            }
+            finally
+            {
+                ResetPersistedState();
+                if (File.Exists(savedAs))
+                    File.Delete(savedAs);
+            }
+        });
+    }
+
+    [Fact]
+    public void RestoreWritesTheRestoredTabsBackImmediately()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1 AS restored_and_kept;");
+            try
+            {
+                Seed(path);
+                var window = new MainWindow();
+
+                /* No flush call here, deliberately: RestoreOpenPlans flushes synchronously at
+                   its own end, so that a crash a moment after startup still finds the session
+                   on disk instead of an empty list waiting out a debounce. Reading the file
+                   straight after the constructor IS the assertion. */
+                Assert.Contains(path, PersistedOpenTabs());
+            }
+            finally
+            {
+                ResetPersistedState();
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The crash-loop invariant. Restore clears the saved list before the first open, and only
+    /// a file that actually opened re-enters it — so a file that fails during restore has, by
+    /// construction, not re-added itself. A file that CRASHES the process mid-load is the same
+    /// case with a bigger bang: it dies before its own re-add, so the next start does not retry
+    /// it. (A test cannot crash its own process to prove that literally; failing to open walks
+    /// the identical path — cleared first, never re-added.)
+    /// </summary>
+    [Fact]
+    public void AFileThatFailsToOpenDuringRestoreStaysOffThePersistedList()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var good = TempSql("SELECT 1 AS survivor;");
+            var poison = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sqlplan");
+            /* Exists (so restore attempts it) but is not a plan, so the open fails and no tab
+               is created. The startup error dialog it raises is ownerless and left behind, the
+               same way ShowErrorBeforeVisibleTests leaves theirs. */
+            File.WriteAllText(poison, "<NotAPlan/>");
+            try
+            {
+                Seed(good, poison);
+                var window = new MainWindow();
+
+                var persisted = PersistedOpenTabs();
+                Assert.Contains(good, persisted);
+                Assert.DoesNotContain(poison, persisted);
+            }
+            finally
+            {
+                ResetPersistedState();
+                File.Delete(good);
+                File.Delete(poison);
+            }
+        });
+    }
+
+    // ── plumbing ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// What is actually on disk, read back through the same serializer the app writes with.
+    /// The redirected file (#451) makes this safe to hit for real.
+    /// </summary>
+    private static List<string> PersistedOpenTabs()
+    {
+        var json = File.ReadAllText(AppSettingsService.SettingsFilePath);
+        return JsonSerializer.Deserialize<AppSettings>(json)!.OpenTabs;
+    }
+
+    /// <summary>
+    /// Stages paths where the next MainWindow will look for the previous session's tabs —
+    /// same mechanism as RestoreQueryTabsTests.Seed: Load returns the process-wide cached
+    /// instance, which is the very object the window reads.
+    /// </summary>
+    private static void Seed(params string[] paths)
+    {
+        var settings = AppSettingsService.Load();
+        settings.OpenTabs.Clear();
+        settings.OpenTabs.AddRange(paths);
+    }
+
+    /// <summary>
+    /// Leaves nothing persisted for the next test's MainWindow to restore. Cache and file
+    /// both, since restore reads the former and these tests assert the latter.
+    /// </summary>
+    private static void ResetPersistedState()
+    {
+        var settings = AppSettingsService.Load();
+        settings.OpenTabs.Clear();
+        AppSettingsService.Save(settings);
+    }
+
+    /// <summary>
+    /// Same job as DetachedUnsavedChangesTests.PutAway: a leaked window outlives its test and
+    /// poisons the shared session (#474), so closure lives in a finally. Sessions here are
+    /// clean, so no prompt ever holds the close.
+    /// </summary>
+    private static void PutAway(Window? detached)
+    {
+        if (detached == null)
+            return;
+
+        foreach (var prompt in detached.OwnedWindows.ToList())
+            prompt.Close();
+
+        detached.Close();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static TabItem QueryTab(MainWindow window, string path) =>
+        window.MainTabControl.Items.OfType<TabItem>()
+            .Single(t => t.Content is QuerySessionControl s && s.SourceFilePath == path);
+
+    private static Button CloseButton(TabItem tab) =>
+        ((StackPanel)tab.Header!).Children.OfType<Button>().Single();
+
+    private static Button RedockButton(Window detached) =>
+        ((DockPanel)detached.Content!).Children.OfType<StackPanel>().Single()
+            .Children.OfType<Button>().Single();
+
+    private static string TempSql(string text)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+        File.WriteAllText(path, text);
+        return path;
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes #490.

Session restore had two gaps: a file-backed tab detached into its own window at exit was never persisted, and the open-tab list was written only at clean close — any abnormal exit (crash, task kill, OS "shut down anyway" past the dirty-tab prompt) restored zero tabs. Restore protection evaporated exactly when it was needed.

- **Continuous, debounced persistence.** Membership changes write the list as they happen (1s trailing-edge debounce so a burst lands as one write, via the existing `AtomicFile` path). The trigger hangs on #481's `TabContentWatcher` — the one subscription that sees every open/close/restore/redock/content-swap, per that PR's own sixteen-call-sites rationale — plus exactly three explicit calls for what the strip cannot show: detach registration, detached-window close, and a tab gaining its first file path in `SaveQueryToPath`. The debounce also quietly does ordering work: a synchronous write at the watcher's moment would land in the gap between `Items.Remove` and the detached-register add and drop the detached file.
- **Crash-loop defense preserved and strengthened.** `RestoreOpenPlans` still clears the list — but now BEFORE the first open rather than after the loop, which closes a pre-existing hole: the old ordering meant a crash *during* restore left the poisoned list intact and looped forever. Each successfully opened tab re-enters via the watcher, and restore ends with a synchronous flush. Net invariant, tested: a file that crashes (or fails) during load never persists; every tab that opened successfully does. A crash mid-restore can lose earlier good tabs for that one start — stated in the doc comment as the accepted cost; the invariant is poison-never-persists.
- **Detached windows join persistence** via a second register beside #473's prompt-only one (that one is query-only by design; persistence needs detached *plans* too). Detached paths append after docked tabs; on the next start they return as ordinary docked tabs — remembering THAT a file was open is the data-loss fix, window geometry is a different feature, deliberately not built.
- **Test-host discipline (#451/#487 pattern):** no real `DispatcherTimer` under the harness — the suite shares one dispatcher, and a live timer would tick during a later test and clobber its staged settings. Tests drive an internal flush seam and assert the redirected settings *file*, not memory.
- Scratch-buffer *content* persistence remains deliberately out of scope (tracked separately).

## How was this tested?

Eight new tests in `SessionPersistenceTests` plus `RestoreQueryTabsTests` updates: open-persists-without-close, close-removes, detached query/plan persisted with redock-exactly-once and detached-close-removes, post-restore immediate repopulation, the poison-exclusion invariant (a well-formed-but-invalid .sqlplan fails restore and is absent while the good file persists), and scratch-gains-file-joins-list. Existing tests whose "restore does not leak" assumption the new rewrite invalidated were fixed with proper seeding/cleanup rather than weakened. Full suite: 453 tests, 452 passed, 1 platform skip, 0 failed — in the worktree and again in the main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvAv72Pwb8czsjDWsCCk7n
