### PR TITLE
Release v1.24.0

### DIFF
--- a/.claude/skills/maintenance/SKILL.md
+++ b/.claude/skills/maintenance/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: maintenance
+description: Quarterly maintenance pass (every 1-3 months) — dependency/security audit, build health, and repo hygiene for PerformanceMonitor and PerformanceStudio
+argument-hint: [optional: deps | build | all]
+disable-model-invocation: false
+---
+
+# Routine Maintenance Pass
+
+A repeatable every-1-3-months health check for the .NET desktop + SQL-monitoring repos
+(PerformanceMonitor = WPF, PerformanceStudio = Avalonia; same dependency/build/release shape).
+`$ARGUMENTS` optionally scopes it (`deps`, `build`, or `all` — default `all`).
+
+Work top to bottom. Do read-only scans first and report findings; make fixes on a feature
+branch/worktree (branch protection: never commit to `dev`/`main`), build + test, then PR to `dev`.
+Low-risk patch/minor bumps can go in one PR; majors and anything release-critical get their own.
+
+## A. Dependencies & Security
+
+> **Scope — scan every project, not just the solution.** A repo's `.sln` may not list every project. PerformanceStudio's `PlanViewer.sln` omits `server/PlanShare.csproj` and the SSMS VSIX (`PlanViewer.Ssms`, `PlanViewer.Ssms.Installer`), so the `dotnet list <Solution>.sln …` scans and the solution build all silently skip them. Run the checks against those projects too. The net472 VSIX is old-style, so `dotnet list` is unreliable on it — read its `<PackageReference>`s by hand (its `Microsoft.VSSDK.BuildTools` is intentionally held on the 17.x line; 18.x is un-restorable from nuget.org and targets VS 18, not VS 2022). Where the `.sln` covers all projects, the solution is enough.
+
+1. **Outdated packages.** `dotnet list <Solution>.sln package --outdated`
+   - Take low-risk **patch/minor** bumps (Microsoft.Extensions.*, Test.Sdk, etc.).
+   - **Majors get their own effort** — especially the update framework (Velopack: bump the library AND the `vpk` CLI pin in the release workflow — `.github/workflows/release.yml` for PerformanceStudio — together; validate the in-app + Setup.exe update path) and anything release-critical.
+   - **Engine-wrapped bindings** (e.g. DuckDB.NET) trail the native engine — bump when the binding catches up, and validate behavior (for DuckDB run `tools/CompactionRepro` re: the parquet-COPY memory-limit floor before changing the version).
+   - After version edits, **if the repo uses lock files** (`packages.lock.json` — PerformanceMonitor does; PerformanceStudio does not), regenerate them: `dotnet restore <Solution>.sln --force-evaluate` (CI restores `--locked-mode`).
+
+2. **Vulnerable packages (security).** `dotnet list <Solution>.sln package --vulnerable --include-transitive`
+   - Must be **zero**. Any hit (incl. transitive) is urgent — bump or pin to a fixed version. This catches CVEs the `--outdated` check does not.
+   - **Code-level pass, not just packages:** run the `security-review` skill/agent on the diff since the last maintenance pass. These apps have real attack surface beyond their dependencies — PerformanceStudio's MCP server opens a local network listener, both store DB credentials (Windows Credential Manager), and both parse untrusted input (e.g. execution-plan XML). Triage anything it flags.
+     - **Calibrate severity to the deployment.** PerformanceStudio runs on a single-user personal laptop, and its MCP tools are strictly read-only (no arbitrary SQL, no writes/config changes). So loopback-bound / opt-in / local-IPC findings — the MCP listener, the named-pipe single-instance server — are **Low/informational here, not High**: there's no other local user or attacker to exploit them, and read-only tools can at most leak data they already return. Reserve High for *remotely reachable* vectors (e.g. a missing `Host`/`Origin` check that allows DNS rebinding) or credential disclosure. This calibration would change only if Studio shipped the MCP server enabled-by-default or ran on a shared/multi-user host. Don't re-raise the same local-IPC findings at High each pass.
+
+3. **Deprecated packages.** `dotnet list <Solution>.sln package --deprecated` — replace anything abandoned.
+
+4. **Framework / runtime currency.** Confirm the TFM is on a **supported, released** .NET (do NOT move to a preview). Take the latest servicing patch of the current major. WPF/Avalonia track the runtime/their own NuGet — check both.
+
+5. **CI tool & action pins.** In `.github/workflows/*.yml`: confirm `uses:` actions are on current majors, and that any `dotnet tool install` is **version-pinned to match its library** (e.g. `vpk --version` must equal the Velopack PackageReference). Bump GitHub Actions that are behind / deprecated.
+
+6. **Dependabot (optional — not a finding).** Two separate features: *security alerts* (passive CVE notifications that close the gap between manual `--vulnerable` passes — mild value) and *version-update PRs* (automated bump PRs — redundant and noisy once you do periodic manual sweeps). For PerformanceStudio, Erik relies on the manual passes; treat Dependabot as **optional and do not report it as a finding**. If alerts are ever wanted they're a one-toggle enable (repo Settings → Code security, no config file); the version-update PRs aren't wanted.
+
+## B. Code & Build Health
+
+7. **Zero-warning build.** Build the whole solution and capture warnings — the standard is **0**:
+   ```
+   dotnet build <Solution>.sln -c Debug --nologo 2>&1 | Select-String ": warning "
+   ```
+   - Kill the running app(s) first OR build in a worktree — a running Dashboard/Lite/Studio locks its `bin` DLLs (MSB3021). Note: an incremental no-op build emits no warnings; force a clean compile of any project you're checking.
+   - Fix each warning honestly (don't add to `NoWarn` to silence). Remove dead code (e.g. an unused test seam → CS0649).
+
+8. **NoWarn review.** Scan each csproj `<NoWarn>`: every suppressed rule should have a reason (these repos keep inline comments). Remove suppressions that no longer fire; don't let the list grow silently. Most existing CA suppressions are intentional high-count ones — leave those.
+
+9. **Stale markers.** `grep -rE "\b(TODO|FIXME|HACK|XXX)\b" --include=*.cs` — resolve or file an issue; a `// TODO: restore to X` next to a non-X value may mean the comment is the leftover (ask before flipping).
+
+10. **Git repo hygiene.**
+    - **Line endings / `.gitattributes`.** If the repo has no `.gitattributes`, line endings drift (CRLF/LF mixed, `core.autocrlf=false`) and bulk edits balloon diffs. Add one and run a **dedicated** `git add --renormalize .` commit (its own PR, when no other work is in flight — it touches nearly every file).
+    - **Stale branches & worktrees.** `git worktree list` — remove leftover worktrees (anything under `.claude/worktrees/` or other agent/isolation worktrees) with `git worktree remove`. Then `git fetch --prune` to drop stale remote-tracking refs, and audit: `git branch --merged origin/dev` (local branches already in dev — safe to delete) and `git branch -r` (remote branches from closed/merged PRs). Delete merged/dead branches; **keep intentionally-parked ones** (note which and why — e.g. a blocked-upgrade branch like `upgrade/avalonia-12`). For branches *you didn't create*, surface and confirm before deleting rather than assuming abandoned. Confirm open PRs are still wanted.
+
+## C. App data & runtime hygiene (lighter)
+
+11. **Retention / archive end-to-end.** Confirm the app's data retention/purge and (Lite) parquet archiving actually prune old data, and logs rotate. A new time-series table must be registered for retention/archive or it grows forever.
+
+12. **Perf regression spot-check.** Re-run the UI-latency-under-load harness if available; watch known hot spots (e.g. the Lite Blocking tab render hitch). Quick collector-health pass.
+
+## D. Release & platform currency (lighter)
+
+13. **Release infra freshness.** Test servers online/patched; signing cert (SignPath) not near expiry; cloud creds (`az`/`aws`) valid; the `release-checklist` skill still accurate.
+    - **Cross-platform publish smoke.** `dotnet publish` the desktop app for the non-Windows runtimes it ships (PerformanceStudio: `linux-x64`, `osx-arm64`/`osx-x64`) and confirm each still produces a runnable app. The Avalonia/SkiaSharp native pins are fragile — the Linux `SkiaSharp.NativeAssets.Linux` pin exists to guard GitHub issue #139 — and a Windows-only build won't catch a broken Linux/macOS runtime.
+
+14. **SQL Server / cloud drift + bundled tools.** New SQL Server CU/version, new DMVs/columns, Azure SQL DB / RDS changes (cloud collector paths have a bug history); refresh bundled community procs (sp_WhoIsActive, sp_BlitzLock, sp_HealthParser, sp_HumanEventsBlockViewer).
+
+## Output
+
+Report per section: ✅ clean / ⚠️ findings (with the fix made or recommended). Group merged PRs and
+"parked" items (e.g. a major bump deferred) so the next pass knows where things stand.

--- a/.gitignore
+++ b/.gitignore
@@ -424,5 +424,6 @@ FodyWeavers.xsd
 
 # Internal development files (not for public release)
 .internal/
-.claude/
+.claude/*
+!.claude/skills/
 CLAUDE.md

--- a/server/PlanShare/Program.cs
+++ b/server/PlanShare/Program.cs
@@ -105,6 +105,16 @@ app.UseCors();
 
 const int MaxTtlDays = 365;
 
+// Depth ceiling for parsing an uploaded share, mirroring PlanViewer.Core's
+// AnalysisJson.MaxDepth — that class is the source of truth for how deep a serialized
+// AnalysisResult can go (#431: an operator costs two JSON levels, so the JsonDocument
+// default of 64 rejects a plan ~30 operators deep as "Invalid JSON" after the client
+// happily serialized it at 1024). Mirrored rather than referenced because this project
+// deliberately takes no dependency on PlanViewer.Core, and a shared constant only helps
+// call sites that reference it; this one cannot. If AnalysisJson.MaxDepth ever changes,
+// change this with it — the client-side depth tests pin 1024, so start there.
+var shareDocumentOptions = new JsonDocumentOptions { MaxDepth = 1024 };
+
 // --- Endpoints ---
 
 app.MapGet("/health", () => Results.Content("OK", "text/plain"));
@@ -127,11 +137,13 @@ app.MapPost("/api/share", async (HttpContext ctx) =>
         return Results.BadRequest("Empty body");
     }
 
-    // Parse and extract ttl_days from the JSON
+    // Parse and extract ttl_days from the JSON. shareDocumentOptions, not defaults: this body
+    // wraps a full serialized analysis, and the default 64-level ceiling turned a deep plan's
+    // legitimate upload into a 400 before ttl_days was ever read.
     int ttlDays = 7;
     try
     {
-        using var doc = JsonDocument.Parse(body);
+        using var doc = JsonDocument.Parse(body, shareDocumentOptions);
         if (doc.RootElement.TryGetProperty("ttl_days", out var ttlProp) && ttlProp.TryGetInt32(out var t))
             ttlDays = Math.Clamp(t, 1, MaxTtlDays);
     }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
     Tests and server/ projects are outside src/ and are unaffected.
   -->
   <PropertyGroup>
-    <Version>1.23.0</Version>
+    <Version>1.24.0</Version>
     <Authors>Erik Darling</Authors>
     <Company>Darling Data LLC</Company>
     <Product>Performance Studio</Product>

--- a/src/PlanViewer.App/AboutWindow.axaml.cs
+++ b/src/PlanViewer.App/AboutWindow.axaml.cs
@@ -231,6 +231,23 @@ public partial class AboutWindow : Window
 
             if (result)
             {
+                /* ApplyUpdatesAndRestart kills the process outright: MainWindow.OnClosing
+                   never fires, so the unsaved-changes walk (#462/#473) never ran on this
+                   route and dirty edits were discarded without a question — and OnClosed's
+                   session save never ran either, so the relaunched app restored nothing
+                   (RestoreOpenPlans had already cleared the saved list at startup). Ask the
+                   same questions the close path asks, and if anyone answers Cancel, abort
+                   the restart and leave this window usable — the update stays downloaded. */
+                if (Owner is MainWindow main)
+                {
+                    if (!await main.ConfirmAllUnsavedWorkAsync())
+                        return;
+
+                    /* After the walk, not before: a Save answer in the walk can give a
+                       scratch tab a file, which this then writes down for the restore. */
+                    main.PersistSessionForRestart();
+                }
+
                 _velopackMgr.ApplyUpdatesAndRestart(_velopackUpdate.TargetFullRelease);
             }
             return;

--- a/src/PlanViewer.App/AboutWindow.axaml.cs
+++ b/src/PlanViewer.App/AboutWindow.axaml.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using Avalonia.Controls;
@@ -188,7 +189,28 @@ public partial class AboutWindow : Window
 
     private bool _updateDownloaded;
 
+    /* Every branch of UpdateLink_Click awaits — a dialog, the unsaved-work walk, a download —
+       and the link stays clickable the whole time, so a second click would start a second
+       concurrent copy of whichever step is in flight (two restart dialogs, two walks prompting
+       about the same tabs, two downloads). One latch at the top covers all of them. */
+    private bool _updateActionInFlight;
+
     private async void UpdateLink_Click(object? sender, PointerPressedEventArgs e)
+    {
+        if (_updateActionInFlight)
+            return;
+        _updateActionInFlight = true;
+        try
+        {
+            await HandleUpdateLinkClickAsync();
+        }
+        finally
+        {
+            _updateActionInFlight = false;
+        }
+    }
+
+    private async Task HandleUpdateLinkClickAsync()
     {
         // Step 3: User clicks "Restart now" after download — confirm first
         if (_updateDownloaded && _velopackMgr != null && _velopackUpdate != null)
@@ -238,7 +260,17 @@ public partial class AboutWindow : Window
                    (RestoreOpenPlans had already cleared the saved list at startup). Ask the
                    same questions the close path asks, and if anyone answers Cancel, abort
                    the restart and leave this window usable — the update stays downloaded. */
-                if (Owner is MainWindow main)
+                /* Resolved through the application lifetime, not Owner: an Owner-typed check
+                   would fail OPEN — shown with any other owner, the walk silently vanishes and
+                   this route is right back to discarding dirty edits, the exact bug being
+                   fixed. The main window owns every session, so if none exists there is no
+                   unsaved work to lose and restarting without a walk is genuinely safe. */
+                var main = Owner as MainWindow
+                    ?? (Avalonia.Application.Current?.ApplicationLifetime
+                        as Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime)
+                        ?.MainWindow as MainWindow;
+
+                if (main != null)
                 {
                     if (!await main.ConfirmAllUnsavedWorkAsync())
                         return;

--- a/src/PlanViewer.App/App.axaml.cs
+++ b/src/PlanViewer.App/App.axaml.cs
@@ -54,7 +54,11 @@ public partial class App : Application
         // Register the .sqlplan association (Windows/Linux) off the UI thread so it
         // never delays first paint. Best-effort; the OS then routes double-clicks to
         // the existing argv/pipe open path. No-op on macOS (handled by Info.plist).
-        Task.Run(FileAssociationService.RegisterForCurrentExecutable);
+        // Never in the test host: this writes HKCU\Software\Classes, and the harness
+        // booting the real App (#451) rewrote the machine's .sqlplan association and
+        // DefaultIcon to point at the test runner executable — confirmed live.
+        if (!AppRuntimeMode.IsTestHost)
+            Task.Run(FileAssociationService.RegisterForCurrentExecutable);
 
         base.OnFrameworkInitializationCompleted();
     }

--- a/src/PlanViewer.App/AppRuntimeMode.cs
+++ b/src/PlanViewer.App/AppRuntimeMode.cs
@@ -1,0 +1,25 @@
+namespace PlanViewer.App;
+
+/// <summary>
+/// Process-wide answer to "is this the real app or the test host?"
+///
+/// <para>The headless test harness (#451) boots the REAL <see cref="App"/> — deliberately,
+/// because MainWindow resolves styles from the application XAML — which means the real
+/// startup side effects run inside the test runner unless something says otherwise. That
+/// was not hypothetical: a local <c>dotnet test</c> rewrote HKCU's .sqlplan association to
+/// point at the test host executable, polluted the developer's Recent Plans with fixture
+/// paths, and destroyed the saved open-tab list, all confirmed live.</para>
+///
+/// <para>This is the one seam those side effects consult, rather than a scattering of
+/// environment sniffs. The harness sets it before the first App boots; nothing in the
+/// product ever sets it, so in the real app every check reads a constant false and
+/// behavior is unchanged.</para>
+/// </summary>
+internal static class AppRuntimeMode
+{
+    /// <summary>
+    /// True only inside the test host. Set once by the test harness's module initializer,
+    /// never by the app itself.
+    /// </summary>
+    internal static bool IsTestHost;
+}

--- a/src/PlanViewer.App/Controls/PlanViewerControl.Interaction.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.Interaction.cs
@@ -360,7 +360,11 @@ public partial class PlanViewerControl : UserControl
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"SavePlan failed: {ex.Message}");
-                CostText.Text = $"Save failed: {(ex.Message.Length > 60 ? ex.Message[..60] + "..." : ex.Message)}";
+                /* #452's mirror, the sixth site (spotted during the review sweep): pre-cutting to
+                   60 characters threw away exactly the part of an I/O error that says what to fix.
+                   Full message out; the tooltip carries whatever the label clips. */
+                CostText.Text = $"Save failed: {ex.Message}";
+                ToolTip.SetTip(CostText, ex.Message);
             }
         }
     }

--- a/src/PlanViewer.App/Controls/PlanViewerControl.Statements.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.Statements.cs
@@ -16,13 +16,16 @@ namespace PlanViewer.App.Controls;
 
 public partial class PlanViewerControl : UserControl
 {
-    private void PopulateStatementsGrid(List<PlanStatement> statements)
+    /* Takes the container-aware entries rather than bare statements (#456 follow-up): the grid
+       now lists stored procedure and UDF body statements alongside the outer batch, and a row
+       needs to say WHICH module its statement came from or five bare SELECTs are indistinguishable. */
+    private void PopulateStatementsGrid(List<StatementWithContainer> statements)
     {
         StatementsHeader.Text = $"Statements ({statements.Count})";
 
-        var hasActualTimes = statements.Any(s => s.QueryTimeStats != null &&
-            (s.QueryTimeStats.CpuTimeMs > 0 || s.QueryTimeStats.ElapsedTimeMs > 0));
-        var hasUdf = statements.Any(s => s.QueryUdfElapsedTimeMs > 0);
+        var hasActualTimes = statements.Any(e => e.Statement.QueryTimeStats != null &&
+            (e.Statement.QueryTimeStats.CpuTimeMs > 0 || e.Statement.QueryTimeStats.ElapsedTimeMs > 0));
+        var hasUdf = statements.Any(e => e.Statement.QueryUdfElapsedTimeMs > 0);
 
         // Build columns
         StatementsGrid.Columns.Clear();
@@ -129,7 +132,7 @@ public partial class PlanViewerControl : UserControl
         var rows = new List<StatementRow>();
         for (int i = 0; i < statements.Count; i++)
         {
-            var stmt = statements[i];
+            var stmt = statements[i].Statement;
             var allWarnings = stmt.PlanWarnings.ToList();
             if (stmt.RootNode != null)
                 CollectNodeWarnings(stmt.RootNode, allWarnings);
@@ -137,6 +140,14 @@ public partial class PlanViewerControl : UserControl
             var fullText = stmt.StatementText;
             if (string.IsNullOrWhiteSpace(fullText))
                 fullText = $"Statement {i + 1}";
+
+            /* A body statement gets its module name in front ("dbo.Proc > SELECT ...") in both
+               the cell and its tooltip — display only. Copy/open-in-editor read
+               row.Statement.StatementText and hand out the statement exactly as the plan
+               recorded it, prefix-free. */
+            if (!string.IsNullOrEmpty(statements[i].ContainerPath))
+                fullText = $"{statements[i].ContainerPath} > {fullText}";
+
             var displayText = fullText.Length > 120 ? fullText[..120] + "..." : fullText;
 
             rows.Add(new StatementRow

--- a/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.axaml.cs
@@ -345,9 +345,20 @@ public partial class PlanViewerControl : UserControl
 
         PlanAnalysisPipeline.AnalyzeParsed(_currentPlan, ConfigLoader.Load(), _serverMetadata);
 
-        var allStatements = _currentPlan.Batches
-            .SelectMany(b => b.Statements)
-            .Where(s => s.RootNode != null)
+        /* #456 gave the analysis pipeline and Human/Robot Advice (ResultMapper) the shared
+           PlanStatements.EnumerateAll traversal, which descends into stored procedure and UDF
+           bodies. The grid and the MCP registration below kept walking batch.Statements, so an
+           EXEC <procedure> plan showed one grid row — the EXEC itself — and registered near-zero
+           counts, while the advice discussed dozens of warnings the UI could neither display nor
+           navigate to. Same traversal here so what the grid shows, what the session reports, and
+           what the advice says are the same plan. */
+        var everyStatement = PlanStatements.EnumerateAllWithContainer(_currentPlan).ToList();
+
+        /* Only statements with a root node can render on the canvas. The same filter has always
+           applied to the outer batch (where the parser's synthetic statement roots mean it
+           rarely excludes anything); it now applies across the whole traversal. */
+        var allStatements = everyStatement
+            .Where(e => e.Statement.RootNode != null)
             .ToList();
 
         if (allStatements.Count == 0)
@@ -361,16 +372,20 @@ public partial class PlanViewerControl : UserControl
         PlanScrollViewer.IsVisible = true;
 
         // Always show statement grid — useful summary even for single-statement plans
-        _allStatements = allStatements;
+        _allStatements = allStatements.Select(e => e.Statement).ToList();
         PopulateStatementsGrid(allStatements);
         ShowStatementsPanel();
         StatementsGrid.SelectedIndex = 0;
 
-        // Register with MCP session manager for AI tool access
-        // Count warnings from both statement-level PlanWarnings and all node Warnings
+        /* Register with MCP session manager for AI tool access. Counts run over EVERY statement,
+           renderable or not, because that is what the advice an MCP client reads was built from:
+           statement-level PlanWarnings plus all node warnings, proc/UDF bodies included.
+           StatementCount likewise matches the analysis output's total_statements rather than the
+           grid's renderable subset. */
         int warningCount = 0, criticalCount = 0;
-        foreach (var s in allStatements)
+        foreach (var entry in everyStatement)
         {
+            var s = entry.Statement;
             warningCount += s.PlanWarnings.Count;
             criticalCount += s.PlanWarnings.Count(w => w.Severity == PlanWarningSeverity.Critical);
             if (s.RootNode != null)
@@ -385,8 +400,8 @@ public partial class PlanViewerControl : UserControl
             Source = sessionSource,
             Plan = _currentPlan,
             QueryText = queryText,
-            StatementCount = allStatements.Count,
-            HasActualStats = allStatements.Any(s => s.QueryTimeStats != null),
+            StatementCount = everyStatement.Count,
+            HasActualStats = everyStatement.Any(e => e.Statement.QueryTimeStats != null),
             WarningCount = warningCount,
             CriticalWarningCount = criticalCount,
             MissingIndexCount = _currentPlan.AllMissingIndexes.Count

--- a/src/PlanViewer.App/Controls/QuerySessionControl.Editor.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.Editor.cs
@@ -167,12 +167,22 @@ public partial class QuerySessionControl : UserControl
     internal static bool ReplaceNeedsConfirmation(bool isDirty, string? currentText) =>
         isDirty && !string.IsNullOrEmpty(currentText);
 
+    /* The prompt below puts an await between the dirty check and the replacement, so without
+       a latch two back-to-back "Open in Query Editor" clicks would each read the same dirty
+       state and stack two Replace prompts — the same reentrancy class the About window's
+       update link had. Not data loss (the assignment stays gated on an explicit Replace
+       either way), just two dialogs racing; first click wins, the second is a no-op. */
+    private bool _replacePromptInFlight;
+
     /// <summary>
     /// Puts a statement from a plan into the query editor. Internal (like the MainWindow
     /// Click handlers) so tests can drive it without a plan viewer to click through.
     /// </summary>
     internal async void OnOpenInEditorRequested(object? sender, string queryText)
     {
+        if (_replacePromptInFlight)
+            return;
+
         /* This used to assign unconditionally — the one wholesale overwrite in the app that
            skipped #462's dirty tracking, so a typed-but-unsaved query was replaced without a
            question. ConfirmationDialog rather than the three-button UnsavedChangesDialog:
@@ -181,10 +191,19 @@ public partial class QuerySessionControl : UserControl
            Dismissing the dialog is a no, and a no leaves the editor and the sub-tab alone. */
         if (ReplaceNeedsConfirmation(IsDirty, QueryEditor.Text))
         {
-            var replace = await ShowConfirmationDialog(
-                "Unsaved Changes",
-                "The query editor has unsaved changes.\n\nReplace them with this statement? Your current text will be lost.",
-                confirmCaption: "Replace");
+            _replacePromptInFlight = true;
+            bool replace;
+            try
+            {
+                replace = await ShowConfirmationDialog(
+                    "Unsaved Changes",
+                    "The query editor has unsaved changes.\n\nReplace them with this statement? Your current text will be lost.",
+                    confirmCaption: "Replace");
+            }
+            finally
+            {
+                _replacePromptInFlight = false;
+            }
 
             if (!replace)
                 return;

--- a/src/PlanViewer.App/Controls/QuerySessionControl.Editor.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.Editor.cs
@@ -162,7 +162,7 @@ public partial class QuerySessionControl : UserControl
     /// (or empty), and a dirty-but-empty one is a buffer the user deleted everything out of —
     /// replacing nothing loses nothing, so both stay as frictionless as they always were.
     /// Split out pure so the decision is testable without a dialog to click, the same trade
-    /// CollectOpenTabPaths made for the session-restore list.</para>
+    /// CollectOpenTabEntries made for the session-restore list.</para>
     /// </summary>
     internal static bool ReplaceNeedsConfirmation(bool isDirty, string? currentText) =>
         isDirty && !string.IsNullOrEmpty(currentText);

--- a/src/PlanViewer.App/Controls/QuerySessionControl.Editor.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.Editor.cs
@@ -155,8 +155,41 @@ public partial class QuerySessionControl : UserControl
         }
     }
 
-    private void OnOpenInEditorRequested(object? sender, string queryText)
+    /// <summary>
+    /// Whether "Open in Query Editor" has to stop and ask before pasting over the editor.
+    ///
+    /// <para>Only typed-but-unsaved work earns a prompt: a clean editor is already on disk
+    /// (or empty), and a dirty-but-empty one is a buffer the user deleted everything out of —
+    /// replacing nothing loses nothing, so both stay as frictionless as they always were.
+    /// Split out pure so the decision is testable without a dialog to click, the same trade
+    /// CollectOpenTabPaths made for the session-restore list.</para>
+    /// </summary>
+    internal static bool ReplaceNeedsConfirmation(bool isDirty, string? currentText) =>
+        isDirty && !string.IsNullOrEmpty(currentText);
+
+    /// <summary>
+    /// Puts a statement from a plan into the query editor. Internal (like the MainWindow
+    /// Click handlers) so tests can drive it without a plan viewer to click through.
+    /// </summary>
+    internal async void OnOpenInEditorRequested(object? sender, string queryText)
     {
+        /* This used to assign unconditionally — the one wholesale overwrite in the app that
+           skipped #462's dirty tracking, so a typed-but-unsaved query was replaced without a
+           question. ConfirmationDialog rather than the three-button UnsavedChangesDialog:
+           a Save answer here would need the save pipeline, which lives on MainWindow and
+           takes the tab — machinery this control has no business growing for one prompt.
+           Dismissing the dialog is a no, and a no leaves the editor and the sub-tab alone. */
+        if (ReplaceNeedsConfirmation(IsDirty, QueryEditor.Text))
+        {
+            var replace = await ShowConfirmationDialog(
+                "Unsaved Changes",
+                "The query editor has unsaved changes.\n\nReplace them with this statement? Your current text will be lost.",
+                confirmCaption: "Replace");
+
+            if (!replace)
+                return;
+        }
+
         QueryEditor.Text = queryText;
         SubTabControl.SelectedIndex = 0; // Switch to the editor tab
         QueryEditor.Focus();

--- a/src/PlanViewer.App/Controls/QuerySessionControl.Execution.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.Execution.cs
@@ -442,10 +442,10 @@ public partial class QuerySessionControl : UserControl
     }
 
     /// <summary>
-    /// Shows a modal confirmation dialog and returns true if the user clicked OK.
+    /// Shows a modal confirmation dialog and returns true if the user confirmed.
     /// </summary>
-    private Task<bool> ShowConfirmationDialog(string title, string message)
-        => Dialogs.ConfirmationDialog.ShowAsync(GetParentWindow(), title, message);
+    private Task<bool> ShowConfirmationDialog(string title, string message, string confirmCaption = "OK")
+        => Dialogs.ConfirmationDialog.ShowAsync(GetParentWindow(), title, message, confirmCaption);
 
     /// <summary>
     /// Extracts the database name from plan XML's StmtSimple DatabaseContext attribute.

--- a/src/PlanViewer.App/Controls/QuerySessionControl.Execution.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.Execution.cs
@@ -197,15 +197,7 @@ public partial class QuerySessionControl : UserControl
 
             // Replace loading content with the plan viewer
             SetStatus($"{planType} plan captured ({sw.Elapsed.TotalSeconds:F1}s)");
-            var viewer = new PlanViewerControl();
-            viewer.Metadata = _serverMetadata;
-            viewer.ConnectionString = _connectionString;
-            viewer.SetConnectionServices(_credentialService, _connectionStore);
-            if (_serverConnection != null)
-                viewer.SetConnectionStatus(_serverConnection.ServerName, _selectedDatabase);
-            viewer.OpenInEditorRequested += OnOpenInEditorRequested;
-            viewer.LoadPlan(planXml, tabLabel, queryText);
-            loadingTab.Content = viewer;
+            ShowCapturedPlan(loadingTab, planXml, tabLabel, queryText);
             HumanAdviceButton.IsEnabled = true;
             RobotAdviceButton.IsEnabled = true;
         }
@@ -222,6 +214,32 @@ public partial class QuerySessionControl : UserControl
         {
             ShowExecutionFailure(loadingPanel, statusLabel, progressBar, cancelBtn, ex.Message);
         }
+    }
+
+    /// <summary>
+    /// Puts a captured plan into the tab that has been showing the progress spinner for it.
+    ///
+    /// <para>Both execution paths end here — the estimated/actual capture and Get Actual Plan — and
+    /// this is the moment a plan appears in a session, so it is the moment Compare Plans has to be
+    /// re-decided. That happens through the sub-tab
+    /// <see cref="Helpers.TabContentWatcher"/> rather than a call added below, because the assignment
+    /// on the last line is what it is watching for (#447).</para>
+    ///
+    /// <para>Internal so a test can drive the plan landing with XML it already has, rather than
+    /// needing a SQL Server to produce some. The half of these paths that reaches out to a server
+    /// is above this; everything that decides what the user ends up looking at is here.</para>
+    /// </summary>
+    internal void ShowCapturedPlan(TabItem planTab, string planXml, string tabLabel, string queryText)
+    {
+        var viewer = new PlanViewerControl();
+        viewer.Metadata = _serverMetadata;
+        viewer.ConnectionString = _connectionString;
+        viewer.SetConnectionServices(_credentialService, _connectionStore);
+        if (_serverConnection != null)
+            viewer.SetConnectionStatus(_serverConnection.ServerName, _selectedDatabase);
+        viewer.OpenInEditorRequested += OnOpenInEditorRequested;
+        viewer.LoadPlan(planXml, tabLabel, queryText);
+        planTab.Content = viewer;
     }
 
     /// <summary>
@@ -402,15 +420,7 @@ public partial class QuerySessionControl : UserControl
             }
 
             SetStatus($"Actual plan captured ({sw.Elapsed.TotalSeconds:F1}s)");
-            var actualViewer = new PlanViewerControl();
-            actualViewer.Metadata = _serverMetadata;
-            actualViewer.ConnectionString = _connectionString;
-            actualViewer.SetConnectionServices(_credentialService, _connectionStore);
-            if (_serverConnection != null)
-                actualViewer.SetConnectionStatus(_serverConnection.ServerName, _selectedDatabase);
-            actualViewer.OpenInEditorRequested += OnOpenInEditorRequested;
-            actualViewer.LoadPlan(actualPlanXml, tabLabel, queryText);
-            loadingTab.Content = actualViewer;
+            ShowCapturedPlan(loadingTab, actualPlanXml, tabLabel, queryText);
         }
         catch (OperationCanceledException)
         {

--- a/src/PlanViewer.App/Controls/QuerySessionControl.Plans.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.Plans.cs
@@ -224,11 +224,13 @@ public partial class QuerySessionControl : UserControl
     /// app could already do.
     ///
     /// <para>Called by the <see cref="TabContentWatcher"/> wired to this session's sub-tabs, and by
-    /// nothing else. It used to be called by hand at the five places that add or remove a plan tab,
-    /// which is why the paths that instead fill in an existing tab — every executed query — never
-    /// reached it.</para>
+    /// <see cref="MainWindow.DetachTabToWindow"/> when this session leaves the tab strip — the
+    /// watcher only fires on sub-tab changes, and detaching changes none, so without that call the
+    /// button froze at whatever the window-wide count last said until the next plan landed. It used
+    /// to be called by hand at the five places that add or remove a plan tab, which is why the
+    /// paths that instead fill in an existing tab — every executed query — never reached it.</para>
     /// </summary>
-    private void UpdateCompareButtonState()
+    internal void UpdateCompareButtonState()
     {
         /* Logical tree, not TopLevel.GetTopLevel. A TabControl realises the selected tab's content
            and nothing else, so a session sitting in a background tab has no visual root and cannot

--- a/src/PlanViewer.App/Controls/QuerySessionControl.Plans.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.Plans.cs
@@ -13,12 +13,14 @@ using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
+using Avalonia.LogicalTree;
 using Avalonia.Media;
 using AvaloniaEdit;
 using AvaloniaEdit.CodeCompletion;
 using AvaloniaEdit.TextMate;
 using Microsoft.Data.SqlClient;
 using PlanViewer.App.Dialogs;
+using PlanViewer.App.Helpers;
 using PlanViewer.App.Services;
 using PlanViewer.Core.Interfaces;
 using PlanViewer.Core.Models;
@@ -108,7 +110,6 @@ public partial class QuerySessionControl : UserControl
 
         SubTabControl.Items.Add(tab);
         SubTabControl.SelectedItem = tab;
-        UpdateCompareButtonState();
         return true;
     }
 
@@ -159,7 +160,6 @@ public partial class QuerySessionControl : UserControl
             if (tab.Content is PlanViewerControl viewer)
                 viewer.Clear();
             SubTabControl.Items.Remove(tab);
-            UpdateCompareButtonState();
         }
     }
 
@@ -180,7 +180,6 @@ public partial class QuerySessionControl : UserControl
                     if (tab.Content is PlanViewerControl closeViewer)
                         closeViewer.Clear();
                     SubTabControl.Items.Remove(tab);
-                    UpdateCompareButtonState();
                 }
                 break;
 
@@ -199,7 +198,6 @@ public partial class QuerySessionControl : UserControl
                         SubTabControl.Items.Remove(t);
                     }
                     SubTabControl.SelectedItem = keepTab;
-                    UpdateCompareButtonState();
                 }
                 break;
 
@@ -215,7 +213,6 @@ public partial class QuerySessionControl : UserControl
                     SubTabControl.Items.Remove(t);
                 }
                 SubTabControl.SelectedIndex = 0; // back to Editor
-                UpdateCompareButtonState();
                 break;
         }
     }
@@ -225,10 +222,21 @@ public partial class QuerySessionControl : UserControl
     /// from another is the ordinary case, and counting only this session's own tabs left the button
     /// disabled in both — the reporter had to save a plan and reopen it to get at a comparison the
     /// app could already do.
+    ///
+    /// <para>Called by the <see cref="TabContentWatcher"/> wired to this session's sub-tabs, and by
+    /// nothing else. It used to be called by hand at the five places that add or remove a plan tab,
+    /// which is why the paths that instead fill in an existing tab — every executed query — never
+    /// reached it.</para>
     /// </summary>
     private void UpdateCompareButtonState()
     {
-        if (TopLevel.GetTopLevel(this) is MainWindow owner)
+        /* Logical tree, not TopLevel.GetTopLevel. A TabControl realises the selected tab's content
+           and nothing else, so a session sitting in a background tab has no visual root and cannot
+           see its own window — and a query started in one tab and left to run while the user works
+           in another lands its plan in exactly that state. GetTopLevel returned null there and the
+           fallback below silently reinstated the bug this method exists to fix. The logical parent
+           chain holds whether the tab is on screen or not. */
+        if (this.FindLogicalAncestorOfType<MainWindow>() is { } owner)
         {
             /* Refreshes every session, not just this one: a plan appearing here can be the second
                plan that makes Compare available over THERE. */

--- a/src/PlanViewer.App/Controls/QuerySessionControl.QueryStore.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.QueryStore.cs
@@ -261,7 +261,14 @@ public partial class QuerySessionControl : UserControl
         SubTabControl.SelectedItem = tab;
     }
 
-    private void OnQueryStorePlansSelected(object? sender, List<QueryStorePlan> plans)
+    /// <summary>
+    /// Opens a plan tab for each plan picked out of the Query Store grid.
+    ///
+    /// <para>Internal so a test can hand it plans it already has. The grid is what fetches them from
+    /// a server; nothing below this line needs one, which is what makes the Query Store side of
+    /// #447 testable without a live instance.</para>
+    /// </summary>
+    internal void OnQueryStorePlansSelected(object? sender, List<QueryStorePlan> plans)
     {
         int loaded = 0;
         foreach (var qsPlan in plans)

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -37,6 +38,18 @@ public partial class QuerySessionControl : UserControl
     /// Full path on disk when the query was loaded from, or last saved to, a file.
     /// </summary>
     public string? SourceFilePath { get; set; }
+
+    /// <summary>
+    /// The encoding the file behind <see cref="SourceFilePath"/> declared with its byte order
+    /// mark, or null for a BOM-less file and for a scratch session — both of which save as
+    /// UTF-8 without a BOM, which is what every save wrote before this existed.
+    ///
+    /// <para>Captured at open so a save writes the bytes the file arrived with. SSMS writes
+    /// .sql files as UTF-16 with a BOM; opening one read fine (File.ReadAllText honors the
+    /// mark) and then the first Ctrl+S silently transcoded the whole file to UTF-8 — every
+    /// byte changed, the BOM gone, without the user asking for any of it.</para>
+    /// </summary>
+    public Encoding? SourceFileEncoding { get; set; }
 
     /// <summary>
     /// The editor text as of the last load or save. A new session starts empty, so a

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -18,6 +18,7 @@ using AvaloniaEdit.CodeCompletion;
 using AvaloniaEdit.TextMate;
 using Microsoft.Data.SqlClient;
 using PlanViewer.App.Dialogs;
+using PlanViewer.App.Helpers;
 using PlanViewer.App.Services;
 using PlanViewer.Core.Interfaces;
 using PlanViewer.Core.Models;
@@ -130,6 +131,13 @@ public partial class QuerySessionControl : UserControl
             _statusClearCts?.Dispose();
             _statusClearCts = null;
         };
+
+        /* #447: a plan appearing in — or leaving — this session changes whether Compare Plans is
+           offered in every session in the window, not just this one. Watched here rather than
+           called at each site that produces a plan, because the sites that produce a plan are the
+           ones nobody remembers: executing a query fills in a tab that already exists, which is
+           neither an Add nor a Remove and is exactly the case the first fix missed. */
+        TabContentWatcher.Watch(SubTabControl, UpdateCompareButtonState);
 
         // Focus the editor when the Editor tab is selected; toggle plan-dependent buttons
         SubTabControl.SelectionChanged += (_, _) =>

--- a/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QuerySessionControl.axaml.cs
@@ -40,6 +40,22 @@ public partial class QuerySessionControl : UserControl
     public string? SourceFilePath { get; set; }
 
     /// <summary>
+    /// Identity of this session's persisted scratch buffer (#496), or null while it has
+    /// none. Assigned by MainWindow the first time a never-saved session's content is
+    /// actually written to the scratch store — not at construction, so an empty tab never
+    /// mints a buffer — and carried back onto the restored session at the next start, which
+    /// is what makes a restored scratch CONTINUE its buffer instead of forking a new one.
+    /// Cleared when the buffer is deleted: the user chose its fate at a prompt (Don't Save,
+    /// or a save that moved the content into a real file), or there is nothing unsaved left
+    /// to protect.
+    ///
+    /// <para>On the session rather than the tab for the same reason <see cref="SourceFilePath"/>
+    /// is: detach discards the TabItem and the session lives on in its own window (#473),
+    /// and its buffer identity has to travel with it.</para>
+    /// </summary>
+    internal Guid? ScratchBufferId { get; set; }
+
+    /// <summary>
     /// The encoding the file behind <see cref="SourceFilePath"/> declared with its byte order
     /// mark, or null for a BOM-less file and for a scratch session — both of which save as
     /// UTF-8 without a BOM, which is what every save wrote before this existed.

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.Fetch.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.Fetch.cs
@@ -57,7 +57,10 @@ public partial class QueryStoreGridControl : UserControl
         }
         catch (Exception ex)
         {
-            StatusText.Text = ex.Message.Length > 80 ? ex.Message[..80] + "..." : ex.Message;
+            /* #452's mirror: pre-cutting to 80 characters threw away text the strip would have
+               shown and the tooltip (wired in the constructor) would have recovered. The full
+               message goes out; where it gets clipped is the display's business. */
+            StatusText.Text = ex.Message;
         }
         finally
         {
@@ -107,7 +110,8 @@ public partial class QueryStoreGridControl : UserControl
         }
         catch (Exception ex)
         {
-            StatusText.Text = ex.Message.Length > 80 ? ex.Message[..80] + "..." : ex.Message;
+            // Same #452 mirror as Fetch_Click above: full message out, tooltip carries the rest.
+            StatusText.Text = ex.Message;
         }
         finally
         {

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.Sort.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.Sort.cs
@@ -68,7 +68,8 @@ public partial class QueryStoreGridControl : UserControl
         catch (OperationCanceledException) { }
         catch (Exception ex)
         {
-            StatusText.Text = ex.Message.Length > 80 ? ex.Message[..80] + "..." : ex.Message;
+            // #452's mirror: full message out, the status tooltip carries what the strip clips.
+            StatusText.Text = ex.Message;
         }
         finally
         {

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.WaitStats.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.WaitStats.cs
@@ -41,7 +41,8 @@ public partial class QueryStoreGridControl : UserControl
         catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
-            StatusText.Text = $"Slicer: {(ex.Message.Length > 60 ? ex.Message[..60] + "..." : ex.Message)}";
+            // #452's mirror: full message out, the status tooltip carries what the strip clips.
+            StatusText.Text = $"Slicer: {ex.Message}";
         }
     }
 

--- a/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/QueryStoreGridControl.axaml.cs
@@ -84,6 +84,19 @@ public partial class QueryStoreGridControl : UserControl
         ServerFilterExpander.Expanded += ServerFilterExpander_StateChanged;
         ServerFilterExpander.Collapsed += ServerFilterExpander_StateChanged;
 
+        /* #452's pattern, carried to this surface: the status strip is one line, so a long
+           message — an error, usually — is readable on hover or not at all. QuerySessionControl
+           funnels every status through SetStatus, which mirrors the text into the tooltip; this
+           control writes StatusText.Text from a dozen sites across five partials, so the mirror
+           is one subscription rather than a funnel every future site would have to remember —
+           and a tooltip set at just the error sites would go stale the moment "Fetching plans..."
+           was written over the text but not the tip. */
+        StatusText.PropertyChanged += (_, e) =>
+        {
+            if (e.Property == TextBlock.TextProperty)
+                ToolTip.SetTip(StatusText, string.IsNullOrEmpty(StatusText.Text) ? null : StatusText.Text);
+        };
+
         ResultsGrid.ItemsSource = _filteredRows;
         Helpers.DataGridBehaviors.Attach(ResultsGrid);
         Helpers.DataGridBehaviors.AttachCopyGuard(ResultsGrid,
@@ -159,7 +172,11 @@ public partial class QueryStoreGridControl : UserControl
         }
         catch (Exception ex)
         {
-            StatusText.Text = ex.Message.Length > 60 ? ex.Message[..60] + "..." : ex.Message;
+            /* Was cut to 60 characters + "..." before display. Trimming to the space available
+               is the display layer's job — the strip clips at its own edge — and pre-cutting
+               here also destroyed the only recovery path: the tooltip the constructor mirrors
+               onto StatusText now carries the full message on hover. Same family as #452. */
+            StatusText.Text = ex.Message;
             QsDatabaseBox.SelectedItem = _database; // revert
             return;
         }

--- a/src/PlanViewer.App/Dialogs/ConfirmationDialog.cs
+++ b/src/PlanViewer.App/Dialogs/ConfirmationDialog.cs
@@ -13,7 +13,10 @@ namespace PlanViewer.App.Dialogs;
 /// </summary>
 public static class ConfirmationDialog
 {
-    public static async Task<bool> ShowAsync(Window owner, string title, string message)
+    /// <param name="confirmCaption">What the confirming button says. "OK" reads fine for
+    /// gating an execution; a destructive confirmation ("Replace") should name the act, so
+    /// the button says what clicking it costs.</param>
+    public static async Task<bool> ShowAsync(Window owner, string title, string message, string confirmCaption = "OK")
     {
         var result = false;
 
@@ -28,9 +31,10 @@ public static class ConfirmationDialog
 
         var okBtn = new Button
         {
-            Content = "OK",
+            Content = confirmCaption,
             Height = 32,
-            Width = 80,
+            // Min rather than fixed: "OK" renders the same, a longer caption ("Replace") isn't clipped.
+            MinWidth = 80,
             Padding = new Avalonia.Thickness(16, 0),
             FontSize = 12,
             HorizontalContentAlignment = HorizontalAlignment.Center,
@@ -42,7 +46,7 @@ public static class ConfirmationDialog
         {
             Content = "Cancel",
             Height = 32,
-            Width = 80,
+            MinWidth = 80,
             Padding = new Avalonia.Thickness(16, 0),
             FontSize = 12,
             Margin = new Avalonia.Thickness(8, 0, 0, 0),

--- a/src/PlanViewer.App/Helpers/DetachedWindowHelper.cs
+++ b/src/PlanViewer.App/Helpers/DetachedWindowHelper.cs
@@ -87,6 +87,14 @@ internal static class DetachedWindowHelper
 		// Set once the guard has answered, so the re-issued close is not questioned again.
 		bool closeConfirmed = false;
 
+		/* Set while a guard is still ASKING, which closeConfirmed cannot cover — it only
+		   latches after a yes. The guard's prompt is modal to this window, but a Save As
+		   picked from that prompt is not, so a second X during the picker used to reach the
+		   guard again and stack a second prompt over the first. Same walk-in-progress latch
+		   MainWindow.OnClosing carries, for the same reentrancy (#485 review's update-link
+		   class). */
+		bool closeGuardPending = false;
+
 		redockBtn.Click += (_, _) =>
 		{
 			if (redocked) return;
@@ -104,16 +112,25 @@ internal static class DetachedWindowHelper
 		// latch that stops the second pass asking all over again.
 		async Task ReissueCloseIfConfirmed(Task<bool> pending)
 		{
-			if (!await pending)
-				return;
+			try
+			{
+				if (!await pending)
+					return;
 
-			closeConfirmed = true;
+				closeConfirmed = true;
 
-			// Posted rather than called: a guard that answers without ever actually waiting
-			// would otherwise land Close() in the middle of the Closing handler that called
-			// it. Safe to post because the guard returns null during app shutdown, so nothing
-			// is ever queued against a dispatcher that is going away.
-			Dispatcher.UIThread.Post(detachedWindow.Close);
+				// Posted rather than called: a guard that answers without ever actually waiting
+				// would otherwise land Close() in the middle of the Closing handler that called
+				// it. Safe to post because the guard returns null during app shutdown, so nothing
+				// is ever queued against a dispatcher that is going away.
+				Dispatcher.UIThread.Post(detachedWindow.Close);
+			}
+			finally
+			{
+				// Cleared on every ending — refused, confirmed, or thrown — so a kept-open
+				// window can be asked about again the next time someone tries to close it.
+				closeGuardPending = false;
+			}
 		}
 
 		detachedWindow.Closing += (_, e) =>
@@ -123,9 +140,18 @@ internal static class DetachedWindowHelper
 
 			if (!closeConfirmed && closeGuard != null)
 			{
+				if (closeGuardPending)
+				{
+					// A guard is already asking about this window; a second close request
+					// joins that question rather than raising its own copy of it.
+					e.Cancel = true;
+					return;
+				}
+
 				var pending = closeGuard(content, detachedWindow);
 				if (pending != null)
 				{
+					closeGuardPending = true;
 					e.Cancel = true;
 					_ = ReissueCloseIfConfirmed(pending);
 					return;

--- a/src/PlanViewer.App/Helpers/TabContentWatcher.cs
+++ b/src/PlanViewer.App/Helpers/TabContentWatcher.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+
+namespace PlanViewer.App.Helpers;
+
+/// <summary>
+/// Reports every change to what a <see cref="TabControl"/> is showing, so state derived from its
+/// contents can be recomputed without a call planted at each site that changes them (#447).
+///
+/// <para><b>Why a collection subscription is not enough.</b> A tab's content is changed two ways,
+/// and only one of them is a collection change. Tabs are added and removed, which
+/// <c>Items</c> raises; but a tab is also created holding a progress spinner and later has its
+/// <c>Content</c> swapped for the finished article — which is how every plan produced by executing
+/// a query arrives, and which the collection says nothing about. #449 watched the collection alone
+/// and so fixed the file path while leaving the execution path exactly as broken as it was
+/// reported.</para>
+///
+/// <para>Both are watched here, which is the point: the next path that produces a plan is correct
+/// without its author knowing this exists, because a plan cannot reach the screen without either
+/// adding a tab or filling one in.</para>
+/// </summary>
+internal static class TabContentWatcher
+{
+    /// <summary>
+    /// Invokes <paramref name="onChanged"/> whenever a tab is added to or removed from
+    /// <paramref name="tabs"/>, or an existing tab's content is replaced.
+    ///
+    /// <para>Meant to be called once, where the control is built. The subscriptions live as long as
+    /// the tab control does, which for both call sites is the lifetime of the window.</para>
+    /// </summary>
+    internal static void Watch(TabControl tabs, Action onChanged)
+    {
+        /* Tracked rather than derived from the collection-changed args, because a Reset carries
+           neither OldItems nor NewItems and would otherwise leave stale subscriptions behind. */
+        var watched = new HashSet<TabItem>();
+
+        void OnTabPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+        {
+            if (e.Property == ContentControl.ContentProperty)
+                onChanged();
+        }
+
+        void Resync()
+        {
+            var current = tabs.Items.OfType<TabItem>().ToHashSet();
+
+            foreach (var gone in watched.Except(current).ToList())
+            {
+                gone.PropertyChanged -= OnTabPropertyChanged;
+                watched.Remove(gone);
+            }
+
+            foreach (var arrived in current.Except(watched).ToList())
+            {
+                arrived.PropertyChanged += OnTabPropertyChanged;
+                watched.Add(arrived);
+            }
+        }
+
+        /* Tabs declared in XAML are already in the collection before anyone gets to watch it. */
+        Resync();
+
+        if (tabs.Items is INotifyCollectionChanged observable)
+        {
+            observable.CollectionChanged += (_, _) =>
+            {
+                Resync();
+                onChanged();
+            };
+        }
+    }
+}

--- a/src/PlanViewer.App/MainWindow.FileOps.cs
+++ b/src/PlanViewer.App/MainWindow.FileOps.cs
@@ -683,7 +683,13 @@ public partial class MainWindow : Window
     /// buffer is read, and a buffer that fails to load is skipped, never re-added, and
     /// deleted (<see cref="TryRestoreScratchTab"/>).</para>
     /// </summary>
-    private void RestoreOpenPlans()
+    /// <param name="createFallbackTab">
+    /// Whether an empty restore opens a fresh query tab. False when the caller is about to
+    /// open a file-argument on top (#496 review) — the fallback exists so a bare launch
+    /// never greets the user with an empty window, and a launch that carries a file is not
+    /// that.
+    /// </param>
+    private void RestoreOpenPlans(bool createFallbackTab = true)
     {
         /* Snapshot first: SaveOpenPlans and this method share the live list, and the clear
            below would otherwise empty the very thing being iterated. */
@@ -730,7 +736,7 @@ public partial class MainWindow : Window
            down NOW so a crash a moment after startup still finds the session on disk. */
         FlushSessionPersist();
 
-        if (!restored)
+        if (!restored && createFallbackTab)
         {
             // Nothing to restore — open a fresh query editor like before
             NewQuery_Click(this, new RoutedEventArgs());

--- a/src/PlanViewer.App/MainWindow.FileOps.cs
+++ b/src/PlanViewer.App/MainWindow.FileOps.cs
@@ -188,6 +188,15 @@ public partial class MainWindow : Window
                UTF-8-without-BOM this always wrote. */
             AtomicFile.WriteAllText(path, session.QueryEditor.Text, session.SourceFileEncoding);
             session.SourceFilePath = path;
+            /* #496: a successful save is the user CHOOSING where this content lives — the
+               real file just written — so the scratch buffer that was protecting it retires
+               here, at the moment the choice lands. After the SourceFilePath assignment
+               above on purpose: from this line on the session is file-backed, its edits are
+               the prompts' job (the scope fence), and the persist below writes the list
+               with the path where the scratch:<guid> entry used to be. A file-backed
+               session was never a scratch, has no buffer id, and passes through as a
+               no-op. */
+            DropScratchBuffer(session);
             /* #490: the one way a tab's place in the session-restore list changes while tab
                membership stays constant — a scratch gaining its first file, or Save As moving
                an existing one. The tab watcher sees neither (no tab was added, removed, or
@@ -468,9 +477,14 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
-    /// The file behind every open tab that has one, in tab order, then the file behind every
-    /// detached window that has one, in detach order. Plans and queries both, since
-    /// <see cref="GetContentFilePath"/> answers for either shape.
+    /// The session-restore entry for every open tab that has one, in tab order, then for
+    /// every detached window that has one, in detach order. Plans and queries both, since
+    /// <see cref="GetContentSessionEntry"/> answers for either shape — and since #496 the
+    /// entries are not all paths: a scratch tab with a persisted buffer rides along as
+    /// <c>scratch:&lt;guid&gt;</c>, IN PLACE, so the strip order the user arranged survives
+    /// a restart with scratch tabs interleaved among the files exactly where they were
+    /// (deliberately better than #495's append-after compromise, which was about detached
+    /// windows, not about tabs sitting between other tabs).
     /// </summary>
     /// <remarks>
     /// <para>Separate from <see cref="SaveOpenPlans"/> so a test can assert what would be
@@ -484,37 +498,37 @@ public partial class MainWindow : Window
     /// a file was open is the data-loss fix, remembering window geometry is a different
     /// feature, deliberately not built here.</para>
     /// </remarks>
-    internal List<string> CollectOpenTabPaths()
+    internal List<string> CollectOpenTabEntries()
     {
-        var paths = new List<string>();
+        var entries = new List<string>();
 
         foreach (var item in MainTabControl.Items)
         {
             if (item is not TabItem tab) continue;
 
-            var path = GetTabFilePath(tab);
-            if (!string.IsNullOrEmpty(path))
-                paths.Add(path);
+            var entry = GetContentSessionEntry(tab.Content as Control);
+            if (!string.IsNullOrEmpty(entry))
+                entries.Add(entry);
         }
 
         foreach (var content in _detachedTabContents)
         {
-            var path = GetContentFilePath(content);
-            if (!string.IsNullOrEmpty(path))
-                paths.Add(path);
+            var entry = GetContentSessionEntry(content);
+            if (!string.IsNullOrEmpty(entry))
+                entries.Add(entry);
         }
 
-        return paths;
+        return entries;
     }
 
     /// <summary>
-    /// Saves the file paths of all currently open file-based tabs, plans and queries alike,
-    /// docked and detached alike (#490).
+    /// Saves the restore entries of all currently open tabs — file paths, and since #496
+    /// scratch buffer entries — docked and detached alike (#490).
     /// </summary>
     private void SaveOpenPlans()
     {
         _appSettings.OpenTabs.Clear();
-        _appSettings.OpenTabs.AddRange(CollectOpenTabPaths());
+        _appSettings.OpenTabs.AddRange(CollectOpenTabEntries());
 
         AppSettingsService.Save(_appSettings);
     }
@@ -585,7 +599,21 @@ public partial class MainWindow : Window
     {
         _sessionPersistTimer?.Stop();
 
-        if (!_sessionPersistPending || IsShuttingDown)
+        if (IsShuttingDown)
+            return;
+
+        /* #496: the list and the buffers it references travel together — any moment the
+           membership list could be written is a moment the scratch content backing its
+           scratch:<guid> entries must already be on disk, or a crash right after the write
+           leaves entries pointing at stale buffers. Draining the content writer here also
+           means every #495 flush point (end of restore, the membership debounce, the test
+           seam) drains scratch for free. Note the ordering dependency: this can mint a
+           first buffer id and set _sessionPersistPending, which is exactly why it runs
+           before the pending check below — the entry the mint created gets written in the
+           same flush, not a debounce later. */
+        FlushScratchBuffers();
+
+        if (!_sessionPersistPending)
             return;
 
         _sessionPersistPending = false;
@@ -609,7 +637,15 @@ public partial class MainWindow : Window
     /// list current by now anyway, but "usually" is a debounce interval wide; this write is
     /// what makes the restart exact.
     /// </summary>
-    internal void PersistSessionForRestart() => SaveOpenPlans();
+    internal void PersistSessionForRestart()
+    {
+        /* #496: same reasoning as the write itself, one layer down — the restart skips
+           OnClosed, so this is the last chance for scratch content typed inside the content
+           debounce to reach disk, and the list written below must reference buffers that
+           exist. */
+        FlushScratchBuffers();
+        SaveOpenPlans();
+    }
 
     /// <summary>
     /// Restores the tabs from the previous session. Skips files that no longer exist.
@@ -637,6 +673,15 @@ public partial class MainWindow : Window
     /// is the other half of the deal — once restore completes, the rebuilt list is on disk
     /// immediately rather than a debounce-interval later, so the common case (restore fine,
     /// crash any time afterwards) loses nothing.</para>
+    ///
+    /// <para><b>Scratch entries (#496).</b> The list routes three ways now: a
+    /// <c>scratch:&lt;guid&gt;</c> entry recreates a dirty query tab from its persisted
+    /// buffer, a plain path opens by extension as always, and an old build reading a list
+    /// with scratch entries in it skips them on its File.Exists guard (see
+    /// <see cref="ScratchBufferStore"/> for why that is guaranteed). Scratch buffers share
+    /// the poison defense wholesale — the entry is already off the cleared list before its
+    /// buffer is read, and a buffer that fails to load is skipped, never re-added, and
+    /// deleted (<see cref="TryRestoreScratchTab"/>).</para>
     /// </summary>
     private void RestoreOpenPlans()
     {
@@ -647,13 +692,36 @@ public partial class MainWindow : Window
         _appSettings.OpenTabs.Clear();
         AppSettingsService.Save(_appSettings);
 
-        var restored = false;
-
-        foreach (var path in savedTabs)
+        /* #496 orphan sweep, from the just-read snapshot and independent of the poison
+           clear above: buffers are deleted the moment the user chooses their fate, so a
+           file no entry references is debris by definition — a buffer stranded by a crash
+           in the write-buffer-then-write-list gap, an AtomicFile .tmp, a buffer whose entry
+           a previous poisoned restore dropped. Before the restore loop, so what the loop is
+           about to read (the referenced set) is exactly what the sweep keeps. */
+        var referencedScratch = new HashSet<Guid>();
+        foreach (var entry in savedTabs)
         {
-            if (File.Exists(path))
+            if (ScratchBufferStore.TryParseEntry(entry, out var referencedId))
+                referencedScratch.Add(referencedId);
+        }
+        ScratchBufferStore.SweepAllExcept(referencedScratch);
+
+        var restored = false;
+        var restoredScratch = new HashSet<Guid>();
+
+        foreach (var entry in savedTabs)
+        {
+            if (ScratchBufferStore.TryParseEntry(entry, out var scratchId))
             {
-                OpenFileByExtension(path);
+                /* Add() doubling as the seen-check: a list corrupted into naming the same
+                   buffer twice must not open two tabs continuing one file — their flushes
+                   would silently overwrite each other forever after. */
+                if (restoredScratch.Add(scratchId) && TryRestoreScratchTab(scratchId))
+                    restored = true;
+            }
+            else if (File.Exists(entry))
+            {
+                OpenFileByExtension(entry);
                 restored = true;
             }
         }

--- a/src/PlanViewer.App/MainWindow.FileOps.cs
+++ b/src/PlanViewer.App/MainWindow.FileOps.cs
@@ -173,7 +173,14 @@ public partial class MainWindow : Window
     {
         try
         {
-            File.WriteAllText(path, session.QueryEditor.Text);
+            /* Atomic on purpose: on the save-in-place path this file is the user's only copy
+               of their query, and a plain truncate-then-write destroys it when the write dies
+               halfway — disk full, crash, yanked share. AtomicFile stages a sibling .tmp and
+               renames it over the top, so a failed save leaves the original bytes on disk and
+               lands in the catch below with the session still dirty. The rename gives the file
+               the temp's attributes and inherited ACLs rather than preserving the original's —
+               the trade every editor that saves this way makes. */
+            AtomicFile.WriteAllText(path, session.QueryEditor.Text);
             session.SourceFilePath = path;
             // Only a write that actually happened settles the dirty state; the catch below
             // deliberately leaves the session modified so the work is still guarded.
@@ -447,6 +454,15 @@ public partial class MainWindow : Window
 
         AppSettingsService.Save(_appSettings);
     }
+
+    /// <summary>
+    /// Writes the open-tab list down for the session that comes back after a Velopack
+    /// restart. <see cref="OnClosed"/> does this on every ordinary shutdown, but
+    /// ApplyUpdatesAndRestart exits the process without closing the window — and
+    /// <see cref="RestoreOpenPlans"/> already cleared the saved list at startup, so without
+    /// this the updated app relaunched with nothing.
+    /// </summary>
+    internal void PersistSessionForRestart() => SaveOpenPlans();
 
     /// <summary>
     /// Restores the tabs from the previous session. Skips files that no longer exist.

--- a/src/PlanViewer.App/MainWindow.FileOps.cs
+++ b/src/PlanViewer.App/MainWindow.FileOps.cs
@@ -188,6 +188,13 @@ public partial class MainWindow : Window
                UTF-8-without-BOM this always wrote. */
             AtomicFile.WriteAllText(path, session.QueryEditor.Text, session.SourceFileEncoding);
             session.SourceFilePath = path;
+            /* #490: the one way a tab's place in the session-restore list changes while tab
+               membership stays constant — a scratch gaining its first file, or Save As moving
+               an existing one. The tab watcher sees neither (no tab was added, removed, or
+               swapped), so the persist trigger lives at the assignment. Detached sessions save
+               through here too (tab == null); their register entry serves up the new path the
+               same way. */
+            RequestSessionPersist();
             // Only a write that actually happened settles the dirty state; the catch below
             // deliberately leaves the session modified so the work is still guarded.
             session.MarkClean();
@@ -461,12 +468,21 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
-    /// The file behind every open tab that has one, in tab order. Plans and queries both,
-    /// since <see cref="GetTabFilePath"/> answers for either shape.
+    /// The file behind every open tab that has one, in tab order, then the file behind every
+    /// detached window that has one, in detach order. Plans and queries both, since
+    /// <see cref="GetContentFilePath"/> answers for either shape.
     /// </summary>
     /// <remarks>
-    /// Separate from <see cref="SaveOpenPlans"/> so a test can assert what would be persisted
-    /// without writing over the user's real settings file.
+    /// <para>Separate from <see cref="SaveOpenPlans"/> so a test can assert what would be
+    /// persisted without writing over the user's real settings file.</para>
+    ///
+    /// <para>#490's detached half: this used to walk MainTabControl alone, so a file-backed
+    /// plan or query detached into its own window at exit was never written down and never
+    /// came back. Detached entries are appended AFTER the docked tabs — docked order is the
+    /// order the user arranged and keeps it; detach order is best-effort. On the next start
+    /// they all come back as ordinary docked tabs, not re-detached windows: remembering THAT
+    /// a file was open is the data-loss fix, remembering window geometry is a different
+    /// feature, deliberately not built here.</para>
     /// </remarks>
     internal List<string> CollectOpenTabPaths()
     {
@@ -481,11 +497,19 @@ public partial class MainWindow : Window
                 paths.Add(path);
         }
 
+        foreach (var content in _detachedTabContents)
+        {
+            var path = GetContentFilePath(content);
+            if (!string.IsNullOrEmpty(path))
+                paths.Add(path);
+        }
+
         return paths;
     }
 
     /// <summary>
-    /// Saves the file paths of all currently open file-based tabs, plans and queries alike.
+    /// Saves the file paths of all currently open file-based tabs, plans and queries alike,
+    /// docked and detached alike (#490).
     /// </summary>
     private void SaveOpenPlans()
     {
@@ -495,12 +519,95 @@ public partial class MainWindow : Window
         AppSettingsService.Save(_appSettings);
     }
 
+    // ── Continuous session persistence (#490) ─────────────────────────────
+
+    /* #468 wrote the list once, at clean close, and #490 is what that cost: any abnormal exit
+       — a crash, a task kill, an OS "shut down anyway" past the dirty-tab prompt — restored
+       zero tabs, because the only writer never ran. Membership changes now write the list as
+       they happen, debounced so a burst (session restore, Close All) lands as one write. The
+       triggers are wired centrally, not per call site — see the TabContentWatcher hookup in
+       the constructor for why. */
+
+    /// <summary>How long the writer waits for a burst of membership changes to settle.</summary>
+    private static readonly TimeSpan SessionPersistDebounce = TimeSpan.FromSeconds(1);
+
+    /// <summary>Trailing-edge debounce for <see cref="SaveOpenPlans"/>; every request restarts it.</summary>
+    private DispatcherTimer? _sessionPersistTimer;
+
+    /// <summary>
+    /// Whether a membership change is waiting to be written. Under the test host this flag is
+    /// the whole mechanism — see <see cref="RequestSessionPersist"/>.
+    /// </summary>
+    private bool _sessionPersistPending;
+
+    /// <summary>
+    /// Notes that tab membership changed — a tab opened, closed, detached, redocked, or gained
+    /// a file path — and schedules the debounced write. Called by the tab watcher for
+    /// everything visible on the strip, and explicitly by the detached register and
+    /// <see cref="SaveQueryToPath"/> for the two changes the strip cannot show.
+    /// </summary>
+    private void RequestSessionPersist()
+    {
+        /* OnClosed is already writing the final authoritative list (and force-closing the
+           detached windows, whose Forget calls land right back here). Nothing may re-arm the
+           timer against a window being torn down. */
+        if (IsShuttingDown)
+            return;
+
+        _sessionPersistPending = true;
+
+        /* No real timer under the test host, in #451's pattern: the suite shares one
+           dispatcher across every test, so a timer armed here would tick during some LATER
+           test's RunJobs and write THIS window's tab list over whatever that test had staged
+           in the redirected settings file — exactly the cross-test bleed the redirect exists
+           to stop. Tests drive the flush deterministically through
+           <see cref="FlushPendingSessionPersistForTests"/> instead. */
+        if (AppRuntimeMode.IsTestHost)
+            return;
+
+        if (_sessionPersistTimer == null)
+        {
+            _sessionPersistTimer = new DispatcherTimer { Interval = SessionPersistDebounce };
+            _sessionPersistTimer.Tick += (_, _) => FlushSessionPersist();
+        }
+
+        // Stop-then-start restarts the interval, which is what makes it a debounce.
+        _sessionPersistTimer.Stop();
+        _sessionPersistTimer.Start();
+    }
+
+    /// <summary>
+    /// Writes a pending membership change down now. The timer's tick, the end of
+    /// <see cref="RestoreOpenPlans"/>, and the test seam all land here; a flush with nothing
+    /// pending is free.
+    /// </summary>
+    private void FlushSessionPersist()
+    {
+        _sessionPersistTimer?.Stop();
+
+        if (!_sessionPersistPending || IsShuttingDown)
+            return;
+
+        _sessionPersistPending = false;
+        SaveOpenPlans();
+    }
+
+    /// <summary>
+    /// The deterministic stand-in for the debounce timer's tick — tests call this where the
+    /// real app waits out <see cref="SessionPersistDebounce"/>. A seam rather than a sleep
+    /// because the harness shares one dispatcher across the whole suite; see
+    /// <see cref="RequestSessionPersist"/> for what a real timer does to that arrangement.
+    /// </summary>
+    internal void FlushPendingSessionPersistForTests() => FlushSessionPersist();
+
     /// <summary>
     /// Writes the open-tab list down for the session that comes back after a Velopack
     /// restart. <see cref="OnClosed"/> does this on every ordinary shutdown, but
     /// ApplyUpdatesAndRestart exits the process without closing the window — and
     /// <see cref="RestoreOpenPlans"/> already cleared the saved list at startup, so without
-    /// this the updated app relaunched with nothing.
+    /// this the updated app relaunched with nothing. #490's continuous writer usually has the
+    /// list current by now anyway, but "usually" is a debounce interval wide; this write is
+    /// what makes the restart exact.
     /// </summary>
     internal void PersistSessionForRestart() => SaveOpenPlans();
 
@@ -511,12 +618,38 @@ public partial class MainWindow : Window
     /// <para>The saved list holds queries as well as plans, so it routes on extension the
     /// same way an ordinary file open does. Sending a .sql file to LoadPlanFile would greet
     /// the user with "the XML is not valid" where their query used to be.</para>
+    ///
+    /// <para><b>The crash-loop defense (#490).</b> The list is cleared and saved EMPTY before
+    /// the first file is opened, so a file that crashes the app during its own load is already
+    /// off the list when the next start reads it — a poisoned entry can never wedge the app
+    /// into crashing at every launch. (The clear used to run after the loop, which only
+    /// defended against crashes AFTER restore finished; a file that crashed DURING it left
+    /// the list intact and looped forever.) Every file that opens successfully re-enters the
+    /// list through the debounced writer, so the net behavior is strictly better than the old
+    /// all-or-nothing: the poison never persists, and everything that actually opened
+    /// does.</para>
+    ///
+    /// <para>Honestly, "everything that opened" holds for a crash after restore, not during
+    /// it. The re-adds are debounced and this loop runs synchronously on the UI thread, so a
+    /// crash while file B loads means file A's pending re-add never flushed and A is lost for
+    /// that start too. Accepted: the invariant being defended is that the poison never
+    /// persists, not that every good tab survives a mid-restore crash. The flush at the end
+    /// is the other half of the deal — once restore completes, the rebuilt list is on disk
+    /// immediately rather than a debounce-interval later, so the common case (restore fine,
+    /// crash any time afterwards) loses nothing.</para>
     /// </summary>
     private void RestoreOpenPlans()
     {
+        /* Snapshot first: SaveOpenPlans and this method share the live list, and the clear
+           below would otherwise empty the very thing being iterated. */
+        var savedTabs = _appSettings.OpenTabs.ToList();
+
+        _appSettings.OpenTabs.Clear();
+        AppSettingsService.Save(_appSettings);
+
         var restored = false;
 
-        foreach (var path in _appSettings.OpenTabs)
+        foreach (var path in savedTabs)
         {
             if (File.Exists(path))
             {
@@ -525,9 +658,9 @@ public partial class MainWindow : Window
             }
         }
 
-        // Clear the restored list now that its tabs are back on screen
-        _appSettings.OpenTabs.Clear();
-        AppSettingsService.Save(_appSettings);
+        /* Each successful open armed the debounced writer through the tab watcher; write it
+           down NOW so a crash a moment after startup still finds the session on disk. */
+        FlushSessionPersist();
 
         if (!restored)
         {

--- a/src/PlanViewer.App/MainWindow.FileOps.cs
+++ b/src/PlanViewer.App/MainWindow.FileOps.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -180,7 +181,12 @@ public partial class MainWindow : Window
                lands in the catch below with the session still dirty. The rename gives the file
                the temp's attributes and inherited ACLs rather than preserving the original's —
                the trade every editor that saves this way makes. */
-            AtomicFile.WriteAllText(path, session.QueryEditor.Text);
+            /* In the encoding the file was opened with, when it declared one: a .sql from SSMS
+               is UTF-16 with a BOM, and writing it back as the default UTF-8 was a silent
+               transcode of the user's only copy — reading honored the BOM, saving discarded
+               it. A scratch session (and a BOM-less file) has null here and keeps the default
+               UTF-8-without-BOM this always wrote. */
+            AtomicFile.WriteAllText(path, session.QueryEditor.Text, session.SourceFileEncoding);
             session.SourceFilePath = path;
             // Only a write that actually happened settles the dirty state; the catch below
             // deliberately leaves the session modified so the work is still guarded.
@@ -278,6 +284,8 @@ public partial class MainWindow : Window
             var session = new QuerySessionControl(_credentialService, _connectionStore);
             session.QueryEditor.Text = text;
             session.SourceFilePath = filePath;
+            // What the file declared is what a save must write back — see SourceFileEncoding.
+            session.SourceFileEncoding = DetectBomEncoding(filePath);
             // What was just loaded is what is on disk — the baseline every later edit is measured against.
             session.MarkClean();
 
@@ -290,6 +298,38 @@ public partial class MainWindow : Window
         {
             ShowFileError("Error Opening File", $"Failed to open: {Path.GetFileName(filePath)}", ex.Message);
         }
+    }
+
+    /// <summary>
+    /// The encoding a file's byte order mark declares, or null when it has none.
+    ///
+    /// <para>Deliberately a sniff of the mark rather than StreamReader.CurrentEncoding after a
+    /// read: CurrentEncoding only moves off its default for UTF-16/32 marks, so it cannot tell
+    /// a UTF-8-with-BOM file from a plain one — and the default instance it reports EMITS a
+    /// mark on write, so handing it to the save would stamp BOMs onto files that never had
+    /// one, a silent change in the opposite direction from the one being fixed. The mark is
+    /// the fact being preserved, so the mark is what gets read.</para>
+    /// </summary>
+    private static Encoding? DetectBomEncoding(string filePath)
+    {
+        Span<byte> mark = stackalloc byte[4];
+        int read;
+        using (var stream = File.OpenRead(filePath))
+            read = stream.Read(mark);
+
+        // UTF-32 LE opens with UTF-16 LE's mark plus two zero bytes, so it is checked first.
+        if (read >= 4 && mark[0] == 0xFF && mark[1] == 0xFE && mark[2] == 0x00 && mark[3] == 0x00)
+            return new UTF32Encoding(bigEndian: false, byteOrderMark: true);
+        if (read >= 4 && mark[0] == 0x00 && mark[1] == 0x00 && mark[2] == 0xFE && mark[3] == 0xFF)
+            return new UTF32Encoding(bigEndian: true, byteOrderMark: true);
+        if (read >= 3 && mark[0] == 0xEF && mark[1] == 0xBB && mark[2] == 0xBF)
+            return new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+        if (read >= 2 && mark[0] == 0xFF && mark[1] == 0xFE)
+            return Encoding.Unicode;
+        if (read >= 2 && mark[0] == 0xFE && mark[1] == 0xFF)
+            return Encoding.BigEndianUnicode;
+
+        return null;
     }
 
     /// <summary>

--- a/src/PlanViewer.App/MainWindow.PlanViewer.cs
+++ b/src/PlanViewer.App/MainWindow.PlanViewer.cs
@@ -27,7 +27,13 @@ namespace PlanViewer.App;
 
 public partial class MainWindow : Window
 {
-    private DockPanel CreatePlanTabContent(PlanViewerControl viewer)
+    /// <summary>
+    /// Wraps a loaded plan in the toolbar a window-level plan tab shows above it.
+    ///
+    /// <para>Internal so a test can reproduce what Get Actual Plan does to a file tab — build this
+    /// and assign it over a tab that was holding a spinner — without executing anything (#447).</para>
+    /// </summary>
+    internal DockPanel CreatePlanTabContent(PlanViewerControl viewer)
     {
         var humanBtn = new Button
         {

--- a/src/PlanViewer.App/MainWindow.ScratchPersist.cs
+++ b/src/PlanViewer.App/MainWindow.ScratchPersist.cs
@@ -1,0 +1,352 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using PlanViewer.App.Controls;
+using PlanViewer.App.Services;
+
+namespace PlanViewer.App;
+
+public partial class MainWindow : Window
+{
+    // ── Scratch buffer content persistence (#496) ─────────────────────────
+
+    /* #495 made the open-tab LIST survive abnormal exits, which brought back every tab that
+       had a file behind it. The remaining loss was the tab that never had one: a scratch
+       query — typed, never saved — kept its place on nothing and lost its CONTENT to any
+       crash, task kill, or OS "shut down anyway". Every interactive way to discard that
+       content already stops and asks (#462/#469/#473/#477), so the design center here is
+       the gap those prompts cannot cover:
+
+           a buffer the user CHOSE to discard dies;
+           a buffer they NEVER GOT TO CHOOSE about survives.
+
+       Concretely: content is written continuously (debounced) to one file per scratch tab,
+       the tab enters the #495 session list as a scratch:<guid> entry in strip order, and
+       the buffer file is deleted at exactly the moments the user answers for it — Don't
+       Save at any prompt, or a save that moves the content into a real file. After a clean
+       close, every scratch buffer is therefore gone, because every one of them was chosen
+       about; buffers exist on disk only after an exit nobody was asked about.
+
+       SCOPE FENCE, on purpose: only SCRATCH tabs' content is persisted. Unsaved edits to a
+       FILE-backed tab stay guarded by the prompts alone — the file is the durable copy the
+       user opted into, and shadowing every open file's edits is a different feature with
+       different questions (staleness against on-disk changes, most of all). That is #496's
+       issue scope, not an oversight. */
+
+    /// <summary>
+    /// How long the writer waits after the last edit before writing a scratch buffer down.
+    /// Deliberately its own debounce, longer than <see cref="SessionPersistDebounce"/>:
+    /// membership changes are click-scale and rare, content changes are keystroke-scale and
+    /// constant, and reusing the membership timer would either write the settings file on a
+    /// typing cadence or slow membership writes to a typing idle. Two timers, two cadences,
+    /// one flush discipline (each flush point drains both — see <see cref="FlushSessionPersist"/>).
+    /// </summary>
+    private static readonly TimeSpan ScratchPersistDebounce = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// A scratch buffer larger than this is not persisted. A pathological paste must not
+    /// grind the idle writer — rewriting megabytes to disk two seconds after every
+    /// keystroke — so past the cap that one tab simply behaves as it did before #496:
+    /// prompts guard it, crashes lose it. Chars rather than bytes because the check has to
+    /// be free on every flush; for SQL text the two are within a small factor of each other,
+    /// and the cap is a courtesy threshold, not a contract.
+    /// </summary>
+    private const int MaxScratchPersistChars = 1024 * 1024;
+
+    /// <summary>Trailing-edge debounce for the content writer; every request restarts it.</summary>
+    private DispatcherTimer? _scratchPersistTimer;
+
+    /// <summary>
+    /// The scratch sessions whose content changed since the last flush. A set keyed on the
+    /// session (not the tab) because content identity lives on the session — a detached
+    /// scratch window (#473) edits the same session object and lands in the same set, which
+    /// is the whole of how detached scratch persistence works.
+    /// </summary>
+    private readonly HashSet<QuerySessionControl> _scratchPersistPending = new();
+
+    /// <summary>
+    /// Which sessions already have the persistence subscription, so the re-subscription
+    /// path (redock rebuilds a tab around a living session via CreateTab) does not stack a
+    /// second handler. ConditionalWeakTable for the same reason _tabDirtyGlyphUnhooks is
+    /// one: the bookkeeping must not outlive the session it is about.
+    /// </summary>
+    private readonly ConditionalWeakTable<QuerySessionControl, object> _scratchPersistHooked = new();
+
+    /// <summary>
+    /// Wires a query session's edits into the scratch content writer. Called from
+    /// <see cref="CreateTab"/> — the one place every top-level session passes through —
+    /// rather than at each construction site, the same sixteen-call-sites reasoning as the
+    /// #495 tab watcher. Idempotent per session, because redock passes a session through
+    /// CreateTab a second time.
+    ///
+    /// <para>The subscription is never taken back off: unlike the glyph handler it closes
+    /// over no TabItem, only the session and this window, so it pins nothing a closed tab
+    /// should release — and a DETACHED session must keep persisting (#496's sixth
+    /// requirement), which is exactly the case an unhook-on-detach would break.</para>
+    /// </summary>
+    private void HookScratchPersistence(QuerySessionControl session)
+    {
+        /* Only sessions that are scratch NOW. SourceFilePath moves null→path exactly once
+           (the save) and never back, so a session arriving here file-backed can never need
+           this hook later — the scope fence again, applied at subscription time. It also
+           keeps a file tab's DirtyStateChanged invocation list exactly the one subscription
+           the #473 glyph-leak test counts by reflection; a second subscriber there would
+           read as the leak that test exists to catch. A scratch that gains a file KEEPS its
+           subscription (nothing unhooks it), which is why the fire-time guard below still
+           exists: it is what makes the kept subscription inert from the save on. */
+        if (session.SourceFilePath != null)
+            return;
+
+        if (_scratchPersistHooked.TryGetValue(session, out _))
+            return;
+
+        _scratchPersistHooked.Add(session, new object());
+
+        /* DirtyStateChanged fires on every editor text change (#462's wiring), which is the
+           signal wanted here. It also fires on MarkClean, but a scratch session is only ever
+           marked clean by the save that just gave it a SourceFilePath, so the guard below
+           already ignores that firing. */
+        session.DirtyStateChanged += (_, _) =>
+        {
+            if (session.SourceFilePath == null)
+                RequestScratchPersist(session);
+        };
+
+        /* A session can arrive at its first CreateTab already holding text nobody typed
+           into it there — Edit Query hands a plan's statement to a fresh scratch session,
+           and a restored scratch (#496) comes back with its buffer's content. Both set the
+           text before the tab exists, so the subscription above never saw it; queue one
+           persist now so "scratch content on screen" implies "scratch content on disk,
+           one debounce later". (Scratch is already guaranteed by the top of this method.) */
+        if (session.IsDirty)
+            RequestScratchPersist(session);
+    }
+
+    /// <summary>
+    /// Notes that a scratch session's content changed and schedules the debounced write.
+    /// </summary>
+    private void RequestScratchPersist(QuerySessionControl session)
+    {
+        /* Same shutdown rule as RequestSessionPersist: OnClosed drains this set itself and
+           nothing may re-arm a timer against a window being torn down. */
+        if (IsShuttingDown)
+            return;
+
+        _scratchPersistPending.Add(session);
+
+        /* No real timer under the test host — read RequestSessionPersist's comment for the
+           full #451/#495 story: the suite shares one dispatcher, so a timer armed here would
+           tick during some LATER test and write THIS window's scratch buffers over whatever
+           that test had staged. Tests drive the flush through
+           FlushPendingScratchPersistForTests instead. */
+        if (AppRuntimeMode.IsTestHost)
+            return;
+
+        if (_scratchPersistTimer == null)
+        {
+            _scratchPersistTimer = new DispatcherTimer { Interval = ScratchPersistDebounce };
+            /* The membership flush is chained on so a buffer and its scratch:<guid> entry
+               reach disk in the same breath: the first write for a session assigns its id
+               and requests a membership persist, and without the chained flush that entry
+               would trail the buffer by a debounce — a crash in that gap would strand a
+               buffer the startup sweep then deletes as unreferenced. */
+            _scratchPersistTimer.Tick += (_, _) =>
+            {
+                FlushScratchBuffers();
+                FlushSessionPersist();
+            };
+        }
+
+        // Stop-then-start restarts the interval, which is what makes it a debounce.
+        _scratchPersistTimer.Stop();
+        _scratchPersistTimer.Start();
+    }
+
+    /// <summary>
+    /// Writes every pending scratch buffer down now. The timer's tick, every membership
+    /// flush point (<see cref="FlushSessionPersist"/>, so end-of-restore and the #495
+    /// debounce both drain this), <see cref="OnClosed"/>, and the test seam all land here;
+    /// a flush with nothing pending is free.
+    ///
+    /// <para>Deliberately NOT gated on <see cref="IsShuttingDown"/> the way the membership
+    /// flush is: OnClosed calls this while shutting down, precisely because the final drain
+    /// is part of the final write — see the ordering comment there.</para>
+    /// </summary>
+    private void FlushScratchBuffers()
+    {
+        _scratchPersistTimer?.Stop();
+
+        if (_scratchPersistPending.Count == 0)
+            return;
+
+        /* Snapshot-and-clear before writing: PersistScratchBuffer can call
+           DropScratchBuffer, which edits this set. */
+        var pending = _scratchPersistPending.ToList();
+        _scratchPersistPending.Clear();
+
+        foreach (var session in pending)
+            PersistScratchBuffer(session);
+    }
+
+    /// <summary>
+    /// Writes one session's buffer, or removes it, according to what the session holds now.
+    /// </summary>
+    private void PersistScratchBuffer(QuerySessionControl session)
+    {
+        /* The scope fence, enforced at the writer as well as the subscription: a session
+           that gained a file between queueing and flushing (Save As raced the debounce) is
+           file-backed now, and SaveQueryToPath already deleted its buffer. */
+        if (session.SourceFilePath != null)
+            return;
+
+        /* A buffer exists to protect UNSAVED work, so a session with none sheds its buffer.
+           For a scratch session clean means empty — its saved-text baseline is forever ""
+           (#462) — so this is what erases the buffer of a tab whose text the user deleted
+           back out, instead of resurrecting that text at the next start as if the deletion
+           never happened. Clean close leans on this too: the only scratch tabs the
+           #462/#469/#477 prompts do not ask about are the ones with nothing typed, and this
+           branch is what guarantees those leave no buffer behind either. */
+        if (!session.IsDirty)
+        {
+            DropScratchBuffer(session);
+            return;
+        }
+
+        var text = session.QueryEditor.Text ?? string.Empty;
+
+        /* Over the cap the buffer is not merely skipped but removed: a stale smaller
+           snapshot restoring under megabytes of newer typing would misrepresent what the
+           user had, which is worse than the honest pre-#496 nothing. */
+        if (text.Length > MaxScratchPersistChars)
+        {
+            DropScratchBuffer(session);
+            return;
+        }
+
+        var firstPersist = session.ScratchBufferId == null;
+        if (firstPersist)
+        {
+            /* The id is minted at first persist, not at construction, so an empty tab never
+               owns a buffer; a restored scratch arrives with its id already set and keeps
+               writing the same buffer across restarts. */
+            session.ScratchBufferId = Guid.NewGuid();
+        }
+
+        try
+        {
+            ScratchBufferStore.Write(session.ScratchBufferId!.Value, text);
+        }
+        catch
+        {
+            /* Best-effort, same stance as AppSettingsService.Save: persistence must never
+               crash the editor it exists to protect. A failed write self-heals — either a
+               later flush succeeds, or restore finds no readable buffer and skips the
+               entry. */
+        }
+
+        /* A newly minted id is a membership change: the scratch:<guid> entry has to enter
+           the #495 list, and the tab watcher cannot see it (no tab was added or removed —
+           the same blind spot as SaveQueryToPath's path change, solved the same way). */
+        if (firstPersist)
+            RequestSessionPersist();
+    }
+
+    /// <summary>
+    /// Deletes a session's scratch buffer and forgets its identity. The mechanics of every
+    /// way a buffer dies; the chose-vs-never-got-to-choose reasoning lives at the call
+    /// sites, because WHICH moments may call this is the entire design of #496:
+    /// <list type="bullet">
+    /// <item>Don't Save answered at any #462/#469/#477 prompt — they chose
+    /// (<see cref="ResolveCloseChoiceAsync"/>).</item>
+    /// <item>A save that succeeded — the content lives in a real file now
+    /// (<see cref="SaveQueryToPath"/>).</item>
+    /// <item>A scratch tab or window closed with nothing unsaved in it — nothing left to
+    /// protect (<see cref="TryCloseTabAsync"/>, the detached close, and the clean branch of
+    /// <see cref="PersistScratchBuffer"/>).</item>
+    /// </list>
+    /// Cancel appears nowhere in that list: a cancelled close changes nothing.
+    /// </summary>
+    private void DropScratchBuffer(QuerySessionControl session)
+    {
+        /* Whatever was queued for this session must not be written after the drop — that
+           would resurrect the buffer the user just chose out of existence. */
+        _scratchPersistPending.Remove(session);
+
+        if (session.ScratchBufferId is not { } id)
+            return;
+
+        session.ScratchBufferId = null;
+        ScratchBufferStore.TryDelete(id);
+
+        /* The scratch:<guid> entry has to leave the #495 list with the buffer. Gated inside
+           RequestSessionPersist during shutdown, where OnClosed's own final SaveOpenPlans —
+           which runs after the final drain — writes the list without it. */
+        RequestSessionPersist();
+    }
+
+    /// <summary>
+    /// The deterministic stand-in for the content debounce's tick — the #496 twin of
+    /// <see cref="FlushPendingSessionPersistForTests"/>, for the same shared-dispatcher
+    /// reason (see <see cref="RequestScratchPersist"/>). Mirrors the real tick exactly,
+    /// membership chain included, so a test observes the same disk state a patient user
+    /// would.
+    /// </summary>
+    internal void FlushPendingScratchPersistForTests()
+    {
+        FlushScratchBuffers();
+        FlushSessionPersist();
+    }
+
+    /// <summary>
+    /// Recreates one scratch tab from its persisted buffer during restore. False when the
+    /// buffer cannot come back, and the buffer file is deleted on that path — the #495
+    /// poison invariant, mirrored: an entry that fails to load is skipped, never re-added
+    /// (the session that would re-list it is never created), and its file is swept rather
+    /// than left to fail again at every start.
+    /// </summary>
+    private bool TryRestoreScratchTab(Guid id)
+    {
+        string text;
+        try
+        {
+            text = File.ReadAllText(ScratchBufferStore.BufferPathFor(id));
+        }
+        catch
+        {
+            ScratchBufferStore.TryDelete(id);
+            return false;
+        }
+
+        /* An empty buffer should not exist — the writer deletes rather than writes empties —
+           so finding one means debris; restoring an empty tab from it would be noise. */
+        if (string.IsNullOrEmpty(text))
+        {
+            ScratchBufferStore.TryDelete(id);
+            return false;
+        }
+
+        _queryCounter++;
+        var session = new QuerySessionControl(_credentialService, _connectionStore);
+        session.QueryEditor.Text = text;
+
+        /* The SAME id, not a fresh one: this session continues the buffer it came from, so
+           its next flush overwrites in place and the list entry stays stable across any
+           number of restarts. */
+        session.ScratchBufferId = id;
+
+        /* Deliberately no MarkClean, unlike LoadSqlFile: this content is unsaved BY
+           DEFINITION — nothing on disk that the user chose backs it — so the tab must come
+           back dirty, marker and close-prompts and all. The session's empty saved-text
+           baseline gives that for free. */
+
+        var tab = CreateTab($"Query {_queryCounter}", session);
+        MainTabControl.Items.Add(tab);
+        MainTabControl.SelectedItem = tab;
+        UpdateEmptyOverlay();
+        return true;
+    }
+}

--- a/src/PlanViewer.App/MainWindow.ScratchPersist.cs
+++ b/src/PlanViewer.App/MainWindow.ScratchPersist.cs
@@ -48,6 +48,15 @@ public partial class MainWindow : Window
     private static readonly TimeSpan ScratchPersistDebounce = TimeSpan.FromSeconds(2);
 
     /// <summary>
+    /// The longest an unflushed content change may wait while the debounce keeps being
+    /// restarted by further typing — see the cap in <see cref="RequestScratchPersist"/>.
+    /// </summary>
+    private static readonly TimeSpan ScratchPersistMaxLatency = TimeSpan.FromSeconds(10);
+
+    /// <summary>When the oldest currently-unflushed content change arrived; null when drained.</summary>
+    private DateTime? _scratchPersistOldestPending;
+
+    /// <summary>
     /// A scratch buffer larger than this is not persisted. A pathological paste must not
     /// grind the idle writer — rewriting megabytes to disk two seconds after every
     /// keystroke — so past the cap that one tab simply behaves as it did before #496:
@@ -137,6 +146,20 @@ public partial class MainWindow : Window
             return;
 
         _scratchPersistPending.Add(session);
+        _scratchPersistOldestPending ??= DateTime.UtcNow;
+
+        /* Max-latency cap (#496 review): a trailing-edge debounce restarts on every
+           keystroke, so continuous typing would defer the write indefinitely — the
+           protection at its weakest exactly while the user is producing the most content.
+           Once the oldest unflushed change has waited this long, write now instead of
+           re-arming; the flush clears the timestamp, so a pause afterwards returns to
+           ordinary debouncing. */
+        if (DateTime.UtcNow - _scratchPersistOldestPending >= ScratchPersistMaxLatency)
+        {
+            FlushScratchBuffers();
+            FlushSessionPersist();
+            return;
+        }
 
         /* No real timer under the test host — read RequestSessionPersist's comment for the
            full #451/#495 story: the suite shares one dispatcher, so a timer armed here would
@@ -179,6 +202,7 @@ public partial class MainWindow : Window
     private void FlushScratchBuffers()
     {
         _scratchPersistTimer?.Stop();
+        _scratchPersistOldestPending = null;
 
         if (_scratchPersistPending.Count == 0)
             return;

--- a/src/PlanViewer.App/MainWindow.Tabs.cs
+++ b/src/PlanViewer.App/MainWindow.Tabs.cs
@@ -224,10 +224,17 @@ public partial class MainWindow : Window
     /// session, and whether <b>Copy Path</b> appears on the tab's context menu. A shape it does
     /// not know about loses both without saying anything.</para>
     /// </summary>
-    private static string? GetTabFilePath(TabItem tab)
+    private static string? GetTabFilePath(TabItem tab) => GetContentFilePath(tab.Content as Control);
+
+    /// <summary>
+    /// The same answer keyed on the content itself, because since #490 the question is also
+    /// asked about content with no tab behind it: a detached window holds the control that WAS
+    /// a tab's content, and what file backs it is a fact about the control, not the strip.
+    /// </summary>
+    private static string? GetContentFilePath(Control? content)
     {
         // Plans opened from file are wrapped in a DockPanel with the viewer as the last child
-        if (tab.Content is DockPanel dp)
+        if (content is DockPanel dp)
         {
             foreach (var child in dp.Children)
             {
@@ -237,7 +244,7 @@ public partial class MainWindow : Window
         }
 
         // Queries are the session control itself, with no wrapper around it
-        if (tab.Content is QuerySessionControl session)
+        if (content is QuerySessionControl session)
             return session.SourceFilePath;
 
         return null;
@@ -347,7 +354,7 @@ public partial class MainWindow : Window
             backgroundBrush: (Avalonia.Media.IBrush?)this.FindResource("BackgroundBrush"),
             onRedock: c =>
             {
-                ForgetDetachedQuerySession(c);
+                ForgetDetachedTabContent(c);
 
                 if (!IsShuttingDown)
                 {
@@ -359,14 +366,14 @@ public partial class MainWindow : Window
             },
             onClosing: c =>
             {
-                ForgetDetachedQuerySession(c);
+                ForgetDetachedTabContent(c);
 
                 if (c is QueryStoreHistoryControl hc)
                     hc.CancelFetch();
             },
             closeGuard: DetachedQueryCloseGuard);
 
-        RememberDetachedQuerySession(detachedWindow, content);
+        RememberDetachedTabContent(detachedWindow, content);
 
         /* #447 made Compare a window-wide count, and this session just left the window: the
            count it is showing is about tabs it can no longer reach. Nothing else recomputes it

--- a/src/PlanViewer.App/MainWindow.Tabs.cs
+++ b/src/PlanViewer.App/MainWindow.Tabs.cs
@@ -402,13 +402,18 @@ public partial class MainWindow : Window
                 /* #496: a detached scratch window ACTUALLY closing is the session leaving
                    the app by the user's hand — the detached twin of TryCloseTabAsync's
                    drop. This callback never runs on redock (the helper's redocked latch
-                   returns first), so a redocked scratch keeps its buffer. Safe at shutdown's
-                   force-close too: by then every DIRTY scratch was resolved at the
-                   #462/#469/#477 walk (saved sessions are no longer scratch, Don't-Saved
-                   ones already dropped), so the only session this can still touch is a
-                   clean one — empty, by scratch's definition of clean — whose buffer is at
-                   most a stale leftover the flush rules would delete anyway. */
-                if (c is QuerySessionControl { SourceFilePath: null } scratchSession)
+                   returns first), so a redocked scratch keeps its buffer.
+
+                   Gated off during shutdown's force-close (#496 review, third finding):
+                   the walk's prompts are modal only to their own window, so the user can
+                   type into a DIFFERENT detached scratch while a prompt is up — dirty,
+                   never asked. OnClosed's final flush writes that buffer and lists its
+                   entry; letting this drop run in the force-close storm afterwards would
+                   delete the just-written buffer and leave the entry dangling. By then the
+                   final write has already made every keep-or-drop decision, and skipping
+                   here loses nothing: OnClosed's flush sheds clean sessions' stale buffers
+                   itself. */
+                if (!IsShuttingDown && c is QuerySessionControl { SourceFilePath: null } scratchSession)
                     DropScratchBuffer(scratchSession);
 
                 if (c is QueryStoreHistoryControl hc)

--- a/src/PlanViewer.App/MainWindow.Tabs.cs
+++ b/src/PlanViewer.App/MainWindow.Tabs.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -36,6 +37,17 @@ public partial class MainWindow : Window
             return s;
         return "Tab";
     }
+
+    /* The glyph refresher CreateTab subscribes onto a query session, keyed by the tab it was
+       built for, so DetachTabToWindow can take exactly its own subscription off again. The
+       session OUTLIVES its tab on the detach path — the tab is discarded, the session moves
+       into the detached window still holding a handler that closes over the dead tab's close
+       button — and redock re-subscribes through CreateTab, so every detach/redock cycle used
+       to pin one more dead TabItem (visual tree and all) to the session for the session's
+       lifetime. A ConditionalWeakTable rather than a Dictionary so the bookkeeping cannot
+       become its own leak: a tab closed normally dies together with its session, and its
+       entry evaporates with the key. */
+    private readonly ConditionalWeakTable<TabItem, Action> _tabDirtyGlyphUnhooks = new();
 
     private TabItem CreateTab(string label, Control content)
     {
@@ -83,7 +95,14 @@ public partial class MainWindow : Window
             void RefreshCloseGlyph() =>
                 closeBtn.Content = CloseButtonGlyph(querySession.IsDirty, closeBtn.IsPointerOver);
 
-            querySession.DirtyStateChanged += (_, _) => RefreshCloseGlyph();
+            /* Named and written down rather than subscribed inline: of everything wired up
+               here, this is the one subscription that lands on an object that can outlive the
+               tab, so it is the one detach has to be able to undo — see _tabDirtyGlyphUnhooks.
+               The pointer handlers below live and die with the button itself. */
+            EventHandler refreshOnDirtyChange = (_, _) => RefreshCloseGlyph();
+            querySession.DirtyStateChanged += refreshOnDirtyChange;
+            _tabDirtyGlyphUnhooks.Add(tab, () => querySession.DirtyStateChanged -= refreshOnDirtyChange);
+
             closeBtn.PointerEntered += (_, _) => RefreshCloseGlyph();
             closeBtn.PointerExited += (_, _) => RefreshCloseGlyph();
 
@@ -303,6 +322,16 @@ public partial class MainWindow : Window
 
         var label = GetTabLabel(tab);
 
+        /* The session is about to leave this tab behind. Take the glyph subscription off it
+           first: the handler is the one reference that would keep the discarded TabItem alive
+           from the still-living session (see _tabDirtyGlyphUnhooks), and redock subscribes
+           afresh through CreateTab. */
+        if (_tabDirtyGlyphUnhooks.TryGetValue(tab, out var unhookDirtyGlyph))
+        {
+            unhookDirtyGlyph();
+            _tabDirtyGlyphUnhooks.Remove(tab);
+        }
+
         // Remove the tab
         MainTabControl.Items.Remove(tab);
         tab.Content = null;
@@ -338,6 +367,17 @@ public partial class MainWindow : Window
             closeGuard: DetachedQueryCloseGuard);
 
         RememberDetachedQuerySession(detachedWindow, content);
+
+        /* #447 made Compare a window-wide count, and this session just left the window: the
+           count it is showing is about tabs it can no longer reach. Nothing else recomputes it
+           here — the session's sub-tab watcher fires on sub-tab changes only, and detaching
+           changes none — so the pre-detach state stuck until the next plan landed. Recompute
+           now; with no MainWindow above it any more, the method's own fallback counts the
+           session's plans, which inside a detached window is the only honest answer. Redock
+           needs no twin call: adding the tab back fires MainWindow's collection watcher. */
+        if (content is QuerySessionControl detachedSession)
+            detachedSession.UpdateCompareButtonState();
+
         return detachedWindow;
     }
 }

--- a/src/PlanViewer.App/MainWindow.Tabs.cs
+++ b/src/PlanViewer.App/MainWindow.Tabs.cs
@@ -109,6 +109,12 @@ public partial class MainWindow : Window
             // A session can arrive already modified — re-docking a detached window builds a
             // fresh tab around a session that has been edited since it left.
             RefreshCloseGlyph();
+
+            /* #496: every top-level query session passes through here exactly when it gets
+               its first tab, which makes this the one wiring point for scratch content
+               persistence — same single-subscription argument as the #495 tab watcher.
+               Idempotent, because redock passes the same living session through again. */
+            HookScratchPersistence(querySession);
         }
 
         // Middle-click to close
@@ -250,6 +256,31 @@ public partial class MainWindow : Window
         return null;
     }
 
+    /// <summary>
+    /// What the session-restore list records for a tab's content: the file path when there
+    /// is one, else the <c>scratch:&lt;guid&gt;</c> entry for a scratch session whose
+    /// content has actually been persisted (#496), else nothing. Layered ON TOP of
+    /// <see cref="GetContentFilePath"/> rather than folded into it, because that method
+    /// also answers Copy Path — and a scratch buffer id is precisely not a path anyone
+    /// should be handed to paste somewhere.
+    ///
+    /// <para>The no-id case is deliberate, not a gap: an empty scratch tab has no buffer
+    /// (ids are minted at first persist), and restoring a parade of blank "Query N" tabs
+    /// would make persistence feel like clutter. A scratch tab earns its entry by having
+    /// content on disk worth coming back for.</para>
+    /// </summary>
+    private static string? GetContentSessionEntry(Control? content)
+    {
+        var path = GetContentFilePath(content);
+        if (path != null)
+            return path;
+
+        if (content is QuerySessionControl { SourceFilePath: null, ScratchBufferId: { } id })
+            return ScratchBufferStore.EntryFor(id);
+
+        return null;
+    }
+
     private void StartRename(StackPanel header, TextBlock headerText)
     {
         var textBox = new TextBox
@@ -367,6 +398,18 @@ public partial class MainWindow : Window
             onClosing: c =>
             {
                 ForgetDetachedTabContent(c);
+
+                /* #496: a detached scratch window ACTUALLY closing is the session leaving
+                   the app by the user's hand — the detached twin of TryCloseTabAsync's
+                   drop. This callback never runs on redock (the helper's redocked latch
+                   returns first), so a redocked scratch keeps its buffer. Safe at shutdown's
+                   force-close too: by then every DIRTY scratch was resolved at the
+                   #462/#469/#477 walk (saved sessions are no longer scratch, Don't-Saved
+                   ones already dropped), so the only session this can still touch is a
+                   clean one — empty, by scratch's definition of clean — whose buffer is at
+                   most a stale leftover the flush rules would delete anyway. */
+                if (c is QuerySessionControl { SourceFilePath: null } scratchSession)
+                    DropScratchBuffer(scratchSession);
 
                 if (c is QueryStoreHistoryControl hc)
                     hc.CancelFetch();

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -164,16 +164,7 @@ public partial class MainWindow : Window
         }, RoutingStrategies.Tunnel);
 
         // Accept command-line argument or restore previously open plans
-        var args = Environment.GetCommandLineArgs();
-        if (args.Length > 1 && File.Exists(args[1]))
-        {
-            LoadPlanFile(args[1]);
-        }
-        else
-        {
-            // Restore plans that were open in the previous session
-            RestoreOpenPlans();
-        }
+        OpenFromStartupArgs(Environment.GetCommandLineArgs());
 
         // Start MCP server if enabled in settings.
         // Not in the test host (#451): this reads the user's real ~/.planview settings and,
@@ -181,6 +172,32 @@ public partial class MainWindow : Window
         // item needs no fallback write — its XAML default is already "MCP Server: Off".
         if (!AppRuntimeMode.IsTestHost)
             StartMcpServer();
+    }
+
+    /// <summary>
+    /// Routes the file handed over on the command line — a double-clicked file association, or
+    /// "PerformanceStudio.exe path" from a shell. Split from the constructor so the routing can
+    /// be tested with an argv of the test's choosing.
+    ///
+    /// <para>Routed by extension, not straight to LoadPlanFile: every other way a path reaches
+    /// this window (the pipe from a second instance, drag-and-drop, session restore) already
+    /// goes through <see cref="OpenFileByExtension"/>, and RestoreOpenPlans' own doc comment
+    /// describes exactly what skipping it does — "Sending a .sql file to LoadPlanFile would
+    /// greet the user with 'the XML is not valid' where their query used to be." That greeting
+    /// is precisely what "PerformanceStudio.exe query.sql" produced. Cold start was the one
+    /// path left hard-wired to the plan loader.</para>
+    /// </summary>
+    internal void OpenFromStartupArgs(string[] args)
+    {
+        if (args.Length > 1 && File.Exists(args[1]))
+        {
+            OpenFileByExtension(args[1]);
+        }
+        else
+        {
+            // Restore plans that were open in the previous session
+            RestoreOpenPlans();
+        }
     }
 
     private void StartPipeServer()

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -348,7 +348,18 @@ public partial class MainWindow : Window
             _sessionPersistTimer?.Stop();
             _sessionPersistPending = false;
 
-            // Save the list of currently open file-based tabs for session restore
+            /* #496, and the order matters: the scratch content writer drains BEFORE the final
+               list write, so the list below references exactly the buffers that exist. On a
+               clean close this drain only ever DELETES — every scratch tab with content was
+               resolved at the #462/#469/#477 prompts by now (saved ones stopped being
+               scratch, Don't-Saved ones already dropped their buffers), so what is left
+               pending is at most a clean scratch shedding a stale buffer. Which is the
+               invariant #496 promises: after a clean close, zero scratch buffers remain,
+               because every one of them was chosen about. */
+            _scratchPersistTimer?.Stop();
+            FlushScratchBuffers();
+
+            // Save the list of currently open tabs (paths and scratch entries) for session restore
             SaveOpenPlans();
 
             _pipeCts.Cancel();
@@ -473,7 +484,7 @@ public partial class MainWindow : Window
         if (content is QuerySessionControl session)
             _detachedQuerySessions.Add((window, session));
 
-        /* This register is half of what CollectOpenTabPaths reads (the tab strip is the other
+        /* This register is half of what CollectOpenTabEntries reads (the tab strip is the other
            half), so a change to it is a membership change the tab watcher cannot see. Detach
            itself also removed a tab — the watcher fired — but by the time the debounced write
            flushes, this entry exists; the debounce is quietly doing ordering work here, since
@@ -540,13 +551,7 @@ public partial class MainWindow : Window
 
         var choice = await UnsavedChangesDialog.ShowAsync(owner, owner.Title ?? "this query");
 
-        return DecideClose(choice, session.SourceFilePath != null) switch
-        {
-            CloseAction.Cancel => false,
-            CloseAction.Close => true,
-            CloseAction.SaveInPlace => SaveQueryToPath(null, session, session.SourceFilePath!),
-            _ => await SaveQueryAsync(null, session, owner.StorageProvider)
-        };
+        return await ResolveCloseChoiceAsync(choice, tab: null, session, owner.StorageProvider);
     }
 
     /// <summary>
@@ -626,13 +631,49 @@ public partial class MainWindow : Window
         MainTabControl.SelectedItem = tab; // show what is being asked about
         var choice = await UnsavedChangesDialog.ShowAsync(this, GetTabLabel(tab));
 
-        return DecideClose(choice, session.SourceFilePath != null) switch
+        return await ResolveCloseChoiceAsync(choice, tab, session, storage: null);
+    }
+
+    /// <summary>
+    /// Acts on the answer to an unsaved-changes prompt, docked and detached alike — the two
+    /// switches this replaces had drifted into near-twins, and #496 needed a THIRD copy or
+    /// one shared resolution point. The point matters beyond deduplication: #496's
+    /// delete-on-choice hooks the RESOLUTION of an answer, not the dialog that collected
+    /// it, so every prompt — tab close, detached close, the shutdown and restart walks —
+    /// honors Don't Save identically by construction. Internal so a test can also drive an
+    /// answer in directly, without a dialog to raise clicks on.
+    /// </summary>
+    /// <param name="tab">Null for a detached session, which has no tab to retitle (#473).</param>
+    /// <param name="storage">
+    /// The picker a Save As should come off of — the detached window's own, so the dialog
+    /// lands where the user is looking (#473). Null means this window's.
+    /// </param>
+    /// <returns>Whether the close may proceed.</returns>
+    internal async Task<bool> ResolveCloseChoiceAsync(
+        UnsavedChangesChoice choice, TabItem? tab, QuerySessionControl session, IStorageProvider? storage)
+    {
+        switch (DecideClose(choice, session.SourceFilePath != null))
         {
-            CloseAction.Cancel => false,
-            CloseAction.Close => true,
-            CloseAction.SaveInPlace => SaveQueryToPath(tab, session, session.SourceFilePath!),
-            _ => await SaveQueryAsync(tab, session)
-        };
+            case CloseAction.Cancel:
+                return false;
+
+            case CloseAction.Close:
+                /* #496, the chose half of chose-vs-never-got-to-choose: Don't Save is the
+                   user explicitly answering "this content may die" — the one signal the
+                   crash-protection buffer must obey, or a discarded query would resurrect
+                   at the next start and the prompt's answer would mean nothing. File-backed
+                   sessions pass through untouched (no buffer to drop); their discarded
+                   edits were never persisted anywhere — the scope fence. */
+                DropScratchBuffer(session);
+                return true;
+
+            case CloseAction.SaveInPlace:
+                // SaveQueryToPath retires any scratch buffer itself — content saved is content chosen.
+                return SaveQueryToPath(tab, session, session.SourceFilePath!);
+
+            default: // SaveAs — DecideClose sends a scratch session's Save here, since it has no path yet.
+                return await SaveQueryAsync(tab, session, storage);
+        }
     }
 
     /// <summary>
@@ -645,6 +686,16 @@ public partial class MainWindow : Window
             return false;
 
         MainTabControl.Items.Remove(tab);
+
+        /* #496: a scratch tab that actually left the strip has had its fate decided —
+           answered at the prompt above (where Don't Save already dropped and a save made it
+           file-backed, so this is a no-op), or clean and therefore never asked. The clean
+           case is the one this line exists for: clean-for-scratch means empty, and an empty
+           tab closed inside the content debounce can still have a stale buffer on disk that
+           would otherwise sit there until the next startup sweep. */
+        if (tab.Content is QuerySessionControl { SourceFilePath: null } closedScratch)
+            DropScratchBuffer(closedScratch);
+
         UpdateEmptyOverlay();
         return true;
     }

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -212,15 +212,23 @@ public partial class MainWindow : Window
            session-restore instead. */
         args = SingleInstance.StripNewInstanceFlag(args);
 
-        if (args.Length > 1 && File.Exists(args[1]))
-        {
+        /* Restore FIRST, on every cold start — then open the requested file on top, where
+           it lands focused. The old either/or (file-arg launches skipped restore entirely)
+           turned destructive once #495/#496 made the saved list continuously rewritten from
+           live membership: a double-clicked file overwrote the list within a debounce,
+           dropping scratch entries, and the NEXT launch's orphan sweep deleted the buffers
+           behind them — never-chosen content destroyed by an everyday flow (#496 review,
+           blocking finding). Restoring unconditionally closes that chain, and it is also
+           what editors do with a double-clicked file; under #489's single instance a
+           running Studio receives the file over the pipe and never re-enters this path, so
+           this only changes the cold start. The restore's new-tab fallback stays out of the
+           way when a file is about to open — a stray empty scratch tab beside the file the
+           user asked for is nobody's intent. */
+        var hasFileArg = args.Length > 1 && File.Exists(args[1]);
+        RestoreOpenPlans(createFallbackTab: !hasFileArg);
+
+        if (hasFileArg)
             OpenFileByExtension(args[1]);
-        }
-        else
-        {
-            // Restore plans that were open in the previous session
-            RestoreOpenPlans();
-        }
     }
 
     private void StartPipeServer()

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.IO;
 using System.IO.Pipes;
 using System.Linq;
@@ -19,6 +18,7 @@ using Avalonia.Platform.Storage;
 using Avalonia.Threading;
 using PlanViewer.App.Controls;
 using PlanViewer.App.Dialogs;
+using PlanViewer.App.Helpers;
 using PlanViewer.App.Services;
 using PlanViewer.Core.Interfaces;
 using PlanViewer.Core.Models;
@@ -79,9 +79,12 @@ public partial class MainWindow : Window
            remove a tab. Compare Plans depends on how many plans exist across the WHOLE window, so
            opening or closing any tab can change whether it is available in every OTHER tab, and a
            refresh that has to be remembered at sixteen call sites is one that gets forgotten at the
-           seventeenth. */
-        if (MainTabControl.Items is INotifyCollectionChanged tabs)
-            tabs.CollectionChanged += (_, _) => RefreshComparePlanAvailability();
+           seventeenth.
+
+           Watching content replacement as well as the collection is the part the first attempt at
+           this got wrong: Get Actual Plan opens a tab holding a spinner and later swaps in the plan,
+           so the tab that gains a plan is one this window already had. */
+        TabContentWatcher.Watch(MainTabControl, RefreshComparePlanAvailability);
 
         // Global hotkeys via tunnel routing so they fire before AvaloniaEdit consumes them
         AddHandler(KeyDownEvent, (_, e) =>

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -30,8 +30,6 @@ namespace PlanViewer.App;
 
 public partial class MainWindow : Window
 {
-    private const string PipeName = "SQLPerformanceStudio_OpenFile";
-
     private readonly ICredentialService _credentialService;
     private readonly ConnectionStore _connectionStore;
     private readonly CancellationTokenSource _pipeCts = new();
@@ -67,7 +65,9 @@ public partial class MainWindow : Window
         if (Enum.TryParse<TimeDisplayMode>(_appSettings.QueryStoreDefaultTimeDisplay, true, out var tdm))
             TimeDisplayHelper.Current = tdm;
 
-        // Listen for file paths from other instances (e.g. SSMS extension).
+        // Listen for file paths from other launches (SSMS extension, a second Studio
+        // launch handing over its file) and for the #489 surface-yourself sentinel a bare
+        // second launch sends instead of running a full instance.
         // Not in the test host (#451): every test window would grab the machine's single
         // SQLPerformanceStudio_OpenFile pipe slot and never release it — OnClosed never
         // runs there — racing any real Studio instance on the same box.
@@ -189,6 +189,15 @@ public partial class MainWindow : Window
     /// </summary>
     internal void OpenFromStartupArgs(string[] args)
     {
+        /* #489: --new-instance is a launcher directive, not a file, and it is scrubbed
+           HERE as well as in Program.Main because this method consumes the raw
+           Environment.GetCommandLineArgs() — Program's scrubbed copy never reaches it.
+           Without this, "PerformanceStudio.exe --new-instance file.sqlplan" would find the
+           flag at args[1]: it happens to fail the File.Exists guard below, but the user's
+           file behind it would still be skipped and the launch would silently
+           session-restore instead. */
+        args = SingleInstance.StripNewInstanceFlag(args);
+
         if (args.Length > 1 && File.Exists(args[1]))
         {
             OpenFileByExtension(args[1]);
@@ -212,21 +221,22 @@ public partial class MainWindow : Window
                 try
                 {
                     using var server = new NamedPipeServerStream(
-                        PipeName, PipeDirection.In, 1,
+                        SingleInstance.PipeName, PipeDirection.In, 1,
                         PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
 
                     await server.WaitForConnectionAsync(token);
 
                     using var reader = new StreamReader(server);
-                    var filePath = await reader.ReadLineAsync();
+                    var line = await reader.ReadLineAsync();
 
-                    if (!string.IsNullOrWhiteSpace(filePath) && File.Exists(filePath))
+                    /* Classified out here rather than inside the UI dispatch on purpose:
+                       Classify calls File.Exists, and a dead UNC path can block for
+                       seconds — that wait belongs on this pipe task, not the dispatcher. */
+                    var kind = SingleInstance.Classify(line);
+                    if (kind != SingleInstance.PipeMessage.Ignore)
                     {
                         await Dispatcher.UIThread.InvokeAsync(() =>
-                        {
-                            OpenFileByExtension(filePath);
-                            Activate();
-                        });
+                            DispatchPipeMessage(kind, line!));
                     }
                 }
                 catch (OperationCanceledException)
@@ -243,6 +253,49 @@ public partial class MainWindow : Window
                 }
             }
         }, token);
+    }
+
+    /// <summary>
+    /// Acts on one classified pipe line, on the UI thread. Split from the pipe loop so the
+    /// dispatch can be pinned by tests without a pipe (#489).
+    ///
+    /// <para>The classification is the compatibility contract with every sender version:
+    /// an existing file path opens — what the SSMS extension and any Studio build have
+    /// always sent, unchanged — the activation sentinel surfaces the window (what a bare
+    /// second launch sends since #489), and anything else, including a path that stopped
+    /// existing between send and receive, was already dropped silently before the
+    /// classifier existed and still is.</para>
+    /// </summary>
+    internal void DispatchPipeMessage(SingleInstance.PipeMessage kind, string line)
+    {
+        switch (kind)
+        {
+            case SingleInstance.PipeMessage.OpenFile:
+                OpenFileByExtension(line);
+                SurfaceWindow();
+                break;
+
+            case SingleInstance.PipeMessage.Activate:
+                SurfaceWindow();
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Brings the main window back to the user after a second launch handed its work to
+    /// this one (#489): restore from minimized, then activate. Deliberately minimal next
+    /// to Lite's surface path — Studio never hides to a tray, so there is nothing to
+    /// re-show.
+    ///
+    /// <para>The file-open message uses it too, where the old handler only called
+    /// Activate(): a plan sent from SSMS to a minimized window used to load into a window
+    /// that stayed in the taskbar.</para>
+    /// </summary>
+    internal void SurfaceWindow()
+    {
+        if (WindowState == WindowState.Minimized)
+            WindowState = WindowState.Normal;
+        Activate();
     }
 
     private void StartMcpServer()

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -100,8 +100,22 @@ public partial class MainWindow : Window
 
            Watching content replacement as well as the collection is the part the first attempt at
            this got wrong: Get Actual Plan opens a tab holding a spinner and later swaps in the plan,
-           so the tab that gains a plan is one this window already had. */
-        TabContentWatcher.Watch(MainTabControl, RefreshComparePlanAvailability);
+           so the tab that gains a plan is one this window already had.
+
+           #490 hangs session persistence on the same watcher, for exactly the reason above: the
+           open-tab list used to be written only at clean close (#468's original scope), so any
+           abnormal exit — crash, task kill, an OS "shut down anyway" past the dirty-tab prompt —
+           restored zero tabs. Requesting a persist at each place that opens or closes a tab is
+           the same sixteen-call-sites trap #447 named; the watcher is the one place that sees
+           them all. The two changes it cannot see get explicit calls instead: detached windows
+           (off the tab strip — see RememberDetachedTabContent / ForgetDetachedTabContent) and a
+           tab whose PATH changes while its membership does not (SaveQueryToPath, where a scratch
+           gains a file). */
+        TabContentWatcher.Watch(MainTabControl, () =>
+        {
+            RefreshComparePlanAvailability();
+            RequestSessionPersist();
+        });
 
         // Global hotkeys via tunnel routing so they fire before AvaloniaEdit consumes them
         AddHandler(KeyDownEvent, (_, e) =>
@@ -272,7 +286,16 @@ public partial class MainWindow : Window
         {
             IsShuttingDown = true;
 
-            // Save the list of currently open file-based plans for session restore
+            /* The debounced writer (#490) is finished: stop its timer so a pending tick cannot
+               fire into a window being torn down, and let the write below be the last word.
+               It stays the authoritative final write — mostly redundant now that membership
+               changes persist continuously, but it covers anything the debounce had not flushed
+               yet, and it runs while the detached windows below are still open and registered,
+               so their paths are in it. */
+            _sessionPersistTimer?.Stop();
+            _sessionPersistPending = false;
+
+            // Save the list of currently open file-based tabs for session restore
             SaveOpenPlans();
 
             _pipeCts.Cancel();
@@ -371,16 +394,56 @@ public partial class MainWindow : Window
     internal IReadOnlyList<(Window Window, QuerySessionControl Session)> DetachedQuerySessions =>
         _detachedQuerySessions;
 
-    internal void RememberDetachedQuerySession(Window window, Control content)
+    /// <summary>
+    /// EVERY top-level tab content currently detached, in detach order — plans and Query Store
+    /// windows included, not just the query sessions above.
+    ///
+    /// <para>#490's second register, kept next to #473's because they answer different
+    /// questions. The prompt register above only cares about content that can lose an edit;
+    /// session persistence cares about content that came from a FILE, and a detached plan is
+    /// exactly that — file-backed, read-only, and invisible to a save list built by walking
+    /// MainTabControl. Sub-tab detaches (a plan torn out of a query session's sub-tab strip)
+    /// stay off both registers on purpose: their session's own tab is still docked and already
+    /// carries the path.</para>
+    /// </summary>
+    private readonly List<Control> _detachedTabContents = new();
+
+    /// <summary>
+    /// Books a detached top-level tab's content into both registers. Named for the content
+    /// rather than the session since #490: persistence needs every detached tab remembered,
+    /// and only the #473 prompt half is query-session-only.
+    /// </summary>
+    internal void RememberDetachedTabContent(Window window, Control content)
     {
+        _detachedTabContents.Add(content);
+
         if (content is QuerySessionControl session)
             _detachedQuerySessions.Add((window, session));
+
+        /* This register is half of what CollectOpenTabPaths reads (the tab strip is the other
+           half), so a change to it is a membership change the tab watcher cannot see. Detach
+           itself also removed a tab — the watcher fired — but by the time the debounced write
+           flushes, this entry exists; the debounce is quietly doing ordering work here, since
+           a synchronous write at the watcher's moment would have landed in the gap between
+           Items.Remove and this call and dropped the detached file. */
+        RequestSessionPersist();
     }
 
-    internal void ForgetDetachedQuerySession(Control content)
+    /// <summary>
+    /// Takes a detached tab's content back off both registers — on redock, and on the detached
+    /// window actually closing.
+    /// </summary>
+    internal void ForgetDetachedTabContent(Control content)
     {
+        _detachedTabContents.Remove(content);
+
         if (content is QuerySessionControl session)
             _detachedQuerySessions.RemoveAll(d => d.Session == session);
+
+        /* Redock re-adds a tab and the watcher sees that; a detached window closed by its own
+           X changes no tab at all, and this is the only place that knows the file left the
+           app. One debounced write covers both. */
+        RequestSessionPersist();
     }
 
     /// <summary>

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -47,6 +47,16 @@ public partial class MainWindow : Window
     /// </summary>
     internal bool IsShuttingDown { get; private set; }
 
+    /// <summary>
+    /// Whether this window's process-external startup services actually launched. Set by the
+    /// launch methods themselves rather than by the <see cref="AppRuntimeMode"/> gate, so the
+    /// test pinning that they stay off under the harness (#451) still fails if a future change
+    /// starts one through a new path. Never read by the app.
+    /// </summary>
+    internal bool PipeServerStarted { get; private set; }
+    internal bool StartupUpdateCheckStarted { get; private set; }
+    internal bool McpServerStartAttempted { get; private set; }
+
     public MainWindow()
     {
         _credentialService = CredentialServiceFactory.Create();
@@ -57,13 +67,20 @@ public partial class MainWindow : Window
         if (Enum.TryParse<TimeDisplayMode>(_appSettings.QueryStoreDefaultTimeDisplay, true, out var tdm))
             TimeDisplayHelper.Current = tdm;
 
-        // Listen for file paths from other instances (e.g. SSMS extension)
-        StartPipeServer();
+        // Listen for file paths from other instances (e.g. SSMS extension).
+        // Not in the test host (#451): every test window would grab the machine's single
+        // SQLPerformanceStudio_OpenFile pipe slot and never release it — OnClosed never
+        // runs there — racing any real Studio instance on the same box.
+        if (!AppRuntimeMode.IsTestHost)
+            StartPipeServer();
 
         InitializeComponent();
 
-        // Check for updates on startup (non-blocking)
-        _ = CheckForUpdatesOnStartupAsync();
+        // Check for updates on startup (non-blocking).
+        // Not in the test host (#451): one GitHub hit per constructed window meant ~36
+        // update checks per local test run.
+        if (!AppRuntimeMode.IsTestHost)
+            _ = CheckForUpdatesOnStartupAsync();
 
         // Build the Recent Plans submenu from saved state
         RebuildRecentPlansMenu();
@@ -158,12 +175,18 @@ public partial class MainWindow : Window
             RestoreOpenPlans();
         }
 
-        // Start MCP server if enabled in settings
-        StartMcpServer();
+        // Start MCP server if enabled in settings.
+        // Not in the test host (#451): this reads the user's real ~/.planview settings and,
+        // when enabled there, binds a real TCP port from inside the test runner. The menu
+        // item needs no fallback write — its XAML default is already "MCP Server: Off".
+        if (!AppRuntimeMode.IsTestHost)
+            StartMcpServer();
     }
 
     private void StartPipeServer()
     {
+        PipeServerStarted = true;
+
         var token = _pipeCts.Token;
         Task.Run(async () =>
         {
@@ -207,6 +230,10 @@ public partial class MainWindow : Window
 
     private void StartMcpServer()
     {
+        // Set before the settings read: reading the user's real ~/.planview file is itself
+        // part of what the test host must not do, so "attempted" starts here.
+        McpServerStartAttempted = true;
+
         var settings = McpSettings.Load();
         if (!settings.Enabled)
         {
@@ -709,6 +736,9 @@ public partial class MainWindow : Window
 
     private async Task CheckForUpdatesOnStartupAsync()
     {
+        // Before the first await, so the flag is visible to a caller synchronously.
+        StartupUpdateCheckStarted = true;
+
         try
         {
             await Task.Delay(5000); // Don't slow down startup

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -314,6 +314,15 @@ public partial class MainWindow : Window
     /// </summary>
     private bool _closeConfirmed;
 
+    /* _closeConfirmed only latches AFTER the walk answers yes, so it does nothing about a
+       second close request arriving WHILE the walk is still asking — a double-clicked X, or
+       another Close() between two of the walk's dialogs (each prompt is modal, but the window
+       is briefly its own again between them, and for the whole of a Save As picker). Each
+       such request used to start a second concurrent walk: duplicate prompts about the same
+       tabs, and a Cancel to one walk that the other never heard about. Same reentrancy class,
+       and same one-latch answer, as the About window's update link (#485 review). */
+    private bool _closeWalkInProgress;
+
     private const string CloseGlyph = "\u2715";   // ✕
     private const string ModifiedGlyph = "\u25CF"; // ●
 
@@ -566,8 +575,20 @@ public partial class MainWindow : Window
     {
         if (!_closeConfirmed && CloseNeedsConfirmation())
         {
+            /* The cancel is unconditional — a close arriving mid-walk must not fall through
+               to base and succeed while the walk is still asking — but only the FIRST one may
+               start a walk. The latch check lives inside this branch on purpose: the walk's
+               own Close() at the end re-enters here with _closeWalkInProgress still true, and
+               it has to sail through on _closeConfirmed above, not be swallowed as a
+               duplicate. */
             e.Cancel = true;
-            _ = ConfirmWindowCloseAsync();
+
+            if (!_closeWalkInProgress)
+            {
+                _closeWalkInProgress = true;
+                _ = ConfirmWindowCloseAsync();
+            }
+
             return;
         }
 
@@ -576,11 +597,20 @@ public partial class MainWindow : Window
 
     private async Task ConfirmWindowCloseAsync()
     {
-        if (!await ConfirmAllUnsavedWorkAsync())
-            return; // one Cancel cancels the shutdown
+        try
+        {
+            if (!await ConfirmAllUnsavedWorkAsync())
+                return; // one Cancel cancels the shutdown
 
-        _closeConfirmed = true;
-        Close();
+            _closeConfirmed = true;
+            Close();
+        }
+        finally
+        {
+            /* Cleared however the walk ends — confirmed, cancelled, or a prompt that threw —
+               so a cancelled shutdown leaves the X able to start a fresh walk. */
+            _closeWalkInProgress = false;
+        }
     }
 
     /// <summary>

--- a/src/PlanViewer.App/MainWindow.axaml.cs
+++ b/src/PlanViewer.App/MainWindow.axaml.cs
@@ -532,12 +532,33 @@ public partial class MainWindow : Window
 
     private async Task ConfirmWindowCloseAsync()
     {
-        /* #473: the sessions that are no longer tabs are asked about here, while every window
-           is still up, rather than from OnClosed where they are force-closed. By then the main
-           window is gone and the app is on its way out — a dialog raised there is at best a
-           window nobody expects and at worst a shutdown that never finishes. Asking here is
-           what earns DetachedContentNeedsSavePrompt the right to wave that force-close
-           through. */
+        if (!await ConfirmAllUnsavedWorkAsync())
+            return; // one Cancel cancels the shutdown
+
+        _closeConfirmed = true;
+        Close();
+    }
+
+    /// <summary>
+    /// Asks about every piece of unsaved work in the app, and answers whether whatever is
+    /// about to destroy that work may proceed.
+    ///
+    /// <para>Split out of <see cref="ConfirmWindowCloseAsync"/> because the window close is
+    /// not the only way the process ends: the About window's Velopack "Restart Now" calls
+    /// ApplyUpdatesAndRestart, which exits without ever raising Closing — so #462's and
+    /// #473's walk never ran on that route and dirty edits were discarded without a word.
+    /// This is only the walk: it does not latch <see cref="_closeConfirmed"/> and does not
+    /// Close, so the restart path can take the answer without the close's bookkeeping.</para>
+    ///
+    /// <para>#473: the sessions that are no longer tabs are asked about here, while every
+    /// window is still up, rather than from OnClosed where they are force-closed. By then the
+    /// main window is gone and the app is on its way out — a dialog raised there is at best a
+    /// window nobody expects and at worst a shutdown that never finishes. Asking here is what
+    /// earns DetachedContentNeedsSavePrompt the right to wave that force-close through.</para>
+    /// </summary>
+    /// <returns>False the moment anyone answers Cancel, or a save they asked for fails.</returns>
+    internal async Task<bool> ConfirmAllUnsavedWorkAsync()
+    {
         foreach (var work in UnsavedWorkOnClose())
         {
             var mayClose = work.Tab != null
@@ -545,11 +566,10 @@ public partial class MainWindow : Window
                 : await ConfirmDetachedCloseAsync(work.Session, work.Owner);
 
             if (!mayClose)
-                return; // one Cancel cancels the shutdown
+                return false;
         }
 
-        _closeConfirmed = true;
-        Close();
+        return true;
     }
 
 

--- a/src/PlanViewer.App/Mcp/McpPlanTools.cs
+++ b/src/PlanViewer.App/Mcp/McpPlanTools.cs
@@ -308,7 +308,16 @@ public sealed class McpPlanTools
             if (statement is null)
                 return "No executable statement found in this plan.";
 
-            var queryText = session.QueryText ?? statement.StatementText ?? "";
+            /* #482: the parameterized form on purpose. ReproScriptBuilder wraps this body in
+               sp_executesql with a parameter list read out of the same plan, so a body that already
+               has the literals inlined would declare parameters that appear nowhere in it — and the
+               plan it produced would be the constant-folded one, not the parameterized compile the
+               repro script exists to reproduce. Falls through to StatementText, which is the same
+               string whenever nothing was substituted. */
+            var queryText = session.QueryText
+                ?? statement.ParameterizedStatementText
+                ?? statement.StatementText
+                ?? "";
             var databaseName = session.DatabaseName ?? statement.OperatorTree?.DatabaseName;
 
             return ReproScriptBuilder.BuildReproScript(

--- a/src/PlanViewer.App/Mcp/McpQueryStoreTools.cs
+++ b/src/PlanViewer.App/Mcp/McpQueryStoreTools.cs
@@ -311,8 +311,16 @@ public sealed class McpQueryStoreTools
         string connectionInfo)
     {
         var analysis = ResultMapper.Map(parsed, "query-store");
-        var allStatements = parsed.Batches.SelectMany(batch => batch.Statements).ToList();
-        var executableStatement = allStatements.FirstOrDefault(statement => statement.RootNode is not null);
+
+        /* #456 follow-up: the counts used to come from a second walk over batch.Statements while
+           the Analysis stored on this very session is mapped from PlanStatements.EnumerateAll —
+           stored procedure and UDF bodies included, node-level warnings counted — so a Query
+           Store EXEC plan registered statement_count 1 and warning_count 0 alongside an analysis
+           full of findings. The counts now come from that analysis's own summary: one source, and
+           nothing left to disagree with what an MCP client reads. */
+        var executableStatement = Core.Services.PlanStatements.EnumerateAll(parsed)
+            .FirstOrDefault(statement => statement.RootNode is not null);
+
         var session = new PlanSession
         {
             SessionId = sessionId,
@@ -324,12 +332,11 @@ public sealed class McpQueryStoreTools
             DatabaseName = executableStatement?.RootNode?.DatabaseName,
             QueryText = queryText,
             ConnectionInfo = connectionInfo,
-            StatementCount = allStatements.Count,
-            HasActualStats = false,
-            WarningCount = allStatements.Sum(statement => statement.PlanWarnings.Count),
-            CriticalWarningCount = allStatements.Sum(statement =>
-                statement.PlanWarnings.Count(warning => warning.Severity == Core.Models.PlanWarningSeverity.Critical)),
-            MissingIndexCount = parsed.AllMissingIndexes.Count
+            StatementCount = analysis.Summary.TotalStatements,
+            HasActualStats = analysis.Summary.HasActualStats,
+            WarningCount = analysis.Summary.TotalWarnings,
+            CriticalWarningCount = analysis.Summary.CriticalWarnings,
+            MissingIndexCount = analysis.Summary.MissingIndexes
         };
 
         parsed.RawXml = string.Empty;

--- a/src/PlanViewer.App/Program.cs
+++ b/src/PlanViewer.App/Program.cs
@@ -142,11 +142,24 @@ class Program
             mutex.Dispose();
             return false;
         }
-        catch
+        catch (Exception ex)
         {
             /* Mutex machinery unavailable — an ACL mismatch on the name, a restrictive
-               sandbox. Claiming ownership is the conservative answer: this instance runs
-               fully, which is exactly the pre-#489 behavior for every launch. */
+               sandbox, or a platform where the named-mutex shim misbehaves (on Unix these
+               are file-backed under /tmp; PlatformNotSupportedException would land here
+               too). Claiming ownership is the conservative answer: this instance runs
+               fully, which is exactly the pre-#489 behavior for every launch.
+
+               Said out loud rather than swallowed, because the degradation is otherwise
+               invisible: if this fires on every launch, single-instancing has quietly
+               no-oped and #489's settings clobber is back with no symptom pointing here.
+               stderr is the right channel — a Windows GUI launch has no console and loses
+               it harmlessly, while the Unix platforms this is most likely to fire on are
+               exactly where launching from a terminal is common. A unit test exercises
+               the named-mutex machinery per platform in CI so a shim that throws fails
+               loudly there first. */
+            Console.Error.WriteLine(
+                $"PerformanceStudio: single-instance detection unavailable ({ex.GetType().Name}); running as a full instance.");
             return true;
         }
     }

--- a/src/PlanViewer.App/Program.cs
+++ b/src/PlanViewer.App/Program.cs
@@ -61,11 +61,21 @@ class Program
 
         if (!newInstanceRequested)
         {
-            // The pre-#489 forwarding, kept first and unchanged: a with-file launch tries
-            // the pipe before anything else. Beyond being the common case, probing before
-            // the mutex is version-skew-proof — an already-running build that predates the
-            // mutex answers its pipe but holds no mutex, and a mutex-first flow would run a
-            // second full window beside it instead of handing the file over.
+            /* The pre-#489 forwarding, kept first and unchanged: a with-file launch tries
+               the pipe before anything else. Beyond being the common case, probing before
+               the mutex makes the WITH-FILE path version-skew-proof — an already-running
+               build that predates the mutex answers its pipe but holds no mutex, and a
+               mutex-first flow would run a second full window beside it instead of handing
+               the file over.
+
+               A BARE launch during that same skew is the one #489 case deliberately left
+               open: it cannot probe first, because an old receiver silently drops the
+               sentinel (File.Exists guard) while delivery still reports success — the
+               launch would exit having surfaced nothing, which is worse than a second
+               instance. So a bare launch beside a pre-mutex build claims the free mutex
+               and runs fully: the pre-#489 status quo, for one transient upgrade window
+               that ends when the old instance exits. Documented rather than solved; a
+               real fix needs an acknowledged (duplex) surfacing protocol. */
             if (effectiveArgs.Length > 0 && TrySendToRunningInstance(effectiveArgs[0], maxAttempts: 1))
                 return;
 

--- a/src/PlanViewer.App/Program.cs
+++ b/src/PlanViewer.App/Program.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using System;
 using System.IO;
 using System.IO.Pipes;
+using System.Threading;
 using System.Threading.Tasks;
 using PlanViewer.App.Services;
 using Velopack;
@@ -10,7 +11,14 @@ namespace PlanViewer.App;
 
 class Program
 {
-    private const string PipeName = "SQLPerformanceStudio_OpenFile";
+    /// <summary>
+    /// Held — never released — by the instance that owns the single-instance slot (#489).
+    /// The OS tears the mutex down when the process exits, crash included, so there is no
+    /// release path to get wrong; a static field keeps the handle rooted for the whole run
+    /// (the previous mutex attempt died precisely because its handle was disposed the
+    /// moment the acquiring method returned, so no instance ever actually held it).
+    /// </summary>
+    private static Mutex? _singleInstanceMutex;
 
     [STAThread]
     public static void Main(string[] args)
@@ -36,12 +44,62 @@ class Program
         }
         velopack.Run();
 
-        // If another instance is running, send the file path to it and exit
-        if (args.Length > 0 && TrySendToRunningInstance(args[0]))
-            return;
+        /* #489: every instance holds a whole-file AppSettings snapshot and Save writes the
+           whole file, so a second instance makes the settings file last-write-wins — the
+           instance that exits second silently clobbers the other's open_tabs and every
+           other setting (AtomicFile prevents torn writes, not lost updates). File-argument
+           launches already forwarded to the running instance over the pipe; a BARE second
+           launch ran a full instance and was exactly the clobber case. So unless the user
+           explicitly asks for a second instance, a launch that finds one running hands it
+           its work — a file path, or a bare "surface yourself" — and exits. */
+        var newInstanceRequested = SingleInstance.NewInstanceRequested(args);
+
+        // The flag is a launcher directive, not a file: strip it so nothing downstream can
+        // mistake it for a path ("PerformanceStudio.exe --new-instance file.sqlplan" must
+        // still open the file). MainWindow re-reads the raw argv and scrubs it again itself.
+        var effectiveArgs = SingleInstance.StripNewInstanceFlag(args);
+
+        if (!newInstanceRequested)
+        {
+            // The pre-#489 forwarding, kept first and unchanged: a with-file launch tries
+            // the pipe before anything else. Beyond being the common case, probing before
+            // the mutex is version-skew-proof — an already-running build that predates the
+            // mutex answers its pipe but holds no mutex, and a mutex-first flow would run a
+            // second full window beside it instead of handing the file over.
+            if (effectiveArgs.Length > 0 && TrySendToRunningInstance(effectiveArgs[0], maxAttempts: 1))
+                return;
+
+            if (!TryBecomeSingleInstanceOwner())
+            {
+                /* Another instance owns the slot but hasn't answered its pipe yet — bare
+                   launches never probed above, and a with-file probe may have raced the
+                   owner's boot (the pipe server starts in the MainWindow constructor,
+                   which on a cold start is seconds after its Main). Retry for ~2s before
+                   giving up on delivery. */
+                var message = effectiveArgs.Length > 0
+                    ? effectiveArgs[0]
+                    : SingleInstance.ActivateSentinel;
+                if (TrySendToRunningInstance(message, maxAttempts: 4))
+                    return;
+
+                /* Delivery failed after retries: the owner is wedged, exiting, or still
+                   booting slowly. Losing the user's action — their double-clicked file, or
+                   the app simply appearing at all — is worse than a rare second instance,
+                   so fall through and run fully. This is also the honest residue of the
+                   startup race: two simultaneous bare launches can BOTH end up proceeding
+                   when the loser's retries run out before the winner's pipe exists. The
+                   mutex closes most of that window; what remains falls back to the
+                   pre-#489 last-write-wins behavior, which is the accepted floor. */
+            }
+        }
 
         BuildAvaloniaApp()
-            .StartWithClassicDesktopLifetime(args);
+            .StartWithClassicDesktopLifetime(effectiveArgs);
+
+        // Reached only at app shutdown. Statics are GC roots, so the field alone keeps the
+        // owner's mutex handle alive; this read exists to say out loud that the handle's
+        // LIFETIME is the point (and to keep the field from reading as write-only).
+        GC.KeepAlive(_singleInstanceMutex);
     }
 
     // Avalonia configuration, don't remove; also used by visual designer.
@@ -52,32 +110,74 @@ class Program
             .LogToTrace();
 
     /// <summary>
-    /// Tries to hand the file path to an already-running instance over its named pipe.
-    /// A failed/timed-out connect means no instance is listening, so the caller should
-    /// launch normally. Returns true only if the path was actually delivered.
+    /// Tries to claim the single-instance slot (#489). True means this process is the
+    /// owner and should run; false means another instance holds the slot and this launch
+    /// should hand its work over instead.
     /// </summary>
-    /// <remarks>
-    /// Detection is via the pipe itself rather than a named mutex: the previous mutex
-    /// was disposed as soon as this method returned, so no instance ever held it and
-    /// the forwarding path was never taken.
-    /// </remarks>
-    private static bool TrySendToRunningInstance(string filePath)
+    private static bool TryBecomeSingleInstanceOwner()
     {
         try
         {
-            using var client = new NamedPipeClientStream(".", PipeName, PipeDirection.Out);
-            // Short timeout: a running instance's listener is idle and connects
-            // immediately; when none is running this is the only added launch delay.
-            client.Connect(500);
-            using var writer = new StreamWriter(client);
-            writer.WriteLine(filePath);
-            writer.Flush();
-            return true;
+            var mutex = new Mutex(initiallyOwned: true, SingleInstance.MutexName, out var createdNew);
+            if (createdNew)
+            {
+                _singleInstanceMutex = mutex;
+                return true;
+            }
+
+            /* Another process owns it. Close our handle right away: if this launch ends up
+               running anyway (the pipe fallback above), a lingering handle would keep the
+               kernel object alive after the real owner exits, and a THIRD launch would then
+               see the name taken with nobody serving the pipe behind it. */
+            mutex.Dispose();
+            return false;
         }
         catch
         {
-            // No instance listening (or pipe busy) — fall through to launch normally.
-            return false;
+            /* Mutex machinery unavailable — an ACL mismatch on the name, a restrictive
+               sandbox. Claiming ownership is the conservative answer: this instance runs
+               fully, which is exactly the pre-#489 behavior for every launch. */
+            return true;
         }
+    }
+
+    /// <summary>
+    /// Tries to hand one line — a file path, or the activation sentinel — to an
+    /// already-running instance over its named pipe. Returns true only if the line was
+    /// actually delivered; the caller decides what a failed delivery costs.
+    /// </summary>
+    private static bool TrySendToRunningInstance(string message, int maxAttempts)
+    {
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            if (attempt > 1)
+            {
+                // Between attempts only: the owner is presumably mid-boot, so give its
+                // pipe server a beat to come up rather than burning connects back-to-back.
+                Thread.Sleep(100);
+            }
+
+            try
+            {
+                using var client = new NamedPipeClientStream(".", SingleInstance.PipeName, PipeDirection.Out);
+                // 500ms per attempt: a running instance's listener is idle and connects
+                // immediately, while Connect burns the full timeout when nothing is
+                // listening — so the single-attempt probe on a with-file launch adds at
+                // most the same half second it always has, and the 4-attempt retry path
+                // totals roughly the ~2s boot grace it exists for.
+                client.Connect(500);
+                using var writer = new StreamWriter(client);
+                writer.WriteLine(message);
+                writer.Flush();
+                return true;
+            }
+            catch
+            {
+                // Not listening yet, or the single server slot was mid-conversation with
+                // another client — retry if the budget allows, otherwise report undelivered.
+            }
+        }
+
+        return false;
     }
 }

--- a/src/PlanViewer.App/Services/AppSettingsService.cs
+++ b/src/PlanViewer.App/Services/AppSettingsService.cs
@@ -20,6 +20,7 @@ internal sealed class AppSettingsService
     private static string SettingsDir;
     private static string SettingsPath;
     private static string OldFormatSettingsPath;
+    private static string ScratchDir;
 
     private static AppSettings? _cached;
 
@@ -30,6 +31,7 @@ internal sealed class AppSettingsService
             "PerformanceStudio");
         SettingsPath = Path.Combine(SettingsDir, "appsettings.json");
         OldFormatSettingsPath = Path.Combine(SettingsDir, "perfstudio_format_settings.json");
+        ScratchDir = Path.Combine(SettingsDir, "scratch");
     }
 
     /// <summary>
@@ -38,6 +40,16 @@ internal sealed class AppSettingsService
     /// can pin that the redirection actually happened (#451) instead of trusting it.
     /// </summary>
     internal static string SettingsFilePath => SettingsPath;
+
+    /// <summary>
+    /// Where scratch query buffers live (#496): one file per never-saved query tab, so an
+    /// abnormal exit does not take typed-but-unsaved work with it. Beside the settings file
+    /// rather than anywhere fancier because it is the same class of state — and, exactly like
+    /// <see cref="SettingsFilePath"/>, it rides <see cref="RedirectStorageForTestHost"/>, so
+    /// tests that exercise the real buffer writes land them in the run-scoped temp root
+    /// instead of the developer's profile (#487's pattern, same reasoning as #451).
+    /// </summary>
+    internal static string ScratchDirectory => ScratchDir;
 
     /// <summary>
     /// Points every settings read and write at <paramref name="directory"/> instead of the
@@ -54,6 +66,7 @@ internal sealed class AppSettingsService
         SettingsDir = directory;
         SettingsPath = Path.Combine(directory, "appsettings.json");
         OldFormatSettingsPath = Path.Combine(directory, "perfstudio_format_settings.json");
+        ScratchDir = Path.Combine(directory, "scratch");
 
         // Anything cached was loaded from the old location; drop it so the first Load
         // after the redirect reads the new one.

--- a/src/PlanViewer.App/Services/AppSettingsService.cs
+++ b/src/PlanViewer.App/Services/AppSettingsService.cs
@@ -14,9 +14,12 @@ namespace PlanViewer.App.Services;
 internal sealed class AppSettingsService
 {
     private const int MaxRecentPlans = 10;
-    private static readonly string SettingsDir;
-    private static readonly string SettingsPath;
-    private static readonly string OldFormatSettingsPath;
+
+    // Not readonly only because RedirectStorageForTestHost exists; nothing in the
+    // product assigns these outside the static constructor.
+    private static string SettingsDir;
+    private static string SettingsPath;
+    private static string OldFormatSettingsPath;
 
     private static AppSettings? _cached;
 
@@ -27,6 +30,34 @@ internal sealed class AppSettingsService
             "PerformanceStudio");
         SettingsPath = Path.Combine(SettingsDir, "appsettings.json");
         OldFormatSettingsPath = Path.Combine(SettingsDir, "perfstudio_format_settings.json");
+    }
+
+    /// <summary>
+    /// The file settings are read from and written to right now — the real per-user path
+    /// unless <see cref="RedirectStorageForTestHost"/> moved it. Exposed so the test suite
+    /// can pin that the redirection actually happened (#451) instead of trusting it.
+    /// </summary>
+    internal static string SettingsFilePath => SettingsPath;
+
+    /// <summary>
+    /// Points every settings read and write at <paramref name="directory"/> instead of the
+    /// real per-user profile. Exists for exactly one caller: the test harness (#451). Its
+    /// MainWindow-driving tests run the real settings code — RestoreOpenPlans clears and
+    /// saves the open-tab list, LoadPlanFile saves Recent Plans — and were doing all of it
+    /// against the developer's actual appsettings.json: fixture paths evicted real recent
+    /// entries and the saved session-restore list was destroyed, confirmed live. When this
+    /// is never called, the paths keep their static-constructor defaults byte for byte, so
+    /// the real app is untouched.
+    /// </summary>
+    internal static void RedirectStorageForTestHost(string directory)
+    {
+        SettingsDir = directory;
+        SettingsPath = Path.Combine(directory, "appsettings.json");
+        OldFormatSettingsPath = Path.Combine(directory, "perfstudio_format_settings.json");
+
+        // Anything cached was loaded from the old location; drop it so the first Load
+        // after the redirect reads the new one.
+        _cached = null;
     }
 
     private static readonly JsonSerializerOptions JsonOptions = new()

--- a/src/PlanViewer.App/Services/AtomicFile.cs
+++ b/src/PlanViewer.App/Services/AtomicFile.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Text;
 
 namespace PlanViewer.App.Services;
 
@@ -15,10 +16,20 @@ internal static class AtomicFile
     /// <paramref name="path"/> keeps its previous contents and a stray
     /// <c>.tmp</c> sibling is left behind (cleaned up on the next call).
     /// </summary>
-    public static void WriteAllText(string path, string contents)
+    /// <param name="encoding">
+    /// Bytes to write the text as; null keeps File.WriteAllText's default, UTF-8
+    /// without a BOM. Callers saving over a file the user opened pass the encoding
+    /// that file arrived with, so a save-in-place is not also a silent transcode.
+    /// </param>
+    public static void WriteAllText(string path, string contents, Encoding? encoding = null)
     {
         var tmp = path + ".tmp";
-        File.WriteAllText(tmp, contents);
+
+        if (encoding != null)
+            File.WriteAllText(tmp, contents, encoding);
+        else
+            File.WriteAllText(tmp, contents);
+
         // File.Move with overwrite:true maps to MoveFileEx(MOVEFILE_REPLACE_EXISTING)
         // on Windows and rename(2) on Unix — both atomic when source and destination
         // live on the same filesystem, which is always the case here.

--- a/src/PlanViewer.App/Services/ScratchBufferStore.cs
+++ b/src/PlanViewer.App/Services/ScratchBufferStore.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace PlanViewer.App.Services;
+
+/// <summary>
+/// The on-disk half of scratch buffer persistence (#496): one file per never-saved query tab
+/// under <see cref="AppSettingsService.ScratchDirectory"/>, named by the tab's stable buffer
+/// id, plus the <c>scratch:&lt;guid&gt;</c> entry format that puts those tabs on the same
+/// ordered <c>open_tabs</c> list the file-backed tabs use (#495).
+///
+/// <para><b>Why the entry rides the existing list instead of a second one.</b> One list is
+/// one ordering: scratch tabs interleave with file tabs on the strip, and two lists would
+/// have to reinvent that interleaving (#495's detached entries already live with an
+/// append-after compromise; docked tabs should not inherit it). Compatibility comes free and
+/// is pinned the way #494's activation sentinel taught: an old build reading a new list
+/// guards every entry with <c>File.Exists</c>, and <see cref="EntryPrefix"/> contains a
+/// colon — not a legal character in a Windows file name, and the app only ever writes
+/// absolute paths to the list, which an entry starting with <c>scratch:</c> is not on any
+/// platform — so old builds skip these entries silently, exactly as they skip a file that
+/// was deleted. A new build reading an old list sees only plain paths and behaves exactly
+/// as before. No version field, no migration.</para>
+///
+/// <para><b>Privacy.</b> Scratch SQL can hold literals — names, ids, whatever the user was
+/// querying for. These buffers land in the user's local profile beside the settings file,
+/// which already stores the recent-plans list and, next to it, saved plan files whose XML
+/// embeds full statement text and parameter values. Same machine, same user, same
+/// sensitivity class as what is already there; no new exposure class is created.</para>
+/// </summary>
+internal static class ScratchBufferStore
+{
+    /// <summary>
+    /// What marks an <c>open_tabs</c> entry as a scratch buffer rather than a file path.
+    /// The colon is load-bearing — see the class comment — so the compat test pins this
+    /// string directly rather than proving anything with a <c>File.Exists</c> that would
+    /// be vacuous on a runner whose filesystem happily allows colons.
+    /// </summary>
+    internal const string EntryPrefix = "scratch:";
+
+    /// <summary>
+    /// .sql so a user digging through their profile can open a buffer and recognize it.
+    /// </summary>
+    private const string BufferExtension = ".sql";
+
+    /// <summary>The <c>open_tabs</c> entry for a scratch buffer.</summary>
+    internal static string EntryFor(Guid id) => EntryPrefix + id.ToString("N");
+
+    /// <summary>
+    /// Whether an <c>open_tabs</c> entry names a scratch buffer. Anything that fails here —
+    /// including a prefixed entry whose tail is not a GUID — is treated as a file path by
+    /// the caller, which is also what makes a file literally named <c>scratch:something</c>
+    /// on a colon-tolerant filesystem keep opening as the file it is.
+    /// </summary>
+    internal static bool TryParseEntry(string? entry, out Guid id)
+    {
+        id = default;
+        return entry != null
+            && entry.StartsWith(EntryPrefix, StringComparison.Ordinal)
+            && Guid.TryParse(entry.AsSpan(EntryPrefix.Length), out id);
+    }
+
+    /// <summary>Where a buffer's content lives on disk.</summary>
+    internal static string BufferPathFor(Guid id) =>
+        Path.Combine(AppSettingsService.ScratchDirectory, id.ToString("N") + BufferExtension);
+
+    /// <summary>
+    /// Writes a buffer's content. Atomic for the same reason every other write in this app's
+    /// profile is (#495): the buffer may be the only copy of the user's typing, and a crash
+    /// mid-write must leave the previous content rather than a truncated file.
+    /// </summary>
+    internal static void Write(Guid id, string text)
+    {
+        Directory.CreateDirectory(AppSettingsService.ScratchDirectory);
+        AtomicFile.WriteAllText(BufferPathFor(id), text);
+    }
+
+    /// <summary>
+    /// Deletes a buffer's file, best-effort. Persistence in this app never throws at the
+    /// user (<see cref="AppSettingsService.Save"/> sets that precedent); a buffer that
+    /// cannot be deleted right now is unreferenced garbage the startup sweep collects later.
+    /// </summary>
+    internal static void TryDelete(Guid id)
+    {
+        try
+        {
+            File.Delete(BufferPathFor(id));
+        }
+        catch
+        {
+            // Best-effort — see doc comment.
+        }
+    }
+
+    /// <summary>
+    /// Deletes every file in the scratch directory that is not one of the referenced
+    /// buffers. Run once at startup, after the saved tab list has been read (#496): a clean
+    /// close deletes each buffer at the moment the user chooses its fate, so anything left
+    /// unreferenced is debris — a buffer whose entry a crash-window skew lost, an
+    /// <c>AtomicFile</c> <c>.tmp</c> stranded by a crash mid-write, a buffer a poisoned
+    /// restore skipped. Matching on the exact expected file name (not the GUID stem) is
+    /// what lets the sweep collect those <c>.tmp</c> siblings too.
+    /// </summary>
+    internal static void SweepAllExcept(IReadOnlyCollection<Guid> referenced)
+    {
+        string[] files;
+        try
+        {
+            files = Directory.GetFiles(AppSettingsService.ScratchDirectory);
+        }
+        catch
+        {
+            // Most commonly: the directory does not exist because nothing has ever
+            // persisted a scratch buffer. Nothing to sweep either way.
+            return;
+        }
+
+        var keep = referenced
+            .Select(id => id.ToString("N") + BufferExtension)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var file in files)
+        {
+            if (keep.Contains(Path.GetFileName(file)))
+                continue;
+
+            try
+            {
+                File.Delete(file);
+            }
+            catch
+            {
+                // Locked or otherwise stuck — the next startup's sweep gets another turn.
+            }
+        }
+    }
+}

--- a/src/PlanViewer.App/Services/ScratchBufferStore.cs
+++ b/src/PlanViewer.App/Services/ScratchBufferStore.cs
@@ -44,6 +44,14 @@ internal static class ScratchBufferStore
     /// </summary>
     private const string BufferExtension = ".sql";
 
+    /// <summary>
+    /// How long an unreferenced buffer survives the startup sweep. Three days spans a long
+    /// weekend of not reopening Studio after a crash — see the age-gate comment in
+    /// <see cref="SweepAllExcept"/>. Internal so the sweep tests can backdate past it
+    /// instead of hardcoding a sibling value that drifts.
+    /// </summary>
+    internal static readonly TimeSpan OrphanGracePeriod = TimeSpan.FromDays(3);
+
     /// <summary>The <c>open_tabs</c> entry for a scratch buffer.</summary>
     internal static string EntryFor(Guid id) => EntryPrefix + id.ToString("N");
 
@@ -120,6 +128,17 @@ internal static class ScratchBufferStore
             .Select(id => id.ToString("N") + BufferExtension)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
+        /* Age gate (#496 review): an unreferenced buffer is USUALLY debris, but two crash
+           shapes make a fresh one innocent — a buffer written moments before a crash in
+           the buffer-then-list gap, and every bystander stranded when a mid-restore crash
+           left the poison-cleared list empty. Only files past the grace period die, which
+           turns "the sweep destroyed never-chosen content" into "an orphan lingered a few
+           days as a recognizable .sql a person can still recover by hand" — the reason
+           buffers carry that extension. The gate costs nothing on the paths that matter:
+           chosen deletions (Don't Save, Save) delete directly and never come through here,
+           and referenced buffers are never candidates at all. */
+        var cutoff = DateTime.UtcNow - OrphanGracePeriod;
+
         foreach (var file in files)
         {
             if (keep.Contains(Path.GetFileName(file)))
@@ -127,6 +146,9 @@ internal static class ScratchBufferStore
 
             try
             {
+                if (File.GetLastWriteTimeUtc(file) >= cutoff)
+                    continue;
+
                 File.Delete(file);
             }
             catch

--- a/src/PlanViewer.App/Services/TextBoxClipboardGuard.cs
+++ b/src/PlanViewer.App/Services/TextBoxClipboardGuard.cs
@@ -14,8 +14,19 @@ namespace PlanViewer.App.Services;
 /// </summary>
 internal static class TextBoxClipboardGuard
 {
+    private static bool _registered;
+
     public static void Register()
     {
+        // Once per process. The real app calls this once at startup anyway, but the test
+        // harness (#451) boots a fresh App per test dispatch, and class handlers live on the
+        // static routed events — not the Application — so each boot was stacking another set
+        // of handlers onto every TextBox in the test host. The guard stays registered for
+        // any test that exercises clipboard behavior; it just stops accumulating.
+        if (_registered)
+            return;
+        _registered = true;
+
         TextBox.CopyingToClipboardEvent.AddClassHandler<TextBox>(OnCopying);
         TextBox.CuttingToClipboardEvent.AddClassHandler<TextBox>(OnCutting);
         TextBox.PastingFromClipboardEvent.AddClassHandler<TextBox>(OnPasting);

--- a/src/PlanViewer.App/SingleInstance.cs
+++ b/src/PlanViewer.App/SingleInstance.cs
@@ -1,0 +1,124 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace PlanViewer.App;
+
+/// <summary>
+/// The names and message grammar shared by both halves of single-instance startup (#489):
+/// the launcher side in <see cref="Program"/> that decides whether to run or to hand its
+/// work to an already-running instance, and the receiver side in <see cref="MainWindow"/>'s
+/// pipe server that acts on what arrives.
+///
+/// <para><b>Why single-instance at all.</b> Every instance holds a whole-file
+/// <c>AppSettings</c> snapshot and Save writes the whole file, so two instances make the
+/// settings file last-write-wins: whichever exits second silently clobbers the other's
+/// open_tabs and every other setting. AtomicFile prevents torn files, not lost updates.
+/// A launch with a file argument already forwarded to the running instance over the named
+/// pipe; a bare launch ran a full second instance and was exactly the clobber case.</para>
+///
+/// <para><b>Why the grammar is this shape.</b> The pipe protocol is one line per
+/// connection, historically always a file path, and two other sender/receiver pairs speak
+/// it: the SSMS extension's AppLauncher (sends plain paths, cannot be updated in lockstep
+/// with the app) and any older Studio build still running across an upgrade. So the
+/// activation message is not a version field or a framed header — it is a single reserved
+/// line that an OLD receiver safely ignores: the pre-#489 handler's only guard is
+/// <c>File.Exists(line)</c>, and <see cref="ActivateSentinel"/> contains characters that
+/// are illegal in Windows file names, so it can never name an existing file there. An old
+/// receiver reads it, finds no such file, drops it, and keeps serving — the worst-case
+/// skew is a bare second launch that exits without surfacing anything, not a crash or a
+/// junk tab.</para>
+/// </summary>
+internal static class SingleInstance
+{
+    /// <summary>
+    /// The pipe every Studio sender and receiver has always shared — also written by the
+    /// SSMS extension's AppLauncher, which is why the name can never change casually.
+    /// </summary>
+    internal const string PipeName = "SQLPerformanceStudio_OpenFile";
+
+    /// <summary>
+    /// Unprefixed, so it lands in the default per-user-session <c>Local\</c> namespace on
+    /// Windows — two users (or two RDP sessions) each get their own instance, which is the
+    /// scope the settings file conflict actually has. Distinct from Lite's
+    /// <c>PerformanceMonitorLite_SingleInstance</c>; the two apps must never see each other.
+    /// </summary>
+    internal const string MutexName = "SQLPerformanceStudio_SingleInstance";
+
+    /// <summary>
+    /// Escape hatch (#489): skip the single-instance check and run a full second instance.
+    /// A user who runs two on purpose accepts settings last-write-wins as their informed
+    /// choice. Stripped from argv before any file-open logic sees it.
+    /// </summary>
+    internal const string NewInstanceFlag = "--new-instance";
+
+    /// <summary>
+    /// The line a bare second launch sends to mean "surface your main window". The
+    /// double-colons make it unrepresentable as a Windows file name on purpose — see the
+    /// class comment for why that property is the entire backward-compatibility story.
+    /// </summary>
+    internal const string ActivateSentinel = "::activate::";
+
+    /// <summary>What one received pipe line means. See <see cref="Classify"/>.</summary>
+    internal enum PipeMessage
+    {
+        /// <summary>Blank, or a path that doesn't exist — dropped silently, exactly as the pre-#489 receiver did.</summary>
+        Ignore,
+
+        /// <summary>The <see cref="ActivateSentinel"/> — a bare second launch asking this window to surface.</summary>
+        Activate,
+
+        /// <summary>An existing file — the SSMS extension or a second launch handing over a path to open.</summary>
+        OpenFile,
+    }
+
+    /// <summary>
+    /// The receiver's dispatch decision for one pipe line, extracted from the pipe loop so
+    /// it can be pinned by tests without a pipe.
+    ///
+    /// <para>The sentinel is checked before <c>File.Exists</c>, not after: on Windows the
+    /// order can't matter (the sentinel is an illegal file name), but on Linux a file named
+    /// <c>::activate::</c> is representable, and the reserved meaning must win over any
+    /// such file. <c>File.Exists</c> on a garbage line returns false rather than throwing,
+    /// which is what made the old receiver's guard safe and keeps this one safe too.</para>
+    /// </summary>
+    internal static PipeMessage Classify(string? line)
+    {
+        if (string.IsNullOrWhiteSpace(line))
+            return PipeMessage.Ignore;
+
+        if (string.Equals(line, ActivateSentinel, StringComparison.Ordinal))
+            return PipeMessage.Activate;
+
+        if (File.Exists(line))
+            return PipeMessage.OpenFile;
+
+        return PipeMessage.Ignore;
+    }
+
+    /// <summary>True when argv carries <see cref="NewInstanceFlag"/> anywhere.</summary>
+    internal static bool NewInstanceRequested(string[] args) =>
+        args.Any(IsNewInstanceFlag);
+
+    /// <summary>
+    /// Argv minus every <see cref="NewInstanceFlag"/>, order otherwise preserved. Applied
+    /// in BOTH places argv is consumed: <see cref="Program.Main"/> (so the forwarded path
+    /// and the args handed to Avalonia are clean) and
+    /// <see cref="MainWindow.OpenFromStartupArgs"/> (which reads the raw
+    /// <c>Environment.GetCommandLineArgs()</c> itself, so Program's scrubbed copy never
+    /// reaches it). Without the second scrub, "PerformanceStudio.exe --new-instance
+    /// file.sqlplan" would see the flag at args[1] instead of the file. The flag happens to
+    /// fail that path's <c>File.Exists</c> guard today, but the file arg behind it would
+    /// still be skipped — being explicit here is what makes the flag invisible rather than
+    /// merely unlucky.
+    /// </summary>
+    internal static string[] StripNewInstanceFlag(string[] args) =>
+        args.Where(a => !IsNewInstanceFlag(a)).ToArray();
+
+    /// <summary>
+    /// Case-insensitive, because Windows users type flags in whatever case survived their
+    /// muscle memory and there is no second flag for this one to collide with.
+    /// </summary>
+    private static bool IsNewInstanceFlag(string arg) =>
+        string.Equals(arg, NewInstanceFlag, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/PlanViewer.Core/Models/PlanModels.cs
+++ b/src/PlanViewer.Core/Models/PlanModels.cs
@@ -12,8 +12,14 @@ public class ParsedPlan
     public bool ClusteredMode { get; set; }
     public List<PlanBatch> Batches { get; set; } = new();
 
-    public List<MissingIndex> AllMissingIndexes => Batches
-        .SelectMany(b => b.Statements)
+    /* #456 follow-up: analysis output lists a missing index per statement, procedure and UDF
+       bodies included, so this rollup must descend the same way — it feeds the MissingIndexCount
+       the MCP session registrations report, and an EXEC <procedure> plan whose only missing-index
+       suggestions live in the body used to register as having none while the advice discussed
+       them. Uses the shared traversal rather than its own descent so it cannot drift from what
+       the analysis actually saw. */
+    public List<MissingIndex> AllMissingIndexes =>
+        Services.PlanStatements.EnumerateAll(this)
         .SelectMany(s => s.MissingIndexes)
         .ToList();
 }

--- a/src/PlanViewer.Core/Output/AnalysisJson.cs
+++ b/src/PlanViewer.Core/Output/AnalysisJson.cs
@@ -70,4 +70,34 @@ public static class AnalysisJson
         MaxDepth = MaxDepth,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
+
+    /// <summary>
+    /// The share wire format: default JSON in every respect except the depth ceiling.
+    ///
+    /// <para>#431 raised the ceiling for "every writer of this object", and the web share
+    /// endpoints turned out to be three more writers nobody listed: the upload serialized the
+    /// analysis with inline default options, and loading a share back parsed and deserialized it
+    /// at the default 64 again — so a deep-but-real plan (~30 nested operators) analyzed fine on
+    /// screen and then failed to Share, or shared and failed to open, with an "object cycle"
+    /// message pointing at the wrong cause. This is deliberately NOT one of the WithoutNulls
+    /// variants: shares already in the database were written with default formatting, and the fix
+    /// is the ceiling, not a wire-format change riding along with it. Used for both directions —
+    /// deserializers enforce MaxDepth too, and a share that was legal to write must be legal to
+    /// read back.</para>
+    /// </summary>
+    public static readonly JsonSerializerOptions Wire = new()
+    {
+        MaxDepth = MaxDepth,
+    };
+
+    /// <summary>
+    /// The same ceiling for <see cref="System.Text.Json.JsonDocument.Parse(string, JsonDocumentOptions)"/>
+    /// call sites: JsonDocumentOptions is a separate type with its own default MaxDepth of 64, so a
+    /// reader that picks a share apart with JsonDocument before deserializing — which is exactly
+    /// what loading a share does — hits the same wall the serializer options alone cannot fix.
+    /// </summary>
+    public static readonly JsonDocumentOptions Document = new()
+    {
+        MaxDepth = MaxDepth,
+    };
 }

--- a/src/PlanViewer.Core/Output/AnalysisResult.cs
+++ b/src/PlanViewer.Core/Output/AnalysisResult.cs
@@ -54,8 +54,30 @@ public class AnalysisSummary
 
 public class StatementResult
 {
+    /// <summary>
+    /// The statement, with the plan's captured parameter values put back where the engine left
+    /// <c>@0</c>, <c>@1</c> … (#482). Identical to what the plan records for any statement with
+    /// nothing to substitute, which is nearly all of them.
+    /// </summary>
     [JsonPropertyName("statement_text")]
     public string StatementText { get; set; } = "";
+
+    /// <summary>
+    /// The statement exactly as the plan records it, present only when
+    /// <see cref="StatementText"/> had values substituted into it and therefore says something
+    /// different.
+    ///
+    /// <para>This is the text that matches the plan cache and Query Store, and the text that has to
+    /// be paired with a declared parameter list — <c>get_repro_script</c> builds an
+    /// <c>sp_executesql</c> call around it, and a body with the literals already inlined would
+    /// declare parameters it never uses and stop reproducing the parameterized compile the script
+    /// exists to reproduce.</para>
+    ///
+    /// <para>Not to be confused with <c>PlanStatement.ParameterizedText</c>, which is showplan's own
+    /// <c>ParameterizedText</c> element and comes from the plan rather than from this mapping.</para>
+    /// </summary>
+    [JsonPropertyName("parameterized_statement_text")]
+    public string? ParameterizedStatementText { get; set; }
 
     [JsonPropertyName("statement_type")]
     public string StatementType { get; set; } = "";

--- a/src/PlanViewer.Core/Output/ResultMapper.cs
+++ b/src/PlanViewer.Core/Output/ResultMapper.cs
@@ -87,9 +87,26 @@ public static class ResultMapper
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
+
+        /* #482: every consumer of the analysis — advice for humans, advice for robots, the HTML
+           export, the comparison report, the MCP tools — reads its statement text from here, so this
+           is where the parameter values go back in. #467 substituted at the two copy paths it was
+           looking at, which left the same @0 in every one of these.
+
+           The parser's PlanStatement is deliberately untouched: the analyzer's rules regex over that
+           text (OPTIMIZE FOR UNKNOWN, NOT IN, MAXDOP hints), the properties panel shows what the plan
+           records, and none of that should start reading manufactured literals. */
+        var runnable = ParameterSubstitution.Apply(stmt.StatementText, stmt.Parameters);
+
         var result = new StatementResult
         {
-            StatementText = stmt.StatementText,
+            StatementText = runnable.Text,
+
+            /* Carried, not discarded — this is the text that matches the plan cache and Query Store,
+               and get_repro_script has to pair a query body with a declared parameter list. Null when
+               nothing was substituted so it never appears on the overwhelming majority of statements
+               that have nothing to say here. */
+            ParameterizedStatementText = runnable.SubstitutionCount > 0 ? stmt.StatementText : null,
             StatementType = stmt.StatementType,
             EstimatedCost = stmt.StatementSubTreeCost,
             EstimatedRows = stmt.StatementEstRows,

--- a/src/PlanViewer.Core/Services/BenefitScorer.cs
+++ b/src/PlanViewer.Core/Services/BenefitScorer.cs
@@ -30,23 +30,26 @@ public static class BenefitScorer
 
     internal static void ScoreCancellable(ParsedPlan plan, CancellationToken cancellationToken)
     {
-        foreach (var batch in plan.Batches)
+        /* #456 made the analyzer descend into stored procedure and UDF bodies via
+           PlanStatements.EnumerateAll, but this walk was left on batch.Statements. The analyzer
+           then CREATED warnings on the body statements and the scorer never visited them, so their
+           MaxBenefitPercent stayed null and their wait stats were never scored or surfaced — the
+           UI sorts unquantified warnings below quantified ones, which quietly buried every finding
+           inside an EXEC <procedure> plan. Same shared traversal as the analyzer so the two passes
+           cannot see different statements again. */
+        foreach (var stmt in PlanStatements.EnumerateAll(plan))
         {
             cancellationToken.ThrowIfCancellationRequested();
-            foreach (var stmt in batch.Statements)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                ScoreStatementWarnings(stmt);
+            ScoreStatementWarnings(stmt);
 
-                if (stmt.RootNode != null)
-                    ScoreNodeTree(stmt.RootNode, stmt, cancellationToken);
+            if (stmt.RootNode != null)
+                ScoreNodeTree(stmt.RootNode, stmt, cancellationToken);
 
-                if (stmt.WaitStats.Count > 0 && stmt.QueryTimeStats != null)
-                    ScoreWaitStats(stmt);
+            if (stmt.WaitStats.Count > 0 && stmt.QueryTimeStats != null)
+                ScoreWaitStats(stmt);
 
-                if (stmt.WaitStats.Count > 0)
-                    EmitWaitStatWarnings(stmt);
-            }
+            if (stmt.WaitStats.Count > 0)
+                EmitWaitStatWarnings(stmt);
         }
     }
 

--- a/src/PlanViewer.Core/Services/ParameterSubstitution.cs
+++ b/src/PlanViewer.Core/Services/ParameterSubstitution.cs
@@ -275,6 +275,14 @@ public static class ParameterSubstitution
     /// Whether the statement's leading keyword chain reaches EXEC or EXECUTE, in which case an
     /// <c>=</c> can only ever mean assignment — the return-status variable or a named argument.
     ///
+    /// <para>Why that holds statement-wide rather than per argument: T-SQL restricts an EXEC
+    /// argument's VALUE to a literal, a variable, NULL, or DEFAULT. An expression — a CASE, a
+    /// subquery, arithmetic — is a compile error there (<c>Incorrect syntax</c>), so no legal
+    /// compiled statement can put a read like <c>CASE WHEN @x = 1 …</c> to the right of a named
+    /// argument. The only <c>@name =</c> pairs that can exist in the region this flag governs are
+    /// assignments. A hand-crafted plan file can of course contain anything, but its author already
+    /// controls the whole statement text, so precision against it protects nothing.</para>
+    ///
     /// <para>The chain is EXEC itself, or the INSERT … EXEC prelude: INSERT, an optional INTO, the
     /// target's possibly bracketed and dotted name, an optional parenthesized column list. The walk
     /// is forward from the start and gives up at the first character that cannot belong to such a

--- a/src/PlanViewer.Core/Services/ParameterSubstitution.cs
+++ b/src/PlanViewer.Core/Services/ParameterSubstitution.cs
@@ -93,7 +93,8 @@ public static class ParameterSubstitution
                     end++;
 
                 var token = statementText[i..end];
-                if (values.TryGetValue(token, out var value))
+                if (values.TryGetValue(token, out var value)
+                    && !IsAssignmentTarget(statementText, i, end))
                 {
                     sb.Append(value);
                     substitutions++;
@@ -114,6 +115,55 @@ public static class ParameterSubstitution
         return substitutions == 0
             ? new ParameterSubstitutionResult(statementText, 0)
             : new ParameterSubstitutionResult(sb.ToString(), substitutions);
+    }
+
+    /// <summary>
+    /// True when the parameter token spanning <paramref name="start"/> to <paramref name="end"/> is
+    /// being assigned TO rather than read from, in which case its value must not be written over it.
+    ///
+    /// <para><b>Why (#482).</b> <c>SELECT @job_name = name, @owner_sid = owner_sid FROM …</c> is a
+    /// real committed plan, and its ParameterList records both of those variables with a compiled
+    /// value of <c>NULL</c>. Substituted blindly it reads <c>SELECT NULL = name, NULL = owner_sid</c>
+    /// — not merely unrunnable but quietly misleading, because it now looks like a comparison. That
+    /// mattered less while substitution was something you asked for on the clipboard; #482 makes it
+    /// what the advice, the exports and the MCP tools show by default.</para>
+    ///
+    /// <para>The three lead-ins below are the ones T-SQL assigns through — <c>SELECT @a = …</c>,
+    /// <c>SET @a = …</c>, and the second and later items of either list. A parameter on the right of
+    /// an <c>=</c> is a read and is left to be substituted, and so is one followed by <c>&gt;=</c>,
+    /// <c>&lt;=</c>, <c>&lt;&gt;</c> or <c>!=</c>, since the scan forward from the token meets that
+    /// operator's first character rather than the <c>=</c>.</para>
+    /// </summary>
+    private static bool IsAssignmentTarget(string text, int start, int end)
+    {
+        var forward = end;
+        while (forward < text.Length && char.IsWhiteSpace(text[forward]))
+            forward++;
+
+        if (forward >= text.Length || text[forward] != '=')
+            return false;
+
+        if (forward + 1 < text.Length && text[forward + 1] == '=')
+            return false;
+
+        var back = start - 1;
+        while (back >= 0 && char.IsWhiteSpace(text[back]))
+            back--;
+
+        if (back < 0)
+            return false;
+
+        /* "SELECT @a = x, @b = y" — everything after the first comma is still a select list. */
+        if (text[back] == ',')
+            return true;
+
+        var wordEnd = back + 1;
+        while (back >= 0 && IsIdentifierPart(text[back]))
+            back--;
+
+        var word = text[(back + 1)..wordEnd];
+        return word.Equals("SELECT", StringComparison.OrdinalIgnoreCase)
+            || word.Equals("SET", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/PlanViewer.Core/Services/ParameterSubstitution.cs
+++ b/src/PlanViewer.Core/Services/ParameterSubstitution.cs
@@ -47,6 +47,14 @@ public static class ParameterSubstitution
         if (values.Count == 0)
             return new ParameterSubstitutionResult(statementText, 0);
 
+        /* One fact about the whole statement, settled up front: inside an EXEC statement, every
+           token sitting to the left of an "=" is an assignment target — the return-status variable
+           or a named argument's name — because EXEC grammar has no other use for "=" at all. A
+           per-token back-scan cannot see this for the FIRST named argument (what precedes it is
+           the procedure name, not a keyword), which is how "EXEC dbo.p @debug = @debug" got its
+           left-hand side substituted into "EXEC dbo.p 1 = @debug". */
+        var assignsThroughEquals = StatementLeadsWithExec(statementText);
+
         var sb = new StringBuilder(statementText.Length);
         var substitutions = 0;
         var i = 0;
@@ -94,7 +102,7 @@ public static class ParameterSubstitution
 
                 var token = statementText[i..end];
                 if (values.TryGetValue(token, out var value)
-                    && !IsAssignmentTarget(statementText, i, end))
+                    && !IsAssignmentTarget(statementText, i, end, assignsThroughEquals))
                 {
                     sb.Append(value);
                     substitutions++;
@@ -128,23 +136,41 @@ public static class ParameterSubstitution
     /// mattered less while substitution was something you asked for on the clipboard; #482 makes it
     /// what the advice, the exports and the MCP tools show by default.</para>
     ///
-    /// <para>The three lead-ins below are the ones T-SQL assigns through — <c>SELECT @a = …</c>,
-    /// <c>SET @a = …</c>, and the second and later items of either list. A parameter on the right of
-    /// an <c>=</c> is a read and is left to be substituted, and so is one followed by <c>&gt;=</c>,
+    /// <para>The lead-ins recognised: <c>SELECT @a = …</c> and <c>SET @a = …</c>, with one balanced
+    /// parenthesized group tolerated between the keyword and the target so <c>SELECT TOP (1) @a =
+    /// …</c> is the assignment it is; the second and later items of either list, via the comma; any
+    /// token in front of an <c>=</c> when the statement is an EXEC
+    /// (<paramref name="assignsThroughEquals"/> — see <see cref="StatementLeadsWithExec"/>); and
+    /// <c>FETCH … INTO @a, @b</c>, which assigns with no <c>=</c> anywhere. A parameter on the right
+    /// of an <c>=</c> is a read and is left to be substituted, and so is one followed by <c>&gt;=</c>,
     /// <c>&lt;=</c>, <c>&lt;&gt;</c> or <c>!=</c>, since the scan forward from the token meets that
     /// operator's first character rather than the <c>=</c>.</para>
     /// </summary>
-    private static bool IsAssignmentTarget(string text, int start, int end)
+    private static bool IsAssignmentTarget(string text, int start, int end, bool assignsThroughEquals)
     {
         var forward = end;
         while (forward < text.Length && char.IsWhiteSpace(text[forward]))
             forward++;
 
-        if (forward >= text.Length || text[forward] != '=')
-            return false;
+        var followedByLoneEquals =
+            forward < text.Length
+            && text[forward] == '='
+            && !(forward + 1 < text.Length && text[forward + 1] == '=');
 
-        if (forward + 1 < text.Length && text[forward + 1] == '=')
-            return false;
+        /* FETCH ... INTO @a, @b assigns without any "=": what follows the token is a comma or the
+           end of the statement, so the forward scan has nothing to find and the question is
+           answered entirely by what leads the list. Checked only on the no-equals path — "INTO
+           @a =" is not a shape T-SQL has — which keeps every "=" case on the scans below. */
+        if (!followedByLoneEquals)
+            return IsFetchIntoTarget(text, start);
+
+        /* EXEC @rc = dbo.proc, and the FIRST named argument of EXEC dbo.p @debug = @debug. The
+           back-scan below cannot see either (what precedes them is a procedure name, not SELECT
+           or SET), but EXEC grammar has no reads-then-"=" shape at all, so inside one the "="
+           alone settles it. Later named arguments were already caught by the comma rule; this
+           makes the first one match its siblings. */
+        if (assignsThroughEquals)
+            return true;
 
         var back = start - 1;
         while (back >= 0 && char.IsWhiteSpace(text[back]))
@@ -157,13 +183,193 @@ public static class ParameterSubstitution
         if (text[back] == ',')
             return true;
 
+        /* SELECT TOP (1) @a = col: the token before the target is TOP's balanced group, which the
+           old scan met as ")" and gave up on — it extracted an empty word and substituted @a into
+           "NULL = col". Skip exactly ONE balanced group backwards and judge what precedes it;
+           nothing but TOP puts a group in an assignment lead-in, so anything else still answers
+           no. TOP (@n) rides along for free — the group's content is opaque to this walk, and @n
+           itself is a read whose own forward scan meets ")" rather than "=". */
+        if (text[back] == ')')
+        {
+            var depth = 0;
+            while (back >= 0)
+            {
+                if (text[back] == ')')
+                {
+                    depth++;
+                }
+                else if (text[back] == '(' && --depth == 0)
+                {
+                    back--;
+                    break;
+                }
+
+                back--;
+            }
+
+            /* Unbalanced means truncated statement text. With no way to tell what leads in, stay
+               on the substitute side, which is where the empty-word scan always landed. */
+            if (depth != 0)
+                return false;
+
+            while (back >= 0 && char.IsWhiteSpace(text[back]))
+                back--;
+        }
+
+        var word = ReadWordEndingAt(text, ref back);
+
+        /* TOP sits between SELECT and its group, so the decider is the word before it. */
+        if (word.Equals("TOP", StringComparison.OrdinalIgnoreCase))
+        {
+            while (back >= 0 && char.IsWhiteSpace(text[back]))
+                back--;
+            word = ReadWordEndingAt(text, ref back);
+        }
+
+        return word.Equals("SELECT", StringComparison.OrdinalIgnoreCase)
+            || word.Equals("SET", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// True when the token at <paramref name="start"/> sits in an INTO list — <c>FETCH … INTO @a,
+    /// @b</c> — which assigns into its variables with no <c>=</c> in sight.
+    ///
+    /// <para>The walk hops backwards over "<c>, @name</c>" pairs so every member of the list is
+    /// protected, not just the first. The hop insists each prior list item is itself an @token,
+    /// which is how the commas of an IN list, a VALUES row, or a positional EXEC argument list —
+    /// all places a parameter is read — fall out: at the first non-variable item, or at the "("
+    /// that opens them. <c>INSERT INTO @tv</c> lands here too, and "assignment target" is the
+    /// right answer there as well — a table variable's NAME is never a value to write over.</para>
+    /// </summary>
+    private static bool IsFetchIntoTarget(string text, int start)
+    {
+        var back = start - 1;
+
+        while (true)
+        {
+            while (back >= 0 && char.IsWhiteSpace(text[back]))
+                back--;
+
+            if (back < 0)
+                return false;
+
+            if (text[back] == ',')
+            {
+                back--;
+                while (back >= 0 && char.IsWhiteSpace(text[back]))
+                    back--;
+
+                var previousItem = ReadWordEndingAt(text, ref back);
+                if (previousItem.Length == 0 || previousItem[0] != '@')
+                    return false;
+
+                continue;
+            }
+
+            return ReadWordEndingAt(text, ref back)
+                .Equals("INTO", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    /// <summary>
+    /// Whether the statement's leading keyword chain reaches EXEC or EXECUTE, in which case an
+    /// <c>=</c> can only ever mean assignment — the return-status variable or a named argument.
+    ///
+    /// <para>The chain is EXEC itself, or the INSERT … EXEC prelude: INSERT, an optional INTO, the
+    /// target's possibly bracketed and dotted name, an optional parenthesized column list. The walk
+    /// is forward from the start and gives up at the first character that cannot belong to such a
+    /// prelude — an operator, a quote, a semicolon — so a SELECT or UPDATE never gets anywhere near
+    /// a false positive: it hits its own <c>=</c> or <c>*</c> within a few tokens. Bracketed name
+    /// parts are skipped opaquely so a procedure named [exec] cannot read as the keyword, and
+    /// EXEC('…') is no counterexample — the string stays opaque to Apply's main loop, so nothing
+    /// inside it is substituted regardless of what this answers. Leading comments are not chased;
+    /// a statement that opens with one keeps the old per-token behavior.</para>
+    /// </summary>
+    private static bool StatementLeadsWithExec(string text)
+    {
+        var i = 0;
+
+        /* A handful of tokens is all the INSERT ... EXEC prelude can hold. The bound is a fuse
+           against pathological text, not part of the grammar. */
+        for (var tokens = 0; tokens < 8; tokens++)
+        {
+            while (i < text.Length && char.IsWhiteSpace(text[i]))
+                i++;
+
+            if (i >= text.Length)
+                return false;
+
+            var c = text[i];
+
+            // The INSERT target's column list, skipped as one balanced unit.
+            if (c == '(')
+            {
+                var depth = 0;
+                while (i < text.Length)
+                {
+                    if (text[i] == '(')
+                    {
+                        depth++;
+                    }
+                    else if (text[i] == ')' && --depth == 0)
+                    {
+                        i++;
+                        break;
+                    }
+
+                    i++;
+                }
+
+                if (depth != 0)
+                    return false;
+
+                continue;
+            }
+
+            // A delimited name part, skipped opaquely; dots just join parts.
+            if (c == '[' || c == '"')
+            {
+                var close = text.IndexOf(c == '[' ? ']' : '"', i + 1);
+                if (close < 0)
+                    return false;
+
+                i = close + 1;
+                continue;
+            }
+
+            if (c == '.')
+            {
+                i++;
+                continue;
+            }
+
+            if (!IsIdentifierPart(c))
+                return false;
+
+            var wordStart = i;
+            while (i < text.Length && IsIdentifierPart(text[i]))
+                i++;
+
+            var word = text[wordStart..i];
+            if (word.Equals("EXEC", StringComparison.OrdinalIgnoreCase)
+                || word.Equals("EXECUTE", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The identifier run ending at <paramref name="back"/>, or the empty string when the character
+    /// there is not part of one. Leaves <paramref name="back"/> on the character before the run.
+    /// </summary>
+    private static string ReadWordEndingAt(string text, ref int back)
+    {
         var wordEnd = back + 1;
         while (back >= 0 && IsIdentifierPart(text[back]))
             back--;
 
-        var word = text[(back + 1)..wordEnd];
-        return word.Equals("SELECT", StringComparison.OrdinalIgnoreCase)
-            || word.Equals("SET", StringComparison.OrdinalIgnoreCase);
+        return text[(back + 1)..wordEnd];
     }
 
     /// <summary>

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.Detection.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.Detection.cs
@@ -211,8 +211,12 @@ public static partial class PlanAnalyzer
     /// why this reads the CONVERT_IMPLICIT argument list rather than splitting on the comparison
     /// operator the way <see cref="IsFunctionOnColumnSide"/> does. The first argument is the target
     /// type and carries no brackets; a column reference in the remainder is the conversion input.</para>
+    ///
+    /// <para>Internal so the column-vs-variable line can be tested against raw predicate strings in
+    /// showplan shape — the table-variable case ([@tv].[col] IS a column) has no committed plan
+    /// fixture, and the distinction lives entirely in this method and the regex it shares.</para>
     /// </summary>
-    private static bool ConvertImplicitWrapsColumn(string predicate)
+    internal static bool ConvertImplicitWrapsColumn(string predicate)
     {
         foreach (Match match in ConvertImplicitRegex.Matches(predicate))
         {

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.Helpers.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.Helpers.cs
@@ -8,11 +8,20 @@ namespace PlanViewer.Core.Services;
 
 public static partial class PlanAnalyzer
 {
+    /* Both passes below match on WarningType alone, and a type name is not unique to us:
+       "Implicit Conversion" is rule 29's legacy-listed type AND what the parser stamps on the
+       engine's own PlanAffectingConvert element (Source = SqlServer). Matching by name only
+       therefore branded the ENGINE's record "[SQL Server] [legacy]" — a badge that exists to
+       flag our un-migrated rules on a warning that is not ours at all — and TryOverrideSeverity
+       routed a user's rule-number override onto engine warnings the rule never produced (the
+       Contains matching makes it worse: every engine Spill variant lands on rule 7, "Memory
+       Grant" on rule 9). Legacy status and rule severity are facts about OUR rules, so anything
+       the engine said is skipped by both. */
     private static void MarkLegacyWarnings(PlanStatement stmt)
     {
         foreach (var w in stmt.PlanWarnings)
         {
-            if (LegacyWarningTypes.Contains(w.WarningType))
+            if (w.Source != PlanWarningSource.SqlServer && LegacyWarningTypes.Contains(w.WarningType))
                 w.IsLegacy = true;
         }
         if (stmt.RootNode != null)
@@ -23,7 +32,7 @@ public static partial class PlanAnalyzer
     {
         foreach (var w in node.Warnings)
         {
-            if (LegacyWarningTypes.Contains(w.WarningType))
+            if (w.Source != PlanWarningSource.SqlServer && LegacyWarningTypes.Contains(w.WarningType))
                 w.IsLegacy = true;
         }
         foreach (var child in node.Children)
@@ -58,6 +67,11 @@ public static partial class PlanAnalyzer
 
     private static void TryOverrideSeverity(PlanWarning warning, AnalyzerConfig cfg)
     {
+        /* The engine's warnings carry no rule number because no rule of ours produced them; see
+           the comment on MarkLegacyWarnings for what the name-only matching did to them here. */
+        if (warning.Source == PlanWarningSource.SqlServer)
+            return;
+
         // Find the rule number for this warning type (partial match for flexibility)
         int? ruleNumber = null;
         foreach (var (rule, type) in RuleWarningTypes)

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.Helpers.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.Helpers.cs
@@ -30,18 +30,21 @@ public static partial class PlanAnalyzer
             MarkLegacyWarningsOnTree(child);
     }
 
+    /* #456 follow-up: the analyzer walks every statement — stored procedure and UDF bodies
+       included — through PlanStatements.EnumerateAll, but this pass still walked batch.Statements,
+       so a user's severity override applied to a warning on the outer batch and silently did not
+       apply to the identical warning inside an EXEC <procedure> body. (MarkLegacyWarnings does not
+       have this problem: it is called per-statement from inside the analyzer's EnumerateAll loop,
+       so it was carried along when that loop learned to descend.) */
     private static void ApplySeverityOverrides(ParsedPlan plan, AnalyzerConfig cfg)
     {
-        foreach (var batch in plan.Batches)
+        foreach (var stmt in PlanStatements.EnumerateAll(plan))
         {
-            foreach (var stmt in batch.Statements)
-            {
-                foreach (var w in stmt.PlanWarnings)
-                    TryOverrideSeverity(w, cfg);
+            foreach (var w in stmt.PlanWarnings)
+                TryOverrideSeverity(w, cfg);
 
-                if (stmt.RootNode != null)
-                    ApplyOverridesToTree(stmt.RootNode, cfg);
-            }
+            if (stmt.RootNode != null)
+                ApplyOverridesToTree(stmt.RootNode, cfg);
         }
     }
 

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.cs
@@ -28,11 +28,15 @@ public static partial class PlanAnalyzer
         @"\bCONVERT_IMPLICIT\s*\(",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-    // A column reference in a ScalarString is multi-part bracket-qualified ([schema].[table]).
-    // A variable is a single bracket pair with an @ prefix ([@0]), so excluding @ from the first
-    // part is what separates the two.
+    /* A column reference in a ScalarString is multi-part bracket-qualified ([schema].[table]).
+       A variable is a single bracket pair with an @ prefix ([@0]) and no dotted part after it —
+       the "].[" sequence is what separates the two, NOT the @. The first cut of this pattern also
+       excluded @ from the first part, which read as belt-and-braces but was actually a hole: a
+       TABLE-variable column renders as [@tv].[col], so a genuine column-side CONVERT_IMPLICIT on
+       one failed the match and the Non-SARGable warning silently vanished. A bare [@p] still
+       cannot match, because nothing dotted follows it. */
     private static readonly Regex ColumnReferenceRegex = new(
-        @"\[[^\]@]+\]\.\[",
+        @"\[[^\]]+\]\.\[",
         RegexOptions.Compiled);
 
     public static void Analyze(ParsedPlan plan, AnalyzerConfig? config = null, ServerMetadata? serverMetadata = null) =>

--- a/src/PlanViewer.Core/Services/PlanStatements.cs
+++ b/src/PlanViewer.Core/Services/PlanStatements.cs
@@ -34,35 +34,90 @@ public static class PlanStatements
     }
 
     /// <summary>
-    /// <paramref name="statements"/> and everything nested beneath them.
+    /// <paramref name="statements"/> and everything nested beneath them. Defined in terms of
+    /// <see cref="EnumerateAllWithContainer(IReadOnlyList{PlanStatement})"/> so the plain and the
+    /// context-carrying enumeration are literally the same walk — a consumer picking either one
+    /// gets the same statements in the same order, which is the whole point of this class.
+    /// </summary>
+    public static IEnumerable<PlanStatement> EnumerateAll(IReadOnlyList<PlanStatement> statements)
+    {
+        foreach (var entry in EnumerateAllWithContainer(statements))
+            yield return entry.Statement;
+    }
+
+    /// <summary>
+    /// Every statement in the plan with the name of the module whose body it came from, for
+    /// consumers that show statements to a person rather than just walking them.
+    ///
+    /// <para>Why the context matters (#456 follow-up): once the desktop statements grid started
+    /// listing procedure-body statements alongside the outer batch, five rows of bare SELECTs with
+    /// nothing saying which came from <c>EXEC dbo.Whatever</c> would be technically complete and
+    /// practically unreadable. The container name is part of the traversal rather than something
+    /// each UI reconstructs with its own walk, because two walks that must agree is exactly the
+    /// arrangement that produced #455.</para>
+    /// </summary>
+    public static IEnumerable<StatementWithContainer> EnumerateAllWithContainer(ParsedPlan plan)
+    {
+        foreach (var batch in plan.Batches)
+        {
+            foreach (var entry in EnumerateAllWithContainer(batch.Statements))
+                yield return entry;
+        }
+    }
+
+    /// <summary>
+    /// <paramref name="statements"/> and everything nested beneath them, each paired with the
+    /// module path it lives in (null for the outer batch).
     ///
     /// <para>An explicit stack rather than recursion, because procedure bodies nest — a procedure
     /// calling a procedure calling a function — and #430 was a crash caused by assuming a plan's
     /// shapes are shallow.</para>
     /// </summary>
-    public static IEnumerable<PlanStatement> EnumerateAll(IReadOnlyList<PlanStatement> statements)
+    public static IEnumerable<StatementWithContainer> EnumerateAllWithContainer(IReadOnlyList<PlanStatement> statements)
     {
-        var pending = new Stack<PlanStatement>();
+        var pending = new Stack<StatementWithContainer>();
         for (var i = statements.Count - 1; i >= 0; i--)
-            pending.Push(statements[i]);
+            pending.Push(new StatementWithContainer(statements[i], ContainerPath: null));
 
-        while (pending.TryPop(out var statement))
+        while (pending.TryPop(out var entry))
         {
-            yield return statement;
+            yield return entry;
 
             /* Pushed in reverse so the bodies come back out in source order, and pushed AFTER the
                statement is yielded so a body follows the EXEC that owns it rather than preceding it. */
+            var statement = entry.Statement;
             for (var i = statement.UdfPlans.Count - 1; i >= 0; i--)
-                PushAll(statement.UdfPlans[i].Statements, pending);
+                PushAll(statement.UdfPlans[i], entry.ContainerPath, pending);
 
             if (statement.StoredProcPlan is not null)
-                PushAll(statement.StoredProcPlan.Statements, pending);
+                PushAll(statement.StoredProcPlan, entry.ContainerPath, pending);
         }
     }
 
-    private static void PushAll(IReadOnlyList<PlanStatement> statements, Stack<PlanStatement> pending)
+    private static void PushAll(FunctionPlanInfo body, string? outerPath, Stack<StatementWithContainer> pending)
     {
-        for (var i = statements.Count - 1; i >= 0; i--)
-            pending.Push(statements[i]);
+        var path = AppendModule(outerPath, body.ProcName);
+        for (var i = body.Statements.Count - 1; i >= 0; i--)
+            pending.Push(new StatementWithContainer(body.Statements[i], path));
+    }
+
+    /// <summary>
+    /// Chains module names for nesting, so a statement two bodies deep reads
+    /// "dbo.Outer &gt; dbo.Inner" rather than pretending it sits directly in dbo.Inner's caller.
+    /// A module the plan left unnamed contributes nothing to the path — the traversal reports what
+    /// the plan said, not a placeholder — so its statements inherit the enclosing path (or none).
+    /// </summary>
+    private static string? AppendModule(string? outerPath, string procName)
+    {
+        if (string.IsNullOrEmpty(procName))
+            return outerPath;
+        return outerPath is null ? procName : outerPath + " > " + procName;
     }
 }
+
+/// <summary>
+/// One statement from <see cref="PlanStatements.EnumerateAllWithContainer(ParsedPlan)"/>:
+/// the statement itself, and the proc/UDF module path it came from — null for a statement in the
+/// outer batch, "dbo.Proc" for a procedure body, "dbo.Outer &gt; dbo.Inner" for nested bodies.
+/// </summary>
+public readonly record struct StatementWithContainer(PlanStatement Statement, string? ContainerPath);

--- a/src/PlanViewer.Core/Services/ShowPlanParser.cs
+++ b/src/PlanViewer.Core/Services/ShowPlanParser.cs
@@ -15,14 +15,23 @@ public static partial class ShowPlanParser
     // Plan XML is untrusted input (opened/pasted/downloaded). Cap recursion depth so a
     // maliciously deep tree throws a catchable exception instead of an uncatchable
     // StackOverflowException that takes the whole process down.
-    private const int MaxParseDepth = 1000;
-    private const int MaxParseCharacters = 16 * 1024 * 1024;
+    // Internal so tests can pin behavior just past each limit without hardcoding the values.
+    internal const int MaxParseDepth = 1000;
+    internal const int MaxParseCharacters = 16 * 1024 * 1024;
 
     public static ParsedPlan Parse(string xml)
     {
         var plan = new ParsedPlan { RawXml = xml };
         try
         {
+            /* Same ceiling ParseAsync enforces through XmlReaderSettings.MaxCharactersInDocument,
+               which this synchronous path (PlanViewerControl, the web viewer, the analysis
+               pipeline) never had - it went straight to XDocument.Parse with no limit at all.
+               The input is already an in-memory string here, so a length check is the equivalent
+               guard; like the reader setting, the limit is in characters, not bytes. */
+            if (xml.Length > MaxParseCharacters)
+                throw new InvalidOperationException(
+                    $"Plan XML exceeds the supported size limit of {MaxParseCharacters.ToString("N0", CultureInfo.InvariantCulture)} characters.");
             return ParseDocument(XDocument.Parse(xml), plan, CancellationToken.None);
         }
         catch (Exception exception)
@@ -109,7 +118,7 @@ public static partial class ShowPlanParser
                 foreach (var statementElement in root.Descendants(Ns + "StmtSimple"))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    var statement = ParseStatement(statementElement, cancellationToken);
+                    var statement = ParseStatement(statementElement, depth: 0, cancellationToken);
                     if (statement is not null)
                         batch.Statements.Add(statement);
                 }
@@ -213,7 +222,7 @@ public static partial class ShowPlanParser
         else
         {
             // StmtSimple or any other statement type
-            var stmt = ParseStatement(stmtEl, cancellationToken);
+            var stmt = ParseStatement(stmtEl, depth, cancellationToken);
             if (stmt != null)
                 results.Add(stmt);
         }
@@ -221,8 +230,16 @@ public static partial class ShowPlanParser
         return results;
     }
 
+    /* The depth parameter exists for the StoredProc/UDF descents below. #456 added those
+       descents calling ParseStatementAndChildren without a depth argument, so the recursion
+       depth silently reset to zero at every procedure boundary and the MaxParseDepth guard in
+       ParseStatementAndChildren could never fire across StoredProc/UDF nesting - a crafted plan
+       alternating StmtSimple > StoredProc > Statements a few thousand levels deep (about sixty
+       bytes each) still reached the uncatchable StackOverflowException the guard exists to
+       prevent. Carrying the caller's depth through this method closes that reset. */
     private static PlanStatement? ParseStatement(
         XElement stmtEl,
+        int depth = 0,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -296,7 +313,7 @@ public static partial class ShowPlanParser
             {
                 foreach (var childStmt in udfStmts.Elements())
                 {
-                    var parsed = ParseStatementAndChildren(childStmt, cancellationToken: cancellationToken);
+                    var parsed = ParseStatementAndChildren(childStmt, depth + 1, cancellationToken);
                     udfInfo.Statements.AddRange(parsed);
                 }
             }
@@ -317,7 +334,7 @@ public static partial class ShowPlanParser
             {
                 foreach (var childStmt in spStmts.Elements())
                 {
-                    var parsed = ParseStatementAndChildren(childStmt, cancellationToken: cancellationToken);
+                    var parsed = ParseStatementAndChildren(childStmt, depth + 1, cancellationToken);
                     spInfo.Statements.AddRange(parsed);
                 }
             }

--- a/src/PlanViewer.Core/Services/ShowPlanParser.cs
+++ b/src/PlanViewer.Core/Services/ShowPlanParser.cs
@@ -214,6 +214,20 @@ public static partial class ShowPlanParser
                         stmt.CursorRequestedType = cursorRequestedType;
                         stmt.CursorConcurrency = cursorConcurrency;
                         stmt.CursorForwardOnly = cursorForwardOnly;
+
+                        /* #491: the same StoredProc/UDF descent every other statement shape gets.
+                           #456 taught ParseStatement to read sub-plan bodies, but a cursor's
+                           operation statements are built HERE, through ParseQueryPlanAsStatement,
+                           and never pass through ParseStatement - so a function called by the
+                           cursor's query carried its whole body in the XML (the Operation element
+                           holds the UDF sub-plan right next to this QueryPlan) and the parser
+                           dropped every statement of it. Attaching the bodies to the operation's
+                           statement is all it takes: PlanStatements.EnumerateAll already walks
+                           UdfPlans/StoredProcPlan on every statement it yields, and since #486
+                           every consumer reads that traversal. Depth passes through unchanged
+                           (#484) - resetting it at this boundary would reopen the MaxParseDepth
+                           bypass across cursor/procedure nesting. */
+                        ParseSubPlans(stmt, opEl, depth, cancellationToken);
                         results.Add(stmt);
                     }
                 }
@@ -300,46 +314,7 @@ public static partial class ShowPlanParser
            so it took that early return and never reached this code, seventy lines further down. The
            parser looked like it descended into procedures and in the one case that matters never
            did. The same was true of a UDF call whose statement carries no plan of its own. */
-        // XSD gap: UDF sub-plans
-        foreach (var udfEl in stmtEl.Elements(Ns + "UDF"))
-        {
-            var udfInfo = new FunctionPlanInfo
-            {
-                ProcName = udfEl.Attribute("ProcName")?.Value ?? "",
-                IsNativelyCompiled = udfEl.Attribute("IsNativelyCompiled")?.Value is "true" or "1"
-            };
-            var udfStmts = udfEl.Element(Ns + "Statements");
-            if (udfStmts != null)
-            {
-                foreach (var childStmt in udfStmts.Elements())
-                {
-                    var parsed = ParseStatementAndChildren(childStmt, depth + 1, cancellationToken);
-                    udfInfo.Statements.AddRange(parsed);
-                }
-            }
-            stmt.UdfPlans.Add(udfInfo);
-        }
-
-        // XSD gap: StoredProc sub-plan
-        var storedProcEl = stmtEl.Element(Ns + "StoredProc");
-        if (storedProcEl != null)
-        {
-            var spInfo = new FunctionPlanInfo
-            {
-                ProcName = storedProcEl.Attribute("ProcName")?.Value ?? "",
-                IsNativelyCompiled = storedProcEl.Attribute("IsNativelyCompiled")?.Value is "true" or "1"
-            };
-            var spStmts = storedProcEl.Element(Ns + "Statements");
-            if (spStmts != null)
-            {
-                foreach (var childStmt in spStmts.Elements())
-                {
-                    var parsed = ParseStatementAndChildren(childStmt, depth + 1, cancellationToken);
-                    spInfo.Statements.AddRange(parsed);
-                }
-            }
-            stmt.StoredProcPlan = spInfo;
-        }
+        ParseSubPlans(stmt, stmtEl, depth, cancellationToken);
 
         if (queryPlanEl == null)
         {
@@ -398,6 +373,64 @@ public static partial class ShowPlanParser
 
 
         return stmt;
+    }
+
+    /// <summary>
+    /// Reads the StoredProc/UDF sub-plan bodies hanging off <paramref name="containerEl"/> onto
+    /// <paramref name="stmt"/>. One reader shared by ParseStatement — where StmtSimple carries the
+    /// UDF/StoredProc elements directly — and the StmtCursor branch (#491), where the same UDF
+    /// element sits beside the QueryPlan under CursorPlan &gt; Operation instead, so the two shapes
+    /// cannot drift apart the way the analyzer and the mapper once did (#455).
+    /// The caller's depth carries into the body statements (#484): this descent is what makes
+    /// module nesting recursive, and resetting depth at a sub-plan boundary is exactly the
+    /// MaxParseDepth bypass #484 closed.
+    /// </summary>
+    private static void ParseSubPlans(
+        PlanStatement stmt,
+        XElement containerEl,
+        int depth,
+        CancellationToken cancellationToken)
+    {
+        // XSD gap: UDF sub-plans
+        foreach (var udfEl in containerEl.Elements(Ns + "UDF"))
+        {
+            var udfInfo = new FunctionPlanInfo
+            {
+                ProcName = udfEl.Attribute("ProcName")?.Value ?? "",
+                IsNativelyCompiled = udfEl.Attribute("IsNativelyCompiled")?.Value is "true" or "1"
+            };
+            var udfStmts = udfEl.Element(Ns + "Statements");
+            if (udfStmts != null)
+            {
+                foreach (var childStmt in udfStmts.Elements())
+                {
+                    var parsed = ParseStatementAndChildren(childStmt, depth + 1, cancellationToken);
+                    udfInfo.Statements.AddRange(parsed);
+                }
+            }
+            stmt.UdfPlans.Add(udfInfo);
+        }
+
+        // XSD gap: StoredProc sub-plan
+        var storedProcEl = containerEl.Element(Ns + "StoredProc");
+        if (storedProcEl != null)
+        {
+            var spInfo = new FunctionPlanInfo
+            {
+                ProcName = storedProcEl.Attribute("ProcName")?.Value ?? "",
+                IsNativelyCompiled = storedProcEl.Attribute("IsNativelyCompiled")?.Value is "true" or "1"
+            };
+            var spStmts = storedProcEl.Element(Ns + "Statements");
+            if (spStmts != null)
+            {
+                foreach (var childStmt in spStmts.Elements())
+                {
+                    var parsed = ParseStatementAndChildren(childStmt, depth + 1, cancellationToken);
+                    spInfo.Statements.AddRange(parsed);
+                }
+            }
+            stmt.StoredProcPlan = spInfo;
+        }
     }
 
     /// <summary>

--- a/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
+++ b/src/PlanViewer.Ssms/Properties/AssemblyInfo.cs
@@ -7,5 +7,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Performance Studio for SSMS")]
 [assembly: AssemblyCopyright("Copyright Darling Data 2026")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("1.23.0.0")]
-[assembly: AssemblyFileVersion("1.23.0.0")]
+[assembly: AssemblyVersion("1.24.0.0")]
+[assembly: AssemblyFileVersion("1.24.0.0")]

--- a/src/PlanViewer.Ssms/source.extension.vsixmanifest
+++ b/src/PlanViewer.Ssms/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="PlanViewer.Ssms.64F79022-9D9A-4463-A1AE-4B19426A0CB1"
-              Version="1.23.0"
+              Version="1.24.0"
               Language="en-US"
               Publisher="Darling Data" />
     <DisplayName>Performance Studio for SSMS</DisplayName>

--- a/src/PlanViewer.Web/Pages/Index.razor
+++ b/src/PlanViewer.Web/Pages/Index.razor
@@ -214,7 +214,14 @@ else
     private PlanNode? selectedNode;
 
     private StatementResult? ActiveStmt => result?.Statements.ElementAtOrDefault(activeStatement);
-    private PlanStatement? ActiveStmtPlan => parsedPlan?.Batches.SelectMany(b => b.Statements).ElementAtOrDefault(activeStatement);
+    /* activeStatement indexes result.Statements, which ResultMapper builds from
+       PlanStatements.EnumerateAll — since #456 that includes statements inside stored procedure
+       and UDF bodies. Mapping the same index into the outer-only batch list returned null for
+       every body statement, so clicking a body statement's tab showed its analysis with no
+       operator tree. The two lists must be walked by the same traversal to line up. */
+    private PlanStatement? ActiveStmtPlan => parsedPlan == null
+        ? null
+        : PlanStatements.EnumerateAll(parsedPlan).ElementAtOrDefault(activeStatement);
 
     private async Task AnalyzePasted()
     {

--- a/src/PlanViewer.Web/PlanViewer.Web.csproj
+++ b/src/PlanViewer.Web/PlanViewer.Web.csproj
@@ -36,6 +36,7 @@
     <Compile Include="..\PlanViewer.Core\Services\PlanIconMapper.cs" Link="Core\Services\PlanIconMapper.cs" />
     <Compile Include="..\PlanViewer.Core\Services\PlanLayoutEngine.cs" Link="Core\Services\PlanLayoutEngine.cs" />
     <Compile Include="..\PlanViewer.Core\Services\TimeDisplayHelper.cs" Link="Core\Services\TimeDisplayHelper.cs" />
+    <Compile Include="..\PlanViewer.Core\Services\ParameterSubstitution.cs" Link="Core\Services\ParameterSubstitution.cs" />
     <Compile Include="..\PlanViewer.Core\Output\AnalysisResult.cs" Link="Core\Output\AnalysisResult.cs" />
     <Compile Include="..\PlanViewer.Core\Output\ResultMapper.cs" Link="Core\Output\ResultMapper.cs" />
     <Compile Include="..\PlanViewer.Core\Output\TextFormatter.cs" Link="Core\Output\TextFormatter.cs" />

--- a/src/PlanViewer.Web/PlanViewer.Web.csproj
+++ b/src/PlanViewer.Web/PlanViewer.Web.csproj
@@ -38,6 +38,7 @@
     <Compile Include="..\PlanViewer.Core\Services\TimeDisplayHelper.cs" Link="Core\Services\TimeDisplayHelper.cs" />
     <Compile Include="..\PlanViewer.Core\Services\ParameterSubstitution.cs" Link="Core\Services\ParameterSubstitution.cs" />
     <Compile Include="..\PlanViewer.Core\Output\AnalysisResult.cs" Link="Core\Output\AnalysisResult.cs" />
+    <Compile Include="..\PlanViewer.Core\Output\AnalysisJson.cs" Link="Core\Output\AnalysisJson.cs" />
     <Compile Include="..\PlanViewer.Core\Output\ResultMapper.cs" Link="Core\Output\ResultMapper.cs" />
     <Compile Include="..\PlanViewer.Core\Output\TextFormatter.cs" Link="Core\Output\TextFormatter.cs" />
     <Compile Include="..\PlanViewer.Core\Output\HtmlExporter.cs" Link="Core\Output\HtmlExporter.cs" />

--- a/src/PlanViewer.Web/Services/PlanShareService.cs
+++ b/src/PlanViewer.Web/Services/PlanShareService.cs
@@ -46,12 +46,16 @@ public sealed class PlanShareService : IPlanShareService
 
     public async Task<PlanShareResult> ShareAsync(AnalysisResult result, string text, int ttlDays)
     {
+        /* AnalysisJson.Wire, not default options: this serializes an AnalysisResult, and #431's
+           depth ceiling exists for "every writer of this object". Default MaxDepth is 64, an
+           operator costs two JSON levels, so sharing a plan ~30 operators deep threw an "object
+           cycle" JsonException here while the same analysis rendered fine everywhere else. */
         var payload = JsonSerializer.Serialize(new
         {
             result = result,
             text = text,
             ttl_days = ttlDays
-        });
+        }, AnalysisJson.Wire);
         var content = new StringContent(payload, Encoding.UTF8, "application/json");
         var response = await _http.PostAsync($"{ApiBase}/api/share", content);
 
@@ -83,9 +87,13 @@ public sealed class PlanShareService : IPlanShareService
         }
 
         var json = await response.Content.ReadAsStringAsync();
-        using var doc = JsonDocument.Parse(json);
+        /* Reading a share hits the default 64 ceiling twice — JsonDocumentOptions and
+           JsonSerializerOptions each carry their own MaxDepth — so a deep plan that ShareAsync
+           could now write would still fail to load without both raised. A share must never be
+           writable but not readable. */
+        using var doc = JsonDocument.Parse(json, AnalysisJson.Document);
         var root = doc.RootElement;
-        var result = JsonSerializer.Deserialize<AnalysisResult>(root.GetProperty("result").GetRawText());
+        var result = JsonSerializer.Deserialize<AnalysisResult>(root.GetProperty("result").GetRawText(), AnalysisJson.Wire);
         var text = root.GetProperty("text").GetString();
         return new SharedPlan(result, text);
     }

--- a/tests/PlanViewer.Core.Tests/AnalysisJsonDepthTests.cs
+++ b/tests/PlanViewer.Core.Tests/AnalysisJsonDepthTests.cs
@@ -107,6 +107,11 @@ public class AnalysisJsonDepthTests
     /// Pins the headroom itself. 1024 is about 500 nested operators against the ~30 that used to fail;
     /// a future edit dropping it back toward the default would re-open #430 for large plans only, which
     /// is the shape of bug that reaches users rather than tests.
+    ///
+    /// <para>The Wire and Document pins matter beyond this assembly: server/PlanShare cannot
+    /// reference PlanViewer.Core and mirrors this number as a literal (a shared constant only
+    /// helps call sites that reference it), so this test is the tripwire that a change here means
+    /// changing the server too.</para>
     /// </summary>
     [Fact]
     public void TheCeilingIsFarAboveAnyRealPlan()
@@ -114,5 +119,50 @@ public class AnalysisJsonDepthTests
         Assert.Equal(1024, AnalysisJson.MaxDepth);
         Assert.Equal(AnalysisJson.MaxDepth, AnalysisJson.Indented.MaxDepth);
         Assert.True(AnalysisJson.Indented.WriteIndented, "advice output is read by people as well as models");
+        Assert.Equal(AnalysisJson.MaxDepth, AnalysisJson.Wire.MaxDepth);
+        Assert.Equal(AnalysisJson.MaxDepth, AnalysisJson.Document.MaxDepth);
+        Assert.False(AnalysisJson.Wire.WriteIndented,
+            "the share wire format has always been default-formatted JSON; only the ceiling changed");
+    }
+
+    /// <summary>
+    /// The three writers #431 missed, found in review: the web Share upload serialized the
+    /// analysis with inline default options, and loading a share back parsed AND deserialized it
+    /// at the default 64 again — so a deep plan analyzed fine on screen and then failed to Share,
+    /// or shared and failed to open. This walks the exact envelope shape the share path uses
+    /// ({result, text, ttl_days} → JsonDocument → GetRawText → Deserialize) through the shared
+    /// options, at 100 operators — past the old ceiling, far under the new one.
+    ///
+    /// <para>Scope, stated honestly: the actual call sites live in PlanViewer.Web (a Blazor WASM
+    /// project this suite does not reference) and server/PlanShare (which references nothing), so
+    /// they are verified by inspection to use these options / mirror this constant. What this test
+    /// pins is the contract those sites rely on — that the shared options round-trip the envelope
+    /// both directions.</para>
+    /// </summary>
+    [Fact]
+    public void TheShareEnvelopeRoundTripsADeepPlan()
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            result = WithOperatorChain(100),
+            text = "=== Summary ===",
+            ttl_days = 7
+        }, AnalysisJson.Wire);
+
+        /* Both proofs that the options are load-bearing: the default reader rejects what the
+           shared writer produced (ThrowsAny because document parsing surfaces the depth failure
+           as JsonReaderException, a JsonException subclass)... */
+        Assert.ThrowsAny<JsonException>(() => JsonDocument.Parse(payload));
+
+        /* ...and the shared reader carries it, all the way back to a typed result. */
+        using var doc = JsonDocument.Parse(payload, AnalysisJson.Document);
+        var result = JsonSerializer.Deserialize<AnalysisResult>(
+            doc.RootElement.GetProperty("result").GetRawText(), AnalysisJson.Wire);
+
+        Assert.NotNull(result);
+        var depth = 0;
+        for (var op = result!.Statements.Single().OperatorTree; op is not null; op = op.Children.FirstOrDefault())
+            depth++;
+        Assert.Equal(100, depth);
     }
 }

--- a/tests/PlanViewer.Core.Tests/AnalysisParameterSubstitutionTests.cs
+++ b/tests/PlanViewer.Core.Tests/AnalysisParameterSubstitutionTests.cs
@@ -1,0 +1,206 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using PlanViewer.App.Mcp;
+using AnalyzerConfig = PlanViewer.Core.Models.AnalyzerConfig;
+using CorePlanSession = PlanViewer.Core.Models.PlanSession;
+using PlanViewer.Core.Output;
+using PlanViewer.Core.Services;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #482: #467 put the parameter values back at the two copy paths it was looking at, and the
+/// reporter came straight back with "still shows parametrized in Human and Robot Advice". Both
+/// advice buttons — and the HTML export, the comparison report, and every MCP tool — read their
+/// statement text out of <see cref="ResultMapper"/>, so that is the seam these cover.
+///
+/// <para>The plan is the #466 reproduction: seven parameters the engine manufactured under
+/// <c>PARAMETERIZATION FORCED</c>, six of them carrying a runtime value and the seventh only a
+/// compiled one.</para>
+/// </summary>
+public class AnalysisParameterSubstitutionTests
+{
+    private const string ParameterizedPlan = "forced_parameterization_plan.sqlplan";
+    private const string NamedParameterPlan = "local_variable_plan.sqlplan";
+
+    /* Two of the seven. The first is a string that keeps its quotes, the second a numeric IN list
+       whose values arrive from showplan wrapped in parentheses. */
+    private const string SubstitutedPredicate = "[t0].[AuthUserId]='123456'";
+    private const string ParameterizedPredicate = "[t0].[AuthUserId]=@0";
+    private const string SubstitutedInList = "[t].[StatusId] in (5,6,7,8,9)";
+
+    [Fact]
+    public void AdviceForHumans_ShowsTheValuesInsteadOfTheParameterNames()
+    {
+        var text = TextFormatter.Format(Analyze(ParameterizedPlan));
+
+        Assert.Contains(SubstitutedPredicate, text);
+        Assert.Contains(SubstitutedInList, text);
+        Assert.Contains("[t].[FromDateTime]>='2026-05-28 10:28:07.3132561'", text);
+
+        /* Scoped to the predicate rather than a bare "@0" — the Parameters section below the
+           statement lists the names on purpose, and should keep doing so. */
+        Assert.DoesNotContain(ParameterizedPredicate, text);
+    }
+
+    [Fact]
+    public void AdviceForRobots_ShowsTheValuesAndStillCarriesTheParameterizedForm()
+    {
+        var json = JsonSerializer.Serialize(Analyze(ParameterizedPlan), AnalysisJson.Indented);
+
+        using var document = JsonDocument.Parse(json);
+        var statement = document.RootElement.GetProperty("statements")[0];
+        var runnable = statement.GetProperty("statement_text").GetString();
+        var parameterized = statement.GetProperty("parameterized_statement_text").GetString();
+
+        Assert.NotNull(runnable);
+        Assert.NotNull(parameterized);
+
+        Assert.Contains(SubstitutedPredicate, runnable);
+        Assert.DoesNotContain(ParameterizedPredicate, runnable);
+
+        /* Both forms, and they say different things — the parameterized one is what matches the
+           plan cache and Query Store, and throwing it away to fix the advice would have been a
+           trade nobody asked for. */
+        Assert.Contains(ParameterizedPredicate, parameterized);
+        Assert.NotEqual(runnable, parameterized);
+    }
+
+    [Fact]
+    public void HtmlExport_ShowsTheValues()
+    {
+        var analysis = Analyze(ParameterizedPlan);
+
+        var html = HtmlExporter.Export(analysis, TextFormatter.Format(analysis));
+
+        /* The IN list rather than the string predicate: the export HTML-encodes what it writes, and
+           an assertion carrying quotes would be testing HttpUtility rather than this change. */
+        Assert.Contains(SubstitutedInList, html);
+        Assert.DoesNotContain("[t].[StatusId] in (@1,@2,@3,@4,@5)", html);
+    }
+
+    [Fact]
+    public void ComparisonReport_ShowsTheValues()
+    {
+        var analysis = Analyze(ParameterizedPlan);
+
+        var comparison = ComparisonFormatter.Compare(analysis, analysis, "before", "after");
+
+        Assert.Contains(SubstitutedPredicate, comparison);
+        Assert.DoesNotContain(ParameterizedPredicate, comparison);
+    }
+
+    [Fact]
+    public void ComparisonStillPairsTwoRunsOfTheSameQueryWithDifferentParameterValues()
+    {
+        /* The reason this change had to be established before it was made. Substituting gives two
+           executions of one query two different statement texts, so if pairing had keyed on that
+           text, comparing a fast run against a slow one would have stopped matching them and
+           reported two unrelated statements instead of one regression. It pairs on QueryHash, which
+           is why substituting here is safe — and this fails the moment somebody changes that. */
+        var slow = Analyze(ParameterizedPlan);
+        var fast = ResultMapper.Map(
+            ShowPlanParser.Parse(PlanXml(ParameterizedPlan).Replace("123456", "999999", StringComparison.Ordinal)),
+            ParameterizedPlan);
+
+        Assert.NotEqual(slow.Statements[0].StatementText, fast.Statements[0].StatementText);
+        Assert.Equal(slow.Statements[0].QueryHash, fast.Statements[0].QueryHash);
+
+        var comparison = ComparisonFormatter.Compare(slow, fast, "before", "after");
+
+        Assert.Contains("--- Statement 1 ---", comparison);
+        Assert.DoesNotContain("only in Plan", comparison);
+    }
+
+    [Fact]
+    public async Task McpAnalyzePlan_HandsTheModelTheRunnableStatement()
+    {
+        /* The consumer that matters most: a model handed @0 with no values is being handed a
+           question it cannot answer. */
+        var manager = new PlanSessionManager();
+        var sessionId = $"mcp-{Guid.NewGuid():N}";
+        manager.Register(new CorePlanSession
+        {
+            SessionId = sessionId,
+            Label = ParameterizedPlan,
+            Source = "file",
+            Plan = PlanTestHelper.LoadAndAnalyze(ParameterizedPlan)
+        });
+        var operations = new PlanOperations(manager, AnalyzerConfig.Default, enforceQueryAdmission: false);
+
+        var json = await McpPlanTools.AnalyzePlan(
+            manager,
+            operations,
+            sessionId,
+            TestContext.Current.CancellationToken);
+
+        using var document = JsonDocument.Parse(json);
+        var statement = document.RootElement.GetProperty("statements")[0];
+        Assert.Contains(SubstitutedPredicate, statement.GetProperty("statement_text").GetString());
+    }
+
+    [Fact]
+    public void McpReproScript_StillBuildsAParameterizedBody()
+    {
+        /* The one consumer that wants the other form. get_repro_script wraps this body in
+           sp_executesql with a parameter list read out of the same plan; a body with the literal
+           already inlined would declare a parameter it never uses, and would compile the
+           constant-folded plan rather than the parameterized one the script exists to reproduce.
+
+           A named parameter rather than the forced-parameterization plan, because ReproScriptBuilder
+           requires a parameter name a human could have typed and drops @0 … @6 before it gets this
+           far — so that plan never reaches the sp_executesql branch this is about. */
+        var manager = new PlanSessionManager();
+        var sessionId = $"repro-{Guid.NewGuid():N}";
+        manager.Register(new CorePlanSession
+        {
+            SessionId = sessionId,
+            Label = NamedParameterPlan,
+            Source = "file",
+            Plan = PlanTestHelper.LoadAndAnalyze(NamedParameterPlan)
+        });
+
+        var script = McpPlanTools.GetReproScript(manager, sessionId);
+
+        Assert.Contains("sp_executesql", script);
+        Assert.Contains("@date datetime", script);
+        Assert.Contains("CreationDate >= @date", script);
+        Assert.DoesNotContain("CreationDate >= '2013-01-01 00:00:00.000'", script);
+    }
+
+    [Fact]
+    public void AssignmentTargets_AreLeftAloneRatherThanTurnedIntoComparisons()
+    {
+        /* SELECT @job_name = name, @owner_sid = owner_sid FROM msdb.dbo.sysjobs_view WHERE
+           (job_id = @job_id) — both assigned variables carry a compiled value of NULL, and writing
+           it over them gives "SELECT NULL = name", which reads as a comparison. The parameter that
+           is actually read still gets its value. */
+        var statement = Analyze("compile_memory_exceeded_plan.sqlplan").Statements[0];
+
+        Assert.Contains("@job_name = name", statement.StatementText);
+        Assert.Contains("@owner_sid = owner_sid", statement.StatementText);
+        Assert.DoesNotContain("NULL = name", statement.StatementText);
+        Assert.Contains("job_id = '846EFE14-2AEE-4A65-9EE0-213187F82250'", statement.StatementText);
+    }
+
+    [Fact]
+    public void StatementWithNothingToSubstitute_KeepsItsTextAndCarriesNoSecondForm()
+    {
+        /* Nearly every plan. The mapped text has to stay byte-identical here, because the CLI's
+           JSON output is hashed as a contract against a plan of exactly this shape — a change in
+           these bytes is something to decide on, not to discover. */
+        var plan = PlanTestHelper.LoadAndAnalyze("row_goal_plan.sqlplan");
+
+        var statement = ResultMapper.Map(plan, "row_goal_plan.sqlplan").Statements[0];
+
+        Assert.Equal(PlanTestHelper.FirstStatement(plan).StatementText, statement.StatementText);
+        Assert.Null(statement.ParameterizedStatementText);
+    }
+
+    private static AnalysisResult Analyze(string planFile) =>
+        ResultMapper.Map(PlanTestHelper.LoadAndAnalyze(planFile), planFile);
+
+    private static string PlanXml(string planFile) =>
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Plans", planFile));
+}

--- a/tests/PlanViewer.Core.Tests/ComparePlansAvailabilityTests.cs
+++ b/tests/PlanViewer.Core.Tests/ComparePlansAvailabilityTests.cs
@@ -1,9 +1,11 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using PlanViewer.App;
 using PlanViewer.App.Controls;
+using PlanViewer.Core.Models;
 
 namespace PlanViewer.Core.Tests;
 
@@ -14,13 +16,128 @@ namespace PlanViewer.Core.Tests;
 /// able to see across sessions. The reporter had to save a plan and reopen it to get at a comparison
 /// the app could already do.
 ///
-/// The scenario is built from plan FILES rather than executed queries deliberately: getting a plan
-/// into a session needs a live SQL Server, and the defect does not require one. What it requires is
-/// plans existing somewhere OTHER than the session whose button is being judged, which two file tabs
-/// provide exactly.
+/// <para><b>The first version of this file is why the issue was reopened.</b> It built its scenario
+/// out of plan FILES on purpose, reasoning that getting a plan into a session needed a live SQL
+/// Server and that the defect did not require one. The second half of that was true and the first
+/// half was the bug: a plan file opens a window-level tab, which is the one path that was already
+/// recomputing. Every test passed against a build in which running two queries — the thing being
+/// reported — still left both buttons dead.</para>
+///
+/// <para>So the tests below drive the paths a plan actually arrives by. What still needs a server is
+/// the round trip that produces plan XML, and only that: the landing step each path performs with
+/// the XML in hand is reachable directly, and is where the whole defect lived.</para>
 /// </summary>
 public class ComparePlansAvailabilityTests
 {
+    /// <summary>
+    /// The report, verbatim: a query run in one tab, another query run in a second tab, Compare
+    /// disabled in both. Driven through the same <c>ShowCapturedPlan</c> both execution paths use
+    /// once the server has answered.
+    /// </summary>
+    [Fact]
+    public void RunningAQueryInEachOfTwoSessionsOffersCompareInBoth()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new MainWindow();
+
+            var first = NewSession(window);
+            var second = NewSession(window);
+
+            RunQuery(first, "row_goal_plan.sqlplan", "Plan 1");
+
+            Assert.All(new[] { first, second }, session => Assert.False(
+                CompareButton(session).IsEnabled,
+                "one plan cannot be compared against anything"));
+
+            RunQuery(second, "key_lookup_plan.sqlplan", "Plan 1");
+
+            Assert.All(new[] { first, second }, session => Assert.True(
+                CompareButton(session).IsEnabled,
+                "a query has now run in each session, which is the whole of the report"));
+        });
+    }
+
+    /// <summary>
+    /// Two queries run in the SAME session, which is the case the pre-#449 arithmetic did handle.
+    /// Here because that arithmetic no longer exists — the count comes from the window now, and a
+    /// window-wide count has its own way of getting a single session wrong.
+    /// </summary>
+    [Fact]
+    public void RunningTwoQueriesInOneSessionOffersCompareThere()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new MainWindow();
+            var session = NewSession(window);
+
+            RunQuery(session, "row_goal_plan.sqlplan", "Plan 1");
+            RunQuery(session, "key_lookup_plan.sqlplan", "Plan 2");
+
+            Assert.True(CompareButton(session).IsEnabled);
+        });
+    }
+
+    /// <summary>
+    /// The Query Store path, which opens its plans by adding tabs rather than filling one in, and a
+    /// plan tab being closed again. Both used to say so with a call written out at the site; they
+    /// now go through the same watcher as everything else, so they need pinning where they did not
+    /// before.
+    /// </summary>
+    [Fact]
+    public void QueryStorePlansOfferCompare_AndClosingOneTakesItAway()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new MainWindow();
+            var session = NewSession(window);
+
+            session.OnQueryStorePlansSelected(null, new List<QueryStorePlan>
+            {
+                QueryStorePlanFrom(11, "row_goal_plan.sqlplan"),
+                QueryStorePlanFrom(22, "key_lookup_plan.sqlplan")
+            });
+
+            Assert.True(CompareButton(session).IsEnabled,
+                "two Query Store plans are open in this session");
+
+            ClosePlanTab(session);
+
+            Assert.False(CompareButton(session).IsEnabled,
+                "one of the two was closed, so there is nothing left to compare against");
+        });
+    }
+
+    /// <summary>
+    /// Get Actual Plan on a window-level plan tab, which produces its plan the same way an executed
+    /// query does — into a tab that has been showing a spinner since the query was sent, and so is
+    /// not an addition to anything.
+    /// </summary>
+    [Fact]
+    public void AnActualPlanArrivingInAnExistingWindowTabIsNoticed()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new MainWindow();
+
+            window.LoadPlanFile(PlanPath("row_goal_plan.sqlplan"));
+            var session = NewSession(window);
+
+            Assert.False(CompareButton(session).IsEnabled);
+
+            var tabs = window.FindControl<TabControl>("MainTabControl")!;
+            var spinnerTab = new TabItem { Header = "Actual Plan", Content = new Grid() };
+            tabs.Items.Add(spinnerTab);
+
+            var viewer = new PlanViewerControl();
+            Assert.True(viewer.LoadPlan(PlanXml("key_lookup_plan.sqlplan"), "Actual Plan"));
+            spinnerTab.Content = window.CreatePlanTabContent(viewer);
+
+            Assert.True(CompareButton(session).IsEnabled,
+                "the window gained a second plan without gaining a tab");
+        });
+    }
+
     [Fact]
     public void ASessionOffersCompareWhenThePlansAreElsewhereInTheWindow()
     {
@@ -86,14 +203,71 @@ public class ComparePlansAvailabilityTests
         });
     }
 
+    /// <summary>
+    /// Runs a query in a session as far as a test without a SQL Server can.
+    ///
+    /// <para>The tab holding the progress spinner is opened first, exactly as the execution paths
+    /// open it, and the session is then handed plan XML from a fixture in place of what the server
+    /// would have returned. Everything after that — building the viewer, loading the plan into it,
+    /// and assigning it over the spinner — is the session's own code, and the assignment is the
+    /// statement #447 was about.</para>
+    /// </summary>
+    private static void RunQuery(QuerySessionControl session, string planFileName, string tabLabel)
+    {
+        var subTabs = SubTabs(session);
+        var spinnerTab = new TabItem { Header = tabLabel, Content = new Grid() };
+        subTabs.Items.Add(spinnerTab);
+        subTabs.SelectedItem = spinnerTab;
+
+        session.ShowCapturedPlan(spinnerTab, PlanXml(planFileName), tabLabel, "select 1;");
+    }
+
+    /// <summary>
+    /// Closes the session's first plan tab through its own close button, rather than reaching into
+    /// the collection — the removal paths are production code too, and they lost their hand-written
+    /// refresh along with the paths that add.
+    /// </summary>
+    private static void ClosePlanTab(QuerySessionControl session)
+    {
+        var tab = SubTabs(session).Items
+            .OfType<TabItem>()
+            .First(t => t.Content is PlanViewerControl);
+
+        var closeButton = ((StackPanel)tab.Header!).Children.OfType<Button>().Last();
+        closeButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+    }
+
+    private static QueryStorePlan QueryStorePlanFrom(long id, string planFileName) =>
+        new()
+        {
+            QueryId = id,
+            PlanId = id,
+            QueryText = "select 1;",
+            PlanXml = PlanXml(planFileName)
+        };
+
+    private static QuerySessionControl NewSession(MainWindow window)
+    {
+        window.NewQuery_Click(window, new RoutedEventArgs());
+        return Sessions(window).Last();
+    }
+
     private static string PlanPath(string name) =>
         Path.Combine(System.AppContext.BaseDirectory, "Plans", name);
 
-    private static System.Collections.Generic.IEnumerable<QuerySessionControl> Sessions(MainWindow window) =>
+    /// <summary>SSMS writes plan files as UTF-16 and declares it; the parser wants the declaration
+    /// to match what it is handed. Same substitution the other plan-loading tests make.</summary>
+    private static string PlanXml(string name) =>
+        File.ReadAllText(PlanPath(name)).Replace("encoding=\"utf-16\"", "encoding=\"utf-8\"");
+
+    private static IEnumerable<QuerySessionControl> Sessions(MainWindow window) =>
         window.FindControl<TabControl>("MainTabControl")!.Items
             .OfType<TabItem>()
             .Select(tab => tab.Content)
             .OfType<QuerySessionControl>();
+
+    private static TabControl SubTabs(QuerySessionControl session) =>
+        session.FindControl<TabControl>("SubTabControl")!;
 
     private static Button CompareButton(QuerySessionControl session) =>
         session.FindControl<Button>("ComparePlansButton")!;

--- a/tests/PlanViewer.Core.Tests/ComparePlansAvailabilityTests.cs
+++ b/tests/PlanViewer.Core.Tests/ComparePlansAvailabilityTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Avalonia.Threading;
 using PlanViewer.App;
 using PlanViewer.App.Controls;
 using PlanViewer.Core.Models;
@@ -202,6 +203,78 @@ public class ComparePlansAvailabilityTests
                 "the session existed before the second plan did, and must still notice it"));
         });
     }
+
+    /// <summary>
+    /// A session that leaves for its own window leaves the window-wide count behind: detached,
+    /// it can only ever compare its own plans, and the sub-tab watcher that keeps the button
+    /// honest fires on sub-tab changes — of which a detach makes none. The button used to keep
+    /// its pre-detach answer until the next plan landed, offering a comparison whose second
+    /// plan was in a window it could no longer reach.
+    /// </summary>
+    [Fact]
+    public void DetachingASessionRecomputesCompareFromItsOwnPlans()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new MainWindow();
+
+            window.LoadPlanFile(PlanPath("row_goal_plan.sqlplan"));
+            var session = NewSession(window);
+            RunQuery(session, "key_lookup_plan.sqlplan", "Plan 1");
+
+            Assert.True(CompareButton(session).IsEnabled,
+                "docked, the window's plan and the session's own make a pair");
+
+            var tab = window.FindControl<TabControl>("MainTabControl")!.Items
+                .OfType<TabItem>().First(t => t.Content == session);
+            var detached = window.DetachTabToWindow(tab)!;
+
+            Assert.False(CompareButton(session).IsEnabled,
+                "detached, the session holds one plan and the window's other one is out of reach");
+
+            /* And coming back is noticed without any hand-written call: re-docking adds a tab,
+               which is exactly what the window's collection watcher listens for. */
+            RedockButton(detached).RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(CompareButton(session).IsEnabled, "docked again, the pair is back");
+        });
+    }
+
+    /// <summary>
+    /// The other direction of the same recompute: a session that owns a pair keeps its button
+    /// through a detach, because the honest own-plans answer is still yes.
+    /// </summary>
+    [Fact]
+    public void ADetachedSessionWithTwoOwnPlansKeepsCompare()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new MainWindow();
+            var session = NewSession(window);
+            RunQuery(session, "row_goal_plan.sqlplan", "Plan 1");
+            RunQuery(session, "key_lookup_plan.sqlplan", "Plan 2");
+
+            var tab = window.FindControl<TabControl>("MainTabControl")!.Items
+                .OfType<TabItem>().First(t => t.Content == session);
+            var detached = window.DetachTabToWindow(tab)!;
+            try
+            {
+                Assert.True(CompareButton(session).IsEnabled,
+                    "both plans travelled with the session, so there is still a pair to offer");
+            }
+            finally
+            {
+                // Nothing dirty, so the close takes the silent first-pass path.
+                detached.Close();
+                Dispatcher.UIThread.RunJobs();
+            }
+        });
+    }
+
+    private static Button RedockButton(Window detached) =>
+        ((DockPanel)detached.Content!).Children.OfType<StackPanel>().Single()
+            .Children.OfType<Button>().Single();
 
     /// <summary>
     /// Runs a query in a session as far as a test without a SQL Server can.

--- a/tests/PlanViewer.Core.Tests/CursorSubPlanTests.cs
+++ b/tests/PlanViewer.Core.Tests/CursorSubPlanTests.cs
@@ -1,0 +1,151 @@
+using System.Linq;
+using PlanViewer.Core.Output;
+using PlanViewer.Core.Services;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #491: #456 taught the parser to descend into StoredProc/UDF sub-plans, but that descent lives
+/// in ParseStatement — and a StmtCursor's operation statements never go through ParseStatement.
+/// They are built in ParseStatementAndChildren's cursor branch, straight from
+/// CursorPlan &gt; Operation &gt; QueryPlan, so a function called by the cursor's query carried
+/// its whole body in the XML (the Operation element holds the UDF sub-plan beside its QueryPlan)
+/// and the parser dropped every statement of it. Same failure mode as #455: the output stayed
+/// well-formed and plausible — the cursor's own query analyzed, the function body silently
+/// contributed nothing.
+///
+/// <para>The plan XML here is generated rather than captured, on the depth-limit tests'
+/// precedent: a cursor wrapping a UDF sub-plan is three nested element shapes, and a minimal
+/// document states that more clearly than a 40KB fixture could. The element shapes mirror the
+/// real showplan schema — StmtCursor &gt; CursorPlan &gt; Operation &gt; QueryPlan, with the UDF
+/// element and its Statements sitting beside the QueryPlan under Operation — matching the
+/// namespace and attributes the parser reads from committed fixtures.</para>
+/// </summary>
+public sealed class CursorSubPlanTests
+{
+    /* One cursor operation whose query calls dbo.CursorFn; the function body carries two
+       statements — one bare (RETURN, no QueryPlan of its own, like the EXEC in #455) and one
+       with a plan — so the descent is proven for both statement shapes. */
+    private const string CursorOverUdfPlan =
+        "<ShowPlanXML xmlns=\"http://schemas.microsoft.com/sqlserver/2004/07/showplan\" Version=\"1.564\" Build=\"16.0.4135.4\">" +
+        "<BatchSequence><Batch><Statements>" +
+        "<StmtCursor StatementText=\"DECLARE cur CURSOR FAST_FORWARD FOR SELECT dbo.CursorFn(o.Id) FROM dbo.Orders AS o\" StatementId=\"1\" StatementCompId=\"1\">" +
+        "<CursorPlan CursorName=\"cur\" CursorActualType=\"FastForward\" CursorRequestedType=\"FastForward\" CursorConcurrency=\"Read Only\" ForwardOnly=\"true\">" +
+        "<Operation OperationType=\"FetchQuery\">" +
+        "<QueryPlan>" +
+        "<RelOp NodeId=\"0\" PhysicalOp=\"Clustered Index Scan\" LogicalOp=\"Clustered Index Scan\" EstimateRows=\"10\" EstimatedTotalSubtreeCost=\"0.005\" />" +
+        "</QueryPlan>" +
+        "<UDF ProcName=\"dbo.CursorFn\" IsNativelyCompiled=\"false\">" +
+        "<Statements>" +
+        "<StmtSimple StatementText=\"RETURN @Id * 2\" StatementId=\"2\" StatementCompId=\"2\" />" +
+        "<StmtSimple StatementText=\"SELECT @Total = COUNT(*) FROM dbo.Numbers AS n\" StatementId=\"3\" StatementCompId=\"3\">" +
+        "<QueryPlan>" +
+        "<RelOp NodeId=\"0\" PhysicalOp=\"Clustered Index Scan\" LogicalOp=\"Clustered Index Scan\" EstimateRows=\"100\" EstimatedTotalSubtreeCost=\"0.02\" />" +
+        "</QueryPlan>" +
+        "</StmtSimple>" +
+        "</Statements>" +
+        "</UDF>" +
+        "</Operation>" +
+        "</CursorPlan>" +
+        "</StmtCursor>" +
+        "</Statements></Batch></BatchSequence></ShowPlanXML>";
+
+    /// <summary>
+    /// The attach point, pinned the way #455 pinned the EXEC's: the cursor operation's statement
+    /// is the one that must carry the function body, because it is the statement the operation's
+    /// query belongs to — and it is built by a code path ParseStatement's descent never touches.
+    /// </summary>
+    [Fact]
+    public void ACursorOperationStatementCarriesItsFunctionBody()
+    {
+        var plan = ShowPlanParser.Parse(CursorOverUdfPlan);
+
+        Assert.Null(plan.ParseError);
+        var operation = Assert.Single(Assert.Single(plan.Batches).Statements);
+
+        // Proves this went down the cursor branch, not some fallback path.
+        Assert.Equal("cur", operation.CursorName);
+
+        var udf = Assert.Single(operation.UdfPlans);
+        Assert.Equal("dbo.CursorFn", udf.ProcName);
+        Assert.Equal(2, udf.Statements.Count);
+        Assert.Equal("RETURN @Id * 2", udf.Statements[0].StatementText);
+        Assert.StartsWith("SELECT @Total", udf.Statements[1].StatementText);
+    }
+
+    /// <summary>
+    /// The shared traversal surfaces the body — which is the whole fix. Every consumer (#486)
+    /// reads PlanStatements.EnumerateAll rather than walking batch.Statements itself, so once the
+    /// bodies are here, the analyzer, the scorer, the mapper, and the statements grid all see
+    /// them without any change of their own. Order matters like it did for #455: the operation
+    /// comes first, its body follows in source order.
+    /// </summary>
+    [Fact]
+    public void EnumerateAllSurfacesCursorFunctionBodyStatements()
+    {
+        var plan = ShowPlanParser.Parse(CursorOverUdfPlan);
+
+        var all = PlanStatements.EnumerateAll(plan).ToList();
+        var operation = Assert.Single(plan.Batches.SelectMany(b => b.Statements));
+
+        Assert.Equal(3, all.Count);
+        Assert.Same(operation, all[0]);
+        Assert.Equal("RETURN @Id * 2", all[1].StatementText);
+        Assert.StartsWith("SELECT @Total", all[2].StatementText);
+
+        /* The context-carrying walk names the module, so a grid row for a body statement says
+           where it came from instead of showing a bare SELECT beside the cursor's. */
+        var entries = PlanStatements.EnumerateAllWithContainer(plan).ToList();
+        Assert.Null(entries[0].ContainerPath);
+        Assert.All(entries.Skip(1), e => Assert.Equal("dbo.CursorFn", e.ContainerPath));
+    }
+
+    /// <summary>
+    /// Downstream of the traversal: the same document through analyze + score + map counts all
+    /// three statements. TotalStatements is the number a report reader trusts first, and before
+    /// this fix a cursor-over-UDF plan reported 1 — the #455 signature all over again, one
+    /// container type later.
+    /// </summary>
+    [Fact]
+    public void CursorFunctionBodyStatementsAreAnalyzedAndCounted()
+    {
+        var plan = ShowPlanParser.Parse(CursorOverUdfPlan);
+        PlanAnalyzer.Analyze(plan);
+        BenefitScorer.Score(plan);
+
+        var result = ResultMapper.Map(plan, "cursor_over_udf");
+
+        Assert.Equal(3, result.Summary.TotalStatements);
+    }
+
+    /// <summary>
+    /// The StoredProc half of the same read. The published XSD only puts UDF under a cursor
+    /// Operation, but the parser reads UDF and StoredProc as a pair everywhere else it descends
+    /// ("XSD gap" reads — plans have carried elements the schema omits before), so the cursor
+    /// branch reads both on purpose. Pinned so the symmetric half cannot rot into untested code.
+    /// </summary>
+    [Fact]
+    public void ACursorOperationStoredProcSubPlanIsReadToo()
+    {
+        const string xml =
+            "<ShowPlanXML xmlns=\"http://schemas.microsoft.com/sqlserver/2004/07/showplan\">" +
+            "<BatchSequence><Batch><Statements>" +
+            "<StmtCursor StatementText=\"DECLARE cur CURSOR FOR SELECT 1\">" +
+            "<CursorPlan CursorName=\"cur\"><Operation OperationType=\"FetchQuery\">" +
+            "<QueryPlan><RelOp NodeId=\"0\" /></QueryPlan>" +
+            "<StoredProc ProcName=\"dbo.CursorProc\"><Statements>" +
+            "<StmtSimple StatementText=\"SELECT 2\" />" +
+            "</Statements></StoredProc>" +
+            "</Operation></CursorPlan></StmtCursor>" +
+            "</Statements></Batch></BatchSequence></ShowPlanXML>";
+
+        var plan = ShowPlanParser.Parse(xml);
+
+        Assert.Null(plan.ParseError);
+        var operation = Assert.Single(Assert.Single(plan.Batches).Statements);
+        Assert.NotNull(operation.StoredProcPlan);
+        Assert.Equal("dbo.CursorProc", operation.StoredProcPlan!.ProcName);
+        Assert.Equal("SELECT 2", Assert.Single(operation.StoredProcPlan.Statements).StatementText);
+        Assert.Equal(2, PlanStatements.EnumerateAll(plan).Count());
+    }
+}

--- a/tests/PlanViewer.Core.Tests/DetachedUnsavedChangesTests.cs
+++ b/tests/PlanViewer.Core.Tests/DetachedUnsavedChangesTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
@@ -216,6 +218,78 @@ public class DetachedUnsavedChangesTests
                 File.Delete(path);
             }
         });
+    }
+
+    /// <summary>
+    /// CreateTab subscribes a glyph refresher onto the session, and the session outlives its
+    /// tab on the detach path — so the subscription used to outlive it too, a closure over the
+    /// dead tab's close button that pinned the whole discarded TabItem to the session, once
+    /// per detach/redock cycle. The counts below read the event's invocation list because the
+    /// leak IS the subscription: nothing observable on screen changes until the memory is
+    /// gone.
+    /// </summary>
+    [Fact]
+    public void DetachTakesTheGlyphSubscriptionOffAndRedockRewiresIt()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            Window? detached = null;
+            QuerySessionControl? session = null;
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                var tab = LastQueryTab(window);
+                session = (QuerySessionControl)tab.Content!;
+
+                Assert.Equal(1, DirtyStateSubscriberCount(session));
+
+                detached = window.DetachTabToWindow(tab)!;
+
+                Assert.Equal(0, DirtyStateSubscriberCount(session));
+
+                RedockButton(detached).RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                Dispatcher.UIThread.RunJobs();
+                detached = null; // re-dock closed it
+
+                /* One again — not two, which is what the cycle used to leave behind. */
+                Assert.Equal(1, DirtyStateSubscriberCount(session));
+
+                /* And the fresh subscription works: the redocked tab's close button still
+                   turns into the modified dot when the session goes dirty, and back. */
+                var redockedTab = LastQueryTab(window);
+                var closeBtn = ((StackPanel)redockedTab.Header!).Children.OfType<Button>().Last();
+
+                session.QueryEditor.Text = "SELECT 2; -- edited";
+                Dispatcher.UIThread.RunJobs();
+                Assert.Equal("●", (string?)closeBtn.Content); // the modified dot
+
+                session.MarkClean();
+                Dispatcher.UIThread.RunJobs();
+                Assert.Equal("✕", (string?)closeBtn.Content); // back to the close cross
+            }
+            finally
+            {
+                PutAway(detached, session);
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The one subscription CreateTab makes on the session itself, counted off the compiler's
+    /// backing delegate. Reflection is the honest tool here: the event is the leak's surface,
+    /// and exposing a count on the product type just to avoid it would be API for a test.
+    /// </summary>
+    private static int DirtyStateSubscriberCount(QuerySessionControl session)
+    {
+        var backingField = typeof(QuerySessionControl).GetField(
+            nameof(QuerySessionControl.DirtyStateChanged),
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        return ((Delegate?)backingField.GetValue(session))?.GetInvocationList().Length ?? 0;
     }
 
     [Fact]

--- a/tests/PlanViewer.Core.Tests/HeadlessUi.cs
+++ b/tests/PlanViewer.Core.Tests/HeadlessUi.cs
@@ -1,10 +1,14 @@
 using System;
+using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Threading;
+using PlanViewer.App;
+using PlanViewer.App.Services;
 
 namespace PlanViewer.Core.Tests;
 
@@ -38,6 +42,44 @@ internal static class HeadlessUi
     private static readonly Lazy<HeadlessUnitTestSession> Session =
         new(() => HeadlessUnitTestSession.StartNew(typeof(PlanViewer.App.App)),
             System.Threading.LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <summary>
+    /// Where this run's redirected settings live, for the tests that pin the redirection.
+    /// </summary>
+    internal static string SettingsRedirectRoot { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Flips the process into test-host mode before anything else in this assembly runs.
+    ///
+    /// <para><b>Why booting the real App needs this at all (#451).</b> The session above
+    /// constructs the actual <see cref="PlanViewer.App.App"/>, so its real startup side
+    /// effects ran inside the test host on every local <c>dotnet test</c>: the .sqlplan
+    /// registry association was rewritten to point at the test runner, tests restored and
+    /// then destroyed the developer's saved open-tab list, and fixture paths evicted real
+    /// Recent Plans entries — all confirmed live. <see cref="AppRuntimeMode.IsTestHost"/>
+    /// is the one seam the app consults to keep the process-external effects (file
+    /// association, pipe server, update check, MCP server) from launching here.</para>
+    ///
+    /// <para><b>Why a module initializer rather than harness setup.</b> It has to run
+    /// before the first App boot AND before any test touches
+    /// <see cref="AppSettingsService"/>, including ones that never go through this class.
+    /// A module initializer is the only spot guaranteed to precede both.</para>
+    ///
+    /// <para><b>Why the settings directory is per RUN, not per test.</b> Tests like
+    /// RestoreQueryTabsTests deliberately exercise save/load continuity across windows
+    /// within a run; tests that need clean state already reset it themselves. A second
+    /// <c>dotnet test</c> gets a fresh directory, which is what keeps runs from leaking
+    /// into each other. The abandoned directories are a few hundred bytes each and left
+    /// to OS temp cleanup — sweeping siblings here could race a concurrent run.</para>
+    /// </summary>
+    [ModuleInitializer]
+    internal static void EnterTestHostMode()
+    {
+        AppRuntimeMode.IsTestHost = true;
+
+        SettingsRedirectRoot = Directory.CreateTempSubdirectory("PlanViewer.Core.Tests-").FullName;
+        AppSettingsService.RedirectStorageForTestHost(SettingsRedirectRoot);
+    }
 
     /// <summary>
     /// Runs <paramref name="body"/> on the Avalonia UI thread and rethrows anything it threw, so an

--- a/tests/PlanViewer.Core.Tests/OpenInEditorOverwriteTests.cs
+++ b/tests/PlanViewer.Core.Tests/OpenInEditorOverwriteTests.cs
@@ -1,0 +1,180 @@
+using System.IO;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using PlanViewer.App;
+using PlanViewer.App.Controls;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// "Open in Query Editor" pasted a plan's statement over whatever was in the editor, no
+/// questions asked — the one wholesale overwrite in the app that skipped #462's dirty
+/// tracking entirely, so a typed-but-unsaved query was simply gone.
+///
+/// <para>Same testing shape as UnsavedQueryChangesTests: whether to ask is a pure value
+/// (<see cref="QuerySessionControl.ReplaceNeedsConfirmation"/>, split out to be testable the
+/// way CollectOpenTabPaths was), and the handler is driven directly with the prompt answered
+/// by closing it — which is Cancel — or by raising a click on its Replace button.</para>
+/// </summary>
+public class OpenInEditorOverwriteTests
+{
+    [Fact]
+    public void OnlyADirtyNonEmptyEditorNeedsAsking()
+    {
+        Assert.False(QuerySessionControl.ReplaceNeedsConfirmation(isDirty: false, currentText: ""));
+        Assert.False(QuerySessionControl.ReplaceNeedsConfirmation(isDirty: false, currentText: "SELECT 1;"));
+
+        /* Dirty-but-empty is a buffer the user deleted everything out of. Replacing nothing
+           loses nothing, so it stays as frictionless as a clean editor. */
+        Assert.False(QuerySessionControl.ReplaceNeedsConfirmation(isDirty: true, currentText: ""));
+        Assert.False(QuerySessionControl.ReplaceNeedsConfirmation(isDirty: true, currentText: null));
+
+        Assert.True(QuerySessionControl.ReplaceNeedsConfirmation(isDirty: true, currentText: "SELECT 1;"));
+    }
+
+    [Fact]
+    public void ACleanEditorIsReplacedWithoutAPrompt()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+                var session = LastSession(window);
+
+                /* The window is deliberately never shown: a prompt raised here would need a
+                   visible owner and blow up, so replacement going through quietly is itself
+                   the no-prompt assertion. This is the everyday path and it must not grow a
+                   detour — a clean editor is already on disk. */
+                session.OnOpenInEditorRequested(null, "SELECT 99 AS from_plan;");
+
+                Assert.Equal("SELECT 99 AS from_plan;", session.QueryEditor.Text);
+                Assert.Equal(0, session.SubTabControl.SelectedIndex);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    [Fact]
+    public void ADismissedPromptLeavesTheDirtyEditorUntouched()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            MainWindow? window = null;
+            QuerySessionControl? session = null;
+            try
+            {
+                window = new MainWindow();
+                window.Show(); // the prompt's ShowDialog needs a visible owner
+                window.LoadSqlFile(path);
+                window.UpdateLayout(); // attach the tab's content so the session can find its window
+
+                session = LastSession(window);
+                session.QueryEditor.Text = "SELECT 2; -- typed, not saved";
+
+                session.OnOpenInEditorRequested(null, "SELECT 99 AS from_plan;");
+                Dispatcher.UIThread.RunJobs();
+
+                /* The question is up and nothing has been replaced while it is. */
+                var prompt = Assert.Single(window.OwnedWindows);
+                Assert.Equal("SELECT 2; -- typed, not saved", session.QueryEditor.Text);
+
+                /* Dismissing the prompt is a no, and a no leaves the work exactly where it
+                   was — this line is the whole bug, stated as an assertion. */
+                prompt.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.Equal("SELECT 2; -- typed, not saved", session.QueryEditor.Text);
+                Assert.True(session.IsDirty, "the unsaved work is still unsaved, not gone");
+            }
+            finally
+            {
+                PutAway(window, session);
+                File.Delete(path);
+            }
+        });
+    }
+
+    [Fact]
+    public void AnsweringReplaceGoesThroughWithIt()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            MainWindow? window = null;
+            QuerySessionControl? session = null;
+            try
+            {
+                window = new MainWindow();
+                window.Show();
+                window.LoadSqlFile(path);
+                window.UpdateLayout();
+
+                session = LastSession(window);
+                session.QueryEditor.Text = "SELECT 2; -- typed, not saved";
+
+                session.OnOpenInEditorRequested(null, "SELECT 99 AS from_plan;");
+                Dispatcher.UIThread.RunJobs();
+
+                var prompt = Assert.Single(window.OwnedWindows);
+                PromptButton(prompt, "Replace").RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                Dispatcher.UIThread.RunJobs();
+
+                /* An explicit yes is still a yes: the statement lands and the editor sub-tab
+                   comes to the front, exactly as the unguarded path always did. */
+                Assert.Equal("SELECT 99 AS from_plan;", session.QueryEditor.Text);
+                Assert.Equal(0, session.SubTabControl.SelectedIndex);
+            }
+            finally
+            {
+                PutAway(window, session);
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Digs the named button out of a ConfirmationDialog: content StackPanel, then the button
+    /// row, then the caption. Same shape as DetachedUnsavedChangesTests.RedockButton.
+    /// </summary>
+    private static Button PromptButton(Window prompt, string caption) =>
+        ((StackPanel)prompt.Content!).Children.OfType<StackPanel>().Single()
+            .Children.OfType<Button>().Single(b => (string?)b.Content == caption);
+
+    /// <summary>
+    /// Same job as DetachedUnsavedChangesTests.PutAway: prompts closed, session settled,
+    /// window shut — from a finally, because the run where it matters is the run where an
+    /// assertion above it failed (#474).
+    /// </summary>
+    private static void PutAway(MainWindow? window, QuerySessionControl? session)
+    {
+        if (window == null)
+            return;
+
+        foreach (var prompt in window.OwnedWindows.ToList())
+            prompt.Close();
+
+        session?.MarkClean();
+        window.Close();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static QuerySessionControl LastSession(MainWindow window) =>
+        window.MainTabControl.Items.OfType<TabItem>()
+            .Select(t => t.Content).OfType<QuerySessionControl>().Last();
+
+    private static string TempSql(string text)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+        File.WriteAllText(path, text);
+        return path;
+    }
+}

--- a/tests/PlanViewer.Core.Tests/OpenInEditorOverwriteTests.cs
+++ b/tests/PlanViewer.Core.Tests/OpenInEditorOverwriteTests.cs
@@ -15,7 +15,7 @@ namespace PlanViewer.Core.Tests;
 ///
 /// <para>Same testing shape as UnsavedQueryChangesTests: whether to ask is a pure value
 /// (<see cref="QuerySessionControl.ReplaceNeedsConfirmation"/>, split out to be testable the
-/// way CollectOpenTabPaths was), and the handler is driven directly with the prompt answered
+/// way CollectOpenTabEntries was), and the handler is driven directly with the prompt answered
 /// by closing it — which is Cancel — or by raising a click on its Replace button.</para>
 /// </summary>
 public class OpenInEditorOverwriteTests

--- a/tests/PlanViewer.Core.Tests/OpenSaveQueryTests.cs
+++ b/tests/PlanViewer.Core.Tests/OpenSaveQueryTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using System.Text;
 using Avalonia.Controls;
 using PlanViewer.App;
 using PlanViewer.App.Controls;
@@ -204,12 +205,143 @@ public class OpenSaveQueryTests
         });
     }
 
+    /// <summary>
+    /// The cold-start argv route, exactly as the constructor takes it. This was the one path
+    /// still hard-wired to LoadPlanFile — the pipe from a second instance, drag-and-drop, and
+    /// session restore all routed by extension — so "PerformanceStudio.exe query.sql" (a shell
+    /// open, a double-clicked association) greeted the user with "The XML is not valid" where
+    /// their query should have been.
+    /// </summary>
+    [Fact]
+    public void ACommandLineSqlFileLandsInAQuerySessionNotThePlanLoader()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1 AS from_argv;");
+            try
+            {
+                var window = new MainWindow();
+                var queryTabsBefore = QueryTabs(window).Count();
+
+                window.OpenFromStartupArgs(new[] { "PerformanceStudio.exe", path });
+
+                Assert.Equal(queryTabsBefore + 1, QueryTabs(window).Count());
+
+                var session = (QuerySessionControl)QueryTabs(window).Last().Content!;
+                Assert.Equal("SELECT 1 AS from_argv;", session.QueryEditor.Text);
+                Assert.Equal(path, session.SourceFilePath);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The route the constructor was hard-wired for still works through the extension router:
+    /// a plan on the command line is still a plan tab.
+    /// </summary>
+    [Fact]
+    public void ACommandLinePlanFileStillOpensAsAPlan()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var planPath = Path.Combine(System.AppContext.BaseDirectory, "Plans", "row_goal_plan.sqlplan");
+
+            var window = new MainWindow();
+            var planTabsBefore = PlanTabs(window).Count();
+
+            window.OpenFromStartupArgs(new[] { "PerformanceStudio.exe", planPath });
+
+            Assert.Equal(planTabsBefore + 1, PlanTabs(window).Count());
+        });
+    }
+
+    /// <summary>
+    /// SSMS writes .sql files as UTF-16 LE with a BOM. Opening one always read correctly —
+    /// File.ReadAllText honors the mark — but SaveQueryToPath wrote UTF-8 without one, so the
+    /// first save-in-place silently transcoded the user's file: every byte changed, the mark
+    /// gone, nothing asked. The encoding captured at open now rides the session to the save.
+    /// </summary>
+    [Fact]
+    public void AUtf16FileIsStillUtf16AfterASaveInPlace()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+            File.WriteAllText(path, "SELECT 1;", Encoding.Unicode);
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                var tab = QueryTabs(window).Last();
+                var session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 2 AS edited;";
+
+                Assert.True(window.SaveQueryToPath(tab, session, path));
+
+                var bytes = File.ReadAllBytes(path);
+                Assert.Equal(new byte[] { 0xFF, 0xFE }, bytes.Take(2).ToArray());
+                Assert.Equal("SELECT 2 AS edited;", File.ReadAllText(path));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The preservation must not cut the other way: a BOM-less file stays BOM-less, and a
+    /// scratch query saves as the UTF-8-without-BOM every save always wrote. Stamping marks
+    /// onto files that never had one would be the same silent-alteration bug in reverse.
+    /// </summary>
+    [Fact]
+    public void BomlessFilesAndScratchQueriesStillSaveWithoutABom()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var bomless = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+            File.WriteAllText(bomless, "SELECT 1;", new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            var scratch = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+            try
+            {
+                var window = new MainWindow();
+
+                window.LoadSqlFile(bomless);
+                var tab = QueryTabs(window).Last();
+                var session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 2 AS edited;";
+                Assert.True(window.SaveQueryToPath(tab, session, bomless));
+                Assert.NotEqual(0xEF, File.ReadAllBytes(bomless)[0]);
+
+                window.NewQuery_Click(window, new Avalonia.Interactivity.RoutedEventArgs());
+                var scratchTab = QueryTabs(window).Last();
+                var scratchSession = (QuerySessionControl)scratchTab.Content!;
+                scratchSession.QueryEditor.Text = "SELECT 3;";
+                Assert.True(window.SaveQueryToPath(scratchTab, scratchSession, scratch));
+                Assert.NotEqual(0xEF, File.ReadAllBytes(scratch)[0]);
+            }
+            finally
+            {
+                File.Delete(bomless);
+                if (File.Exists(scratch))
+                    File.Delete(scratch);
+            }
+        });
+    }
+
     private static string TempSql(string text)
     {
         var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
         File.WriteAllText(path, text);
         return path;
     }
+
+    private static System.Collections.Generic.IEnumerable<TabItem> PlanTabs(MainWindow window) =>
+        window.MainTabControl.Items.OfType<TabItem>().Where(t => t.Content is DockPanel);
 
     private static System.Collections.Generic.IEnumerable<TabItem> QueryTabs(MainWindow window) =>
         window.MainTabControl.Items.OfType<TabItem>().Where(t => t.Content is QuerySessionControl);

--- a/tests/PlanViewer.Core.Tests/OpenSaveQueryTests.cs
+++ b/tests/PlanViewer.Core.Tests/OpenSaveQueryTests.cs
@@ -107,6 +107,76 @@ public class OpenSaveQueryTests
     }
 
     [Fact]
+    public void SavingInPlaceRoundTripsAndLeavesNoStagingFileBehind()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var opened = TempSql("SELECT 1;");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(opened);
+
+                var tab = QueryTabs(window).Last();
+                var session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 2 AS edited;";
+
+                /* Save-in-place — same path in, same path out — is the route the unsaved-
+                   changes prompt takes for a file-backed tab, and the one where a botched
+                   write costs the user their only copy. It now stages through a sibling
+                   .tmp (AtomicFile), which must be gone once the save has landed. */
+                Assert.True(window.SaveQueryToPath(tab, session, opened));
+
+                Assert.Equal("SELECT 2 AS edited;", File.ReadAllText(opened));
+                Assert.False(session.IsDirty);
+                Assert.Equal(opened, session.SourceFilePath);
+                Assert.False(File.Exists(opened + ".tmp"), "the staging file must not linger");
+            }
+            finally
+            {
+                File.Delete(opened);
+            }
+        });
+    }
+
+    [Fact]
+    public void ASaveThatCannotStageItsTempLeavesTheOriginalFileAlone()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var opened = TempSql("SELECT 1;");
+            /* A directory squatting where AtomicFile stages its temp, so the staging write
+               throws while the target file itself is perfectly writable. */
+            var tmpBlocker = opened + ".tmp";
+            Directory.CreateDirectory(tmpBlocker);
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(opened);
+
+                var tab = QueryTabs(window).Last();
+                var session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 2 AS edited;";
+
+                /* The point of routing SaveQueryToPath through AtomicFile: a save that dies
+                   before it finishes must not have truncated the user's file first. Under
+                   the old truncate-then-write this save would have gone straight to the
+                   target and "succeeded" — failing here, with the original bytes untouched
+                   and the session still dirty, is the new contract. */
+                Assert.False(window.SaveQueryToPath(tab, session, opened));
+
+                Assert.Equal("SELECT 1;", File.ReadAllText(opened));
+                Assert.True(session.IsDirty, "a save that threw has not saved anything");
+            }
+            finally
+            {
+                Directory.Delete(tmpBlocker);
+                File.Delete(opened);
+            }
+        });
+    }
+
+    [Fact]
     public void AFailedSaveLeavesTheSessionPointingAtItsOriginalFile()
     {
         HeadlessUi.Run(() =>

--- a/tests/PlanViewer.Core.Tests/ParameterSubstitutionTests.cs
+++ b/tests/PlanViewer.Core.Tests/ParameterSubstitutionTests.cs
@@ -63,6 +63,62 @@ public class ParameterSubstitutionTests
     }
 
     [Fact]
+    public void AssignedVariable_IsNotOverwrittenWithItsOwnValue()
+    {
+        /* #482: the shape that made this worth handling is a real committed plan —
+           "SELECT @job_name = name, @owner_sid = owner_sid" with both compiled values NULL. Writing
+           the value over the target gives "SELECT NULL = name", which is not merely unrunnable but
+           reads as a comparison. Both list positions, because the second one arrives after a comma
+           rather than after SELECT. */
+        var result = ParameterSubstitution.Apply(
+            "SELECT @a = name, @b = owner FROM t WHERE id = @c",
+            new List<PlanParameter> { Param("@a", "NULL"), Param("@b", "NULL"), Param("@c", "(9)") });
+
+        Assert.Equal("SELECT @a = name, @b = owner FROM t WHERE id = 9", result.Text);
+        Assert.Equal(1, result.SubstitutionCount);
+    }
+
+    [Fact]
+    public void SetAssignment_IsNotOverwrittenEither()
+    {
+        var result = ParameterSubstitution.Apply(
+            "SET @a = @b",
+            new List<PlanParameter> { Param("@a", "(1)"), Param("@b", "(2)") });
+
+        Assert.Equal("SET @a = 2", result.Text);
+        Assert.Equal(1, result.SubstitutionCount);
+    }
+
+    [Fact]
+    public void ComparisonOperatorsThatEndInEquals_AreStillSubstituted()
+    {
+        /* The parameter on the LEFT, which is the only side where the assignment check has anything
+           to decide. It looks forward for a lone "=", and ">=" / "<=" / "<>" / "!=" all put their own
+           character in front of it — so a comparison written with the parameter first must not be
+           mistaken for an assignment. The last one is a bare "=" that is still a comparison, because
+           what precedes it is AND rather than SELECT, SET or a list comma. */
+        var result = ParameterSubstitution.Apply(
+            "WHERE @0 >= a AND @0 <= b AND @0 <> c AND @0 != d AND @0 = e",
+            new List<PlanParameter> { Param("@0", "(3)") });
+
+        Assert.Equal("WHERE 3 >= a AND 3 <= b AND 3 <> c AND 3 != d AND 3 = e", result.Text);
+        Assert.Equal(5, result.SubstitutionCount);
+    }
+
+    [Fact]
+    public void SelectListAliasAssignment_IsStillSubstituted()
+    {
+        /* "VoteTypeId = @VoteTypeId" is an alias on the left and the parameter on the right — a read,
+           and the exact shape param-sniffing-posttypeid2 carries. */
+        var result = ParameterSubstitution.Apply(
+            "SELECT VoteTypeId = @p FROM v WHERE v.VoteTypeId = @p",
+            new List<PlanParameter> { Param("@p", "(2)") });
+
+        Assert.Equal("SELECT VoteTypeId = 2 FROM v WHERE v.VoteTypeId = 2", result.Text);
+        Assert.Equal(2, result.SubstitutionCount);
+    }
+
+    [Fact]
     public void NameInsideAStringLiteral_IsLeftAlone()
     {
         var result = ParameterSubstitution.Apply(

--- a/tests/PlanViewer.Core.Tests/ParameterSubstitutionTests.cs
+++ b/tests/PlanViewer.Core.Tests/ParameterSubstitutionTests.cs
@@ -90,6 +90,101 @@ public class ParameterSubstitutionTests
     }
 
     [Fact]
+    public void TopClauseAssignment_IsNotOverwritten()
+    {
+        /* SELECT TOP (1) @a = col: the back-scan from @a used to meet TOP's ")" and extract an
+           empty word, so the #482 guard never engaged and the copied SQL read "TOP (1) NULL =
+           SomeCol". The guard now steps over exactly one balanced group; @n inside TOP's own
+           group is still a read and still gets its value, which is what makes the copy runnable. */
+        var result = ParameterSubstitution.Apply(
+            "SELECT TOP (1) @a = SomeCol FROM t ORDER BY SomeCol",
+            new List<PlanParameter> { Param("@a", "NULL") });
+
+        Assert.Equal("SELECT TOP (1) @a = SomeCol FROM t ORDER BY SomeCol", result.Text);
+        Assert.Equal(0, result.SubstitutionCount);
+    }
+
+    [Fact]
+    public void TopClauseParameter_IsStillSubstituted()
+    {
+        /* The mirror image: @n is TOP's row count, a read, and the assignment target next to it
+           must not drag it under the guard. */
+        var result = ParameterSubstitution.Apply(
+            "SELECT TOP (@n) @a = SomeCol FROM t",
+            new List<PlanParameter> { Param("@n", "(5)"), Param("@a", "NULL") });
+
+        Assert.Equal("SELECT TOP (5) @a = SomeCol FROM t", result.Text);
+        Assert.Equal(1, result.SubstitutionCount);
+    }
+
+    [Fact]
+    public void ExecReturnStatusAndFirstNamedArgument_AreNotOverwritten()
+    {
+        /* Two shapes the back-scan cannot see, because what precedes each is a procedure name
+           rather than SELECT or SET. Inside an EXEC statement "=" has no other meaning, so both
+           the return-status variable and the FIRST named argument are targets — the second and
+           later named arguments were already protected by the list-comma rule, and must stay so. */
+        var result = ParameterSubstitution.Apply(
+            "EXEC @rc = dbo.proc @debug = @debug, @limit = @limit",
+            new List<PlanParameter>
+            {
+                Param("@rc", "(0)"), Param("@debug", "(1)"), Param("@limit", "(50)")
+            });
+
+        /* The names survive on the left; the values land on the right, which is the whole point
+           of substituting an EXEC — a runnable call with this execution's arguments. */
+        Assert.Equal("EXEC @rc = dbo.proc @debug = 1, @limit = 50", result.Text);
+        Assert.Equal(2, result.SubstitutionCount);
+    }
+
+    [Fact]
+    public void FetchIntoTargets_AreNotOverwritten()
+    {
+        /* FETCH assigns with no "=" anywhere, so the forward scan finds nothing and the answer
+           has to come from the INTO leading the list — for every member of it, not just the
+           first. */
+        var result = ParameterSubstitution.Apply(
+            "FETCH NEXT FROM cur INTO @a, @b",
+            new List<PlanParameter> { Param("@a", "(1)"), Param("@b", "(2)") });
+
+        Assert.Equal("FETCH NEXT FROM cur INTO @a, @b", result.Text);
+        Assert.Equal(0, result.SubstitutionCount);
+    }
+
+    [Fact]
+    public void UpdateSetAgainstAColumn_IsStillSubstituted()
+    {
+        /* SET here is UPDATE's, assigning INTO the column FROM the parameter — a read of @p.
+           The keyword rule only guards a parameter directly in front of the "=", and @p is on
+           the other side of it. */
+        var result = ParameterSubstitution.Apply(
+            "UPDATE t SET col = @p WHERE id = @id",
+            new List<PlanParameter> { Param("@p", "(7)"), Param("@id", "(3)") });
+
+        Assert.Equal("UPDATE t SET col = 7 WHERE id = 3", result.Text);
+        Assert.Equal(2, result.SubstitutionCount);
+    }
+
+    [Fact]
+    public void PositionalExecArgumentsAndInLists_AreStillSubstituted()
+    {
+        /* Comma-separated reads, either side of the INTO hop's reasoning: positional EXEC
+           arguments have a procedure name at the head of their list, an IN list has "(" — and
+           neither is INTO, so both keep their values. */
+        var exec = ParameterSubstitution.Apply(
+            "EXEC dbo.p @a, @b",
+            new List<PlanParameter> { Param("@a", "(1)"), Param("@b", "(2)") });
+
+        Assert.Equal("EXEC dbo.p 1, 2", exec.Text);
+
+        var inList = ParameterSubstitution.Apply(
+            "WHERE x IN (@a, @b)",
+            new List<PlanParameter> { Param("@a", "(1)"), Param("@b", "(2)") });
+
+        Assert.Equal("WHERE x IN (1, 2)", inList.Text);
+    }
+
+    [Fact]
     public void ComparisonOperatorsThatEndInEquals_AreStillSubstituted()
     {
         /* The parameter on the LEFT, which is the only side where the assignment check has anything

--- a/tests/PlanViewer.Core.Tests/PlanAnalyzerTests.cs
+++ b/tests/PlanViewer.Core.Tests/PlanAnalyzerTests.cs
@@ -306,6 +306,36 @@ public class PlanAnalyzerTests
     }
 
     // ---------------------------------------------------------------
+    // Rule 12: Non-SARGable Predicate — table-variable columns
+    // ---------------------------------------------------------------
+
+    /// <summary>
+    /// A table-variable COLUMN renders as [@tv].[col] in a ScalarString — the @ belongs to the
+    /// table's name, not to a scalar variable. The old column pattern excluded @ from the first
+    /// bracket part to keep [@p] out, which also kept [@tv].[col] out: a genuine column-side
+    /// CONVERT_IMPLICIT on one lost its Non-SARGable warning. The "].[" sequence is what a bare
+    /// variable can never have, so it alone draws the line.
+    /// </summary>
+    [Fact]
+    public void Rule12f_NonSargable_TableVariableColumnConversion_IsFlagged()
+    {
+        Assert.True(PlanAnalyzer.ConvertImplicitWrapsColumn(
+            "CONVERT_IMPLICIT(nvarchar(40),[@tv].[col],0)=[@p]"));
+    }
+
+    /// <summary>
+    /// The parameter-side mirror of the case above, and the #436 rule restated: converting the
+    /// parameter up to the column's type costs nothing, table variable or not, so widening the
+    /// column pattern must not start flagging it.
+    /// </summary>
+    [Fact]
+    public void Rule12f_NonSargable_TableVariableParameterSideConversion_IsNotFlagged()
+    {
+        Assert.False(PlanAnalyzer.ConvertImplicitWrapsColumn(
+            "[@tv].[col]=CONVERT_IMPLICIT(nvarchar(40),[@p],0)"));
+    }
+
+    // ---------------------------------------------------------------
     // Rule 12: Non-SARGable Predicate — Function Call
     // ---------------------------------------------------------------
 

--- a/tests/PlanViewer.Core.Tests/PlanTestHelper.cs
+++ b/tests/PlanViewer.Core.Tests/PlanTestHelper.cs
@@ -38,6 +38,24 @@ public static class PlanTestHelper
     }
 
     /// <summary>
+    /// Same load + analyze + score, with an analyzer config (for rules-config behavior like
+    /// severity overrides). Named rather than overloaded so an existing
+    /// <c>LoadAndAnalyze(name, null)</c> call can never silently pick a different overload.
+    /// </summary>
+    public static ParsedPlan LoadAndAnalyzeWithConfig(string planFileName, AnalyzerConfig config)
+    {
+        var path = Path.Combine("Plans", planFileName);
+        Assert.True(File.Exists(path), $"Test plan not found: {path}");
+
+        var xml = File.ReadAllText(path);
+        xml = xml.Replace("encoding=\"utf-16\"", "encoding=\"utf-8\"");
+        var plan = ShowPlanParser.Parse(xml);
+        PlanAnalyzer.Analyze(plan, config);
+        BenefitScorer.Score(plan);
+        return plan;
+    }
+
+    /// <summary>
     /// Gets all warnings across all statements and all nodes in the plan.
     /// </summary>
     public static List<PlanWarning> AllWarnings(ParsedPlan plan)

--- a/tests/PlanViewer.Core.Tests/ProcBodyStatementsGridTests.cs
+++ b/tests/PlanViewer.Core.Tests/ProcBodyStatementsGridTests.cs
@@ -1,0 +1,78 @@
+using System.IO;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.LogicalTree;
+using PlanViewer.App.Controls;
+using PlanViewer.Core.Services;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #456 in the desktop app: analysis and Human/Robot Advice walk every statement through
+/// PlanStatements.EnumerateAll, but the statements grid and the MCP session registration were
+/// still built from the outer batch only. For an <c>EXEC &lt;procedure&gt;</c> plan that meant
+/// one grid row — the EXEC, on its synthetic root node — and near-zero registered counts, while
+/// the advice discussed warnings across the whole body that the grid could neither display nor
+/// navigate to.
+///
+/// <para>Drives the real control headlessly rather than testing a list-building helper, because
+/// the defect was precisely the distance between what the pipeline computed and what the control
+/// chose to show.</para>
+/// </summary>
+public class ProcBodyStatementsGridTests
+{
+    [Fact]
+    public void TheGridListsBodyStatementsAndRendersThem()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = Path.Combine("Plans", "exec_stored_procedure_plan.sqlplan");
+            Assert.True(File.Exists(path), $"Test plan not found: {path}");
+            var xml = File.ReadAllText(path).Replace("encoding=\"utf-16\"", "encoding=\"utf-8\"");
+
+            var viewer = new PlanViewerControl();
+            Assert.True(
+                viewer.LoadPlan(xml, "exec_stored_procedure_plan.sqlplan"),
+                $"an EXEC plan must load, not refuse: {viewer.LastLoadError}");
+
+            var window = new Window { Content = viewer, Width = 1400, Height = 900 };
+            window.Show();
+            window.UpdateLayout();
+
+            var grid = viewer.GetLogicalDescendants()
+                .OfType<DataGrid>().First(g => g.Name == "StatementsGrid");
+            var rows = ((System.Collections.IEnumerable)grid.ItemsSource!)
+                .Cast<StatementRow>().ToList();
+
+            /* The grid must agree with the traversal the analysis used: every statement that
+               carries a plan of its own, body statements included. (The parser synthesizes a
+               root node even for the EXEC and SET statements, so for this fixture that is all
+               six — and before this fix the grid showed exactly one row: the EXEC.) Counted
+               independently from a fresh parse so the assertion cannot be satisfied by the
+               control agreeing with itself. */
+            var expected = PlanStatements.EnumerateAll(ShowPlanParser.Parse(xml))
+                .Count(s => s.RootNode != null);
+
+            Assert.True(expected > 1, "fixture must carry multiple renderable body statements");
+            Assert.Equal(expected, rows.Count);
+
+            /* The outer EXEC keeps its bare text — it isn't inside anything — while every body
+               row names its module, which is the label a reader needs to tell five bare body
+               statements apart. Copy paths hand out the raw statement text; only the display is
+               prefixed. */
+            Assert.StartsWith("EXEC dbo.ReproProc", rows[0].QueryText);
+            Assert.All(rows.Skip(1), r => Assert.StartsWith("dbo.ReproProc > ", r.QueryText));
+
+            /* Selecting a body statement must draw its plan on the canvas. Row 0 was selected by
+               LoadPlan; move to the last row to force a re-render of a different body statement,
+               and fail loudly if rendering threw or produced nothing. */
+            var canvas = viewer.GetLogicalDescendants()
+                .OfType<Canvas>().First(c => c.Name == "PlanCanvas");
+            grid.SelectedIndex = rows.Count - 1;
+            window.UpdateLayout();
+
+            Assert.True(canvas.Children.Count > 0,
+                "selecting a procedure-body statement must render its operators");
+        });
+    }
+}

--- a/tests/PlanViewer.Core.Tests/QueryStoreErrorDisplayTests.cs
+++ b/tests/PlanViewer.Core.Tests/QueryStoreErrorDisplayTests.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using Avalonia.Controls;
+using PlanViewer.App.Controls;
+using PlanViewer.Core.Interfaces;
+using PlanViewer.Core.Models;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #452's pattern on the Query Store grid: five catch sites cut exception text to 60-80
+/// characters + "..." before handing it to a one-line status strip, throwing away the part of
+/// a SQL error that says what actually went wrong (the interesting half of a login or firewall
+/// message is rarely in its first 60 characters). The sites now pass the full message, and the
+/// strip mirrors whatever it shows into its tooltip — trimming belongs to the display, and the
+/// hover is the only way a one-line strip can ever surrender the rest.
+///
+/// <para>What is pinned here is the mirror, driven through StatusText the way every one of the
+/// five sites drives it. The sites themselves are SQL failure paths, and a test that
+/// manufactures a real connection failure inherits the machine's SQL state and SqlClient's
+/// timeouts — the wrong trade for a display contract.</para>
+/// </summary>
+public class QueryStoreErrorDisplayTests
+{
+    [Fact]
+    public void TheStatusStripMirrorsItsFullTextIntoTheTooltip()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var grid = new QueryStoreGridControl(
+                new ServerConnection { ServerName = "tcp:127.0.0.1,1", DisplayName = "unit test" },
+                new NoCredentials(),
+                initialDatabase: "master",
+                databases: new List<string> { "master" });
+
+            var status = grid.FindControl<TextBlock>("StatusText")!;
+
+            /* Longer than either of the old cut-offs, so a reintroduced pre-truncation at any
+               site would be visible as a tooltip that no longer matches what the site sent. */
+            var fullError = "A network-related or instance-specific error occurred while "
+                + "establishing a connection to SQL Server. The server was not found or was not "
+                + "accessible. Verify that the instance name is correct and that SQL Server is "
+                + "configured to allow remote connections. (provider: TCP Provider, error: 0)";
+
+            status.Text = fullError;
+            Assert.Equal(fullError, ToolTip.GetTip(status));
+
+            /* And an empty status must not leave a stale error hovering over nothing. */
+            status.Text = "";
+            Assert.Null(ToolTip.GetTip(status));
+        });
+    }
+
+    /// <summary>
+    /// Windows-auth credentials so the constructor's connection-string build asks for nothing;
+    /// no test here ever opens the connection.
+    /// </summary>
+    private sealed class NoCredentials : ICredentialService
+    {
+        public bool SaveCredential(string serverId, string username, string password) => false;
+        public (string Username, string Password)? GetCredential(string serverId) => null;
+        public bool DeleteCredential(string serverId) => false;
+        public bool CredentialExists(string serverId) => false;
+        public bool UpdateCredential(string serverId, string username, string password) => false;
+    }
+}

--- a/tests/PlanViewer.Core.Tests/RestoreQueryTabsTests.cs
+++ b/tests/PlanViewer.Core.Tests/RestoreQueryTabsTests.cs
@@ -39,7 +39,7 @@ public class RestoreQueryTabsTests
                 var window = new MainWindow();
                 window.LoadSqlFile(path);
 
-                Assert.Contains(path, window.CollectOpenTabPaths());
+                Assert.Contains(path, window.CollectOpenTabEntries());
             }
             finally
             {
@@ -49,9 +49,11 @@ public class RestoreQueryTabsTests
     }
 
     /// <summary>
-    /// The deliberate edge of the fix. A never-saved scratch buffer has no path, so there is
-    /// nothing to write down and it does not come back — persisting unsaved text is #462's job,
-    /// not this one's.
+    /// The edge #463 drew, redrawn by #496: a scratch tab enters the list only once its
+    /// CONTENT has actually persisted (as a scratch:&lt;guid&gt; entry —
+    /// ScratchBufferPersistenceTests owns that half). A fresh, empty scratch has no buffer,
+    /// no id, and therefore still no entry — which is what keeps a restart from restoring a
+    /// parade of blank "Query N" tabs.
     /// </summary>
     [Fact]
     public void AScratchQueryHasNoFileAndIsNotWrittenDown()
@@ -63,7 +65,7 @@ public class RestoreQueryTabsTests
 
             var session = Sessions(window).Last();
             Assert.Null(session.SourceFilePath);
-            Assert.Empty(window.CollectOpenTabPaths());
+            Assert.Empty(window.CollectOpenTabEntries());
         });
     }
 
@@ -107,7 +109,7 @@ public class RestoreQueryTabsTests
 
                 var window = new MainWindow();
 
-                Assert.Contains(path, window.CollectOpenTabPaths());
+                Assert.Contains(path, window.CollectOpenTabEntries());
                 Assert.Contains(Viewers(window), v => v.SourceFilePath == path);
             }
             finally

--- a/tests/PlanViewer.Core.Tests/RestoreQueryTabsTests.cs
+++ b/tests/PlanViewer.Core.Tests/RestoreQueryTabsTests.cs
@@ -85,6 +85,7 @@ public class RestoreQueryTabsTests
             }
             finally
             {
+                Unseed();
                 File.Delete(path);
             }
         });
@@ -100,12 +101,21 @@ public class RestoreQueryTabsTests
         HeadlessUi.Run(() =>
         {
             var path = Path.Combine(System.AppContext.BaseDirectory, "Plans", "row_goal_plan.sqlplan");
-            Seed(path);
+            try
+            {
+                Seed(path);
 
-            var window = new MainWindow();
+                var window = new MainWindow();
 
-            Assert.Contains(path, window.CollectOpenTabPaths());
-            Assert.Contains(Viewers(window), v => v.SourceFilePath == path);
+                Assert.Contains(path, window.CollectOpenTabPaths());
+                Assert.Contains(Viewers(window), v => v.SourceFilePath == path);
+            }
+            finally
+            {
+                /* This one seeds a fixture that is never deleted, so without the unseed every
+                   later MainWindow in the run would restore a phantom plan tab. */
+                Unseed();
+            }
         });
     }
 
@@ -192,14 +202,25 @@ public class RestoreQueryTabsTests
 
     /// <summary>
     /// Puts one path where the next MainWindow will look for the previous session's tabs.
-    /// Load returns the process-wide cached instance, which is the same object the window reads,
-    /// and restore clears it again on the way out — so this does not leak into other tests.
+    /// Load returns the process-wide cached instance, which is the same object the window reads.
+    /// Since #490, restore REWRITES the list with whatever it successfully opened — that is the
+    /// crash-safety — so a seeding test has to blank the list again on its way out
+    /// (<see cref="Unseed"/>) or the next MainWindow constructed anywhere in the run restores
+    /// this test's file.
     /// </summary>
     private static void Seed(string path)
     {
         var settings = AppSettingsService.Load();
         settings.OpenTabs.Clear();
         settings.OpenTabs.Add(path);
+    }
+
+    /// <summary>The other half of <see cref="Seed"/>, for a finally block.</summary>
+    private static void Unseed()
+    {
+        var settings = AppSettingsService.Load();
+        settings.OpenTabs.Clear();
+        AppSettingsService.Save(settings);
     }
 
     private static MenuItem ContextMenuItem(TabItem tab, string header) =>

--- a/tests/PlanViewer.Core.Tests/ScratchBufferPersistenceTests.cs
+++ b/tests/PlanViewer.Core.Tests/ScratchBufferPersistenceTests.cs
@@ -173,7 +173,12 @@ public class ScratchBufferPersistenceTests
             }
             finally
             {
-                PutAwayMainWindow(window);
+                /* The session too, like this test's siblings: if an assertion above fails
+                   before the Don't Save click lands, the scratch tab is still dirty, and a
+                   PutAway that skips MarkClean would raise the #462 walk's modal during
+                   teardown — the leaked-window poisoning #474's helper exists to prevent,
+                   biting exactly while masking the real failure. */
+                PutAwayMainWindow(window, session);
                 ResetScratchState();
             }
         });

--- a/tests/PlanViewer.Core.Tests/ScratchBufferPersistenceTests.cs
+++ b/tests/PlanViewer.Core.Tests/ScratchBufferPersistenceTests.cs
@@ -144,12 +144,13 @@ public class ScratchBufferPersistenceTests
         HeadlessUi.Run(() =>
         {
             MainWindow? window = null;
+            QuerySessionControl? session = null;
             try
             {
                 window = new MainWindow();
                 window.Show(); // the prompt's ShowDialog needs a visible owner, headless or not
 
-                var session = NewScratchTab(window, "SELECT 1 AS discarded_on_purpose;");
+                session = NewScratchTab(window, "SELECT 1 AS discarded_on_purpose;");
                 window.FlushPendingScratchPersistForTests();
 
                 var id = session.ScratchBufferId!.Value;

--- a/tests/PlanViewer.Core.Tests/ScratchBufferPersistenceTests.cs
+++ b/tests/PlanViewer.Core.Tests/ScratchBufferPersistenceTests.cs
@@ -305,23 +305,37 @@ public class ScratchBufferPersistenceTests
     }
 
     /// <summary>
-    /// Startup collects what nothing references: buffers stranded by crash-window skew and
-    /// AtomicFile .tmp siblings alike — deletion normally happens at the moment of choice,
-    /// so unreferenced means debris. The referenced buffer rides through untouched.
+    /// Startup collects what nothing references — but only past the grace period (#496
+    /// review): a FRESH unreferenced buffer can be an innocent bystander (written moments
+    /// before a crash in the buffer-then-list gap, or stranded when a mid-restore crash
+    /// left the poison-cleared list empty), so it survives as a recoverable .sql until the
+    /// grace runs out. Aged debris — stale buffers and AtomicFile .tmp siblings — still
+    /// dies, and the referenced buffer rides through untouched at any age.
     /// </summary>
     [Fact]
-    public void OrphanedBufferFilesAreSweptAtStartupAndReferencedOnesAreKept()
+    public void TheSweepSparesFreshOrphansAndCollectsAgedOnes()
     {
         HeadlessUi.Run(() =>
         {
             var kept = Guid.NewGuid();
-            var orphan = Guid.NewGuid();
-            var strayTmp = ScratchBufferStore.BufferPathFor(orphan) + ".tmp";
+            var agedOrphan = Guid.NewGuid();
+            var freshOrphan = Guid.NewGuid();
+            var strayTmp = ScratchBufferStore.BufferPathFor(agedOrphan) + ".tmp";
             try
             {
                 ScratchBufferStore.Write(kept, "SELECT 1 AS referenced;");
-                ScratchBufferStore.Write(orphan, "SELECT 2 AS stranded;");
+                ScratchBufferStore.Write(agedOrphan, "SELECT 2 AS stranded_long_ago;");
+                ScratchBufferStore.Write(freshOrphan, "SELECT 3 AS innocent_bystander;");
                 File.WriteAllText(strayTmp, "half a write");
+
+                /* Backdate past the grace period, derived from the store's own constant so
+                   the two can't drift apart. The kept buffer is aged too, proving reference
+                   beats age. */
+                var stale = DateTime.UtcNow - ScratchBufferStore.OrphanGracePeriod - TimeSpan.FromMinutes(1);
+                File.SetLastWriteTimeUtc(ScratchBufferStore.BufferPathFor(kept), stale);
+                File.SetLastWriteTimeUtc(ScratchBufferStore.BufferPathFor(agedOrphan), stale);
+                File.SetLastWriteTimeUtc(strayTmp, stale);
+
                 Seed(ScratchBufferStore.EntryFor(kept));
 
                 var window = new MainWindow();
@@ -329,12 +343,67 @@ public class ScratchBufferPersistenceTests
                 Assert.True(File.Exists(ScratchBufferStore.BufferPathFor(kept)));
                 Assert.NotNull(Sessions(window).SingleOrDefault(s => s.ScratchBufferId == kept));
 
-                Assert.False(File.Exists(ScratchBufferStore.BufferPathFor(orphan)));
+                Assert.False(File.Exists(ScratchBufferStore.BufferPathFor(agedOrphan)));
                 Assert.False(File.Exists(strayTmp));
+
+                Assert.True(
+                    File.Exists(ScratchBufferStore.BufferPathFor(freshOrphan)),
+                    "a fresh orphan may be a crash bystander and must outlive the sweep until the grace period ends");
             }
             finally
             {
+                File.Delete(ScratchBufferStore.BufferPathFor(freshOrphan));
                 ResetScratchState();
+            }
+        });
+    }
+
+    /// <summary>
+    /// The #496 review's blocking finding, closed: a cold start that carries a file
+    /// argument used to SKIP restore, so the continuous writer rewrote the list without
+    /// the previous session's scratch entries and the next start's sweep destroyed their
+    /// buffers — never-chosen content lost to an everyday double-click. A file-arg start
+    /// now restores first and opens the file on top, and the fallback scratch tab stays
+    /// out of the way.
+    /// </summary>
+    [Fact]
+    public void AFileArgColdStartRestoresTheScratchSessionAndOpensTheFile()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var opened = TempSql("SELECT 1 AS from_argv;");
+            var id = Guid.NewGuid();
+            MainWindow? window = null;
+            try
+            {
+                /* The pre-relaunch on-disk state, laid down directly rather than through a
+                   first window: a scratch buffer and its list entry, exactly what an
+                   abnormal exit leaves behind. Seeding after construction is the #489 tests'
+                   pattern — a window's own constructor already runs OpenFromStartupArgs once
+                   (with the test runner's file-less argv), so driving the seam a second time
+                   here is the single cold-start-with-a-file call under test, not a double
+                   restore. */
+                window = new MainWindow();
+                ScratchBufferStore.Write(id, "SELECT 2 AS must_survive_the_double_click;");
+                Seed(ScratchBufferStore.EntryFor(id));
+
+                window.OpenFromStartupArgs(new[] { "PerformanceStudio.exe", opened });
+                window.FlushPendingSessionPersistForTests();
+
+                // The scratch survived the file-arg launch instead of being overwritten...
+                Assert.NotNull(Sessions(window).SingleOrDefault(s => s.ScratchBufferId == id));
+                Assert.True(File.Exists(ScratchBufferStore.BufferPathFor(id)));
+
+                // ...and the requested file opened on top, both on the persisted list.
+                var persisted = PersistedOpenTabs();
+                Assert.Contains(ScratchBufferStore.EntryFor(id), persisted);
+                Assert.Contains(opened, persisted);
+            }
+            finally
+            {
+                PutAwayMainWindow(window);
+                ResetScratchState();
+                File.Delete(opened);
             }
         });
     }

--- a/tests/PlanViewer.Core.Tests/ScratchBufferPersistenceTests.cs
+++ b/tests/PlanViewer.Core.Tests/ScratchBufferPersistenceTests.cs
@@ -1,0 +1,680 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using PlanViewer.App;
+using PlanViewer.App.Controls;
+using PlanViewer.App.Services;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #496: after #495 made the open-tab list survive abnormal exits, the one thing still lost
+/// to a crash was a scratch tab's CONTENT — typed, never saved, backed by nothing. Content
+/// now persists continuously to one buffer file per scratch tab (debounced, beside the
+/// settings file), the tab rides the #495 list as a <c>scratch:&lt;guid&gt;</c> entry in
+/// strip order, and the buffer dies at exactly the moments the user chooses its fate. The
+/// design center under every test here: a buffer the user CHOSE to discard dies; a buffer
+/// they NEVER GOT TO CHOOSE about survives.
+///
+/// <para>Same disciplines as SessionPersistenceTests, because this is the same feature one
+/// layer deeper: assertions read the redirected FILES (#451/#487 — which is also what makes
+/// letting the startup orphan sweep actually delete things safe), the debounce is driven
+/// through <see cref="MainWindow.FlushPendingScratchPersistForTests"/> rather than waited
+/// out (shared dispatcher — see RequestSessionPersist), and every test that stages
+/// persisted state blanks it on the way out, list and buffer files both, because the next
+/// MainWindow constructed anywhere in the run restores the one and sweeps the other.</para>
+/// </summary>
+public class ScratchBufferPersistenceTests
+{
+    [Fact]
+    public void TypedScratchContentIsPersistedWithoutClosingTheApp()
+    {
+        HeadlessUi.Run(() =>
+        {
+            try
+            {
+                var window = new MainWindow();
+                var session = NewScratchTab(window, "SELECT 1 AS scratch_live;");
+
+                /* The keystrokes armed the content debounce through DirtyStateChanged; the
+                   seam stands in for its tick. Before #496 this text existed nowhere but
+                   the editor. */
+                window.FlushPendingScratchPersistForTests();
+
+                var id = session.ScratchBufferId;
+                Assert.NotNull(id); // minted at first persist, not at construction
+
+                Assert.Equal(
+                    "SELECT 1 AS scratch_live;",
+                    File.ReadAllText(ScratchBufferStore.BufferPathFor(id!.Value)));
+
+                /* And the entry landed with the buffer, not a debounce later — the seam
+                   mirrors the real tick's chained membership flush, so a crash right after
+                   the idle write already finds both halves on disk. */
+                Assert.Contains(ScratchBufferStore.EntryFor(id.Value), PersistedOpenTabs());
+            }
+            finally
+            {
+                ResetScratchState();
+            }
+        });
+    }
+
+    [Fact]
+    public void ARestoredScratchTabIsDirtyIntactAndContinuesItsBuffer()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var id = Guid.NewGuid();
+            try
+            {
+                ScratchBufferStore.Write(id, "SELECT 1 AS survived_the_crash;");
+                Seed(ScratchBufferStore.EntryFor(id));
+
+                var window = new MainWindow();
+
+                var session = Sessions(window).Single(s => s.ScratchBufferId == id);
+                Assert.Equal("SELECT 1 AS survived_the_crash;", session.QueryEditor.Text);
+
+                /* Dirty by definition: nothing the user chose backs this content, so the
+                   modified marker and every close prompt must treat it as unsaved work. */
+                Assert.True(session.IsDirty);
+                Assert.Null(session.SourceFilePath);
+
+                /* The SAME id came back — this session continues its buffer across
+                   restarts rather than forking a new file per launch — and restore
+                   re-listed it immediately, same as it does for file tabs. */
+                Assert.True(File.Exists(ScratchBufferStore.BufferPathFor(id)));
+                Assert.Contains(ScratchBufferStore.EntryFor(id), PersistedOpenTabs());
+            }
+            finally
+            {
+                ResetScratchState();
+            }
+        });
+    }
+
+    /// <summary>
+    /// The reason scratch entries live INSIDE the one ordered list instead of appended to
+    /// it: a scratch tab sitting between two file tabs comes back between them. (#495's
+    /// detached entries keep their documented append-after compromise; this pins that
+    /// docked tabs never inherited it.)
+    /// </summary>
+    [Fact]
+    public void AScratchEntryKeepsItsPlaceAmongFilePaths()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var first = TempSql("SELECT 1 AS first;");
+            var last = TempSql("SELECT 2 AS last;");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(first);
+                var session = NewScratchTab(window, "SELECT 0 AS in_between;");
+                window.LoadSqlFile(last);
+
+                window.FlushPendingScratchPersistForTests();
+
+                var entry = ScratchBufferStore.EntryFor(session.ScratchBufferId!.Value);
+                Assert.Equal(new[] { first, entry, last }, PersistedOpenTabs());
+            }
+            finally
+            {
+                ResetScratchState();
+                File.Delete(first);
+                File.Delete(last);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The chose half of the design center, through the real prompt: Don't Save is the user
+    /// answering "this content may die", and the buffer obeys — or a discarded query would
+    /// resurrect at the next start and the prompt's answer would mean nothing.
+    /// </summary>
+    [Fact]
+    public void DontSaveAtTheClosePromptDeletesTheBuffer()
+    {
+        HeadlessUi.Run(() =>
+        {
+            MainWindow? window = null;
+            try
+            {
+                window = new MainWindow();
+                window.Show(); // the prompt's ShowDialog needs a visible owner, headless or not
+
+                var session = NewScratchTab(window, "SELECT 1 AS discarded_on_purpose;");
+                window.FlushPendingScratchPersistForTests();
+
+                var id = session.ScratchBufferId!.Value;
+                Assert.True(File.Exists(ScratchBufferStore.BufferPathFor(id)));
+
+                var tab = TabOf(window, session);
+                CloseButton(tab).RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                Dispatcher.UIThread.RunJobs();
+
+                var prompt = Assert.Single(window.OwnedWindows);
+                PromptButton(prompt, "Don't Save").RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.DoesNotContain(tab, window.MainTabControl.Items.OfType<TabItem>());
+                Assert.False(File.Exists(ScratchBufferStore.BufferPathFor(id)),
+                    "Don't Save is a choice, and a chosen buffer dies");
+                Assert.Null(session.ScratchBufferId);
+
+                window.FlushPendingScratchPersistForTests();
+                Assert.DoesNotContain(ScratchBufferStore.EntryFor(id), PersistedOpenTabs());
+            }
+            finally
+            {
+                PutAwayMainWindow(window);
+                ResetScratchState();
+            }
+        });
+    }
+
+    /// <summary>
+    /// The other way a user chooses: a save that succeeds moves the content into a real
+    /// file, the list entry becomes the path, and the buffer that was protecting the
+    /// content retires.
+    /// </summary>
+    [Fact]
+    public void ASuccessfulSaveTurnsTheEntryIntoThePathAndDeletesTheBuffer()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var savedAs = Path.Combine(Path.GetTempPath(), $"saved_{Path.GetRandomFileName()}.sql");
+            try
+            {
+                var window = new MainWindow();
+                var session = NewScratchTab(window, "SELECT 1 AS graduated;");
+                window.FlushPendingScratchPersistForTests();
+
+                var id = session.ScratchBufferId!.Value;
+                Assert.True(File.Exists(ScratchBufferStore.BufferPathFor(id)));
+                Assert.Contains(ScratchBufferStore.EntryFor(id), PersistedOpenTabs());
+
+                Assert.True(window.SaveQueryToPath(TabOf(window, session), session, savedAs));
+                window.FlushPendingScratchPersistForTests();
+
+                Assert.False(File.Exists(ScratchBufferStore.BufferPathFor(id)),
+                    "content saved is content chosen — the real file owns it now");
+                Assert.Null(session.ScratchBufferId);
+
+                var persisted = PersistedOpenTabs();
+                Assert.Contains(savedAs, persisted);
+                Assert.DoesNotContain(ScratchBufferStore.EntryFor(id), persisted);
+            }
+            finally
+            {
+                ResetScratchState();
+                if (File.Exists(savedAs))
+                    File.Delete(savedAs);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The consequence the design center promises: a CLEAN close leaves zero buffers,
+    /// because every scratch tab with content was asked about on the way out — buffers
+    /// exist on disk only after an exit nobody got to answer. This drives the whole route:
+    /// window close, the #462/#473 walk, Don't Save clicked, OnClosed's final drain and
+    /// list write.
+    /// </summary>
+    [Fact]
+    public void ACleanCloseLeavesNoScratchBuffersBehind()
+    {
+        HeadlessUi.Run(() =>
+        {
+            MainWindow? window = null;
+            QuerySessionControl? session = null;
+            try
+            {
+                window = new MainWindow();
+                window.Show();
+
+                session = NewScratchTab(window, "SELECT 1 AS asked_about;");
+                window.FlushPendingScratchPersistForTests();
+                Assert.Single(ScratchFiles());
+
+                window.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                var prompt = Assert.Single(window.OwnedWindows);
+                PromptButton(prompt, "Don't Save").RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.False(window.IsVisible, "the answered walk lets the close proceed");
+                Assert.Empty(ScratchFiles());
+                Assert.DoesNotContain(PersistedOpenTabs(),
+                    e => e.StartsWith(ScratchBufferStore.EntryPrefix, StringComparison.Ordinal));
+            }
+            finally
+            {
+                PutAwayMainWindow(window, session);
+                ResetScratchState();
+            }
+        });
+    }
+
+    /// <summary>
+    /// The tab nobody is ever asked about: a scratch whose text was deleted back out is
+    /// clean (its saved-text baseline is forever ""), holds no unsaved work, and must not
+    /// resurrect its old text at the next start as if the deletion never happened. This is
+    /// also the branch that keeps the zero-buffers-after-clean-close invariant airtight for
+    /// tabs the prompts skip.
+    /// </summary>
+    [Fact]
+    public void AnEmptiedScratchTabShedsItsBufferOnTheNextFlush()
+    {
+        HeadlessUi.Run(() =>
+        {
+            try
+            {
+                var window = new MainWindow();
+                var session = NewScratchTab(window, "SELECT 1 AS typed_then_deleted;");
+                window.FlushPendingScratchPersistForTests();
+
+                var id = session.ScratchBufferId!.Value;
+                Assert.True(File.Exists(ScratchBufferStore.BufferPathFor(id)));
+
+                session.QueryEditor.Text = "";
+                window.FlushPendingScratchPersistForTests();
+
+                Assert.False(File.Exists(ScratchBufferStore.BufferPathFor(id)));
+                Assert.Null(session.ScratchBufferId);
+                Assert.DoesNotContain(ScratchBufferStore.EntryFor(id), PersistedOpenTabs());
+            }
+            finally
+            {
+                ResetScratchState();
+            }
+        });
+    }
+
+    /// <summary>
+    /// Startup collects what nothing references: buffers stranded by crash-window skew and
+    /// AtomicFile .tmp siblings alike — deletion normally happens at the moment of choice,
+    /// so unreferenced means debris. The referenced buffer rides through untouched.
+    /// </summary>
+    [Fact]
+    public void OrphanedBufferFilesAreSweptAtStartupAndReferencedOnesAreKept()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var kept = Guid.NewGuid();
+            var orphan = Guid.NewGuid();
+            var strayTmp = ScratchBufferStore.BufferPathFor(orphan) + ".tmp";
+            try
+            {
+                ScratchBufferStore.Write(kept, "SELECT 1 AS referenced;");
+                ScratchBufferStore.Write(orphan, "SELECT 2 AS stranded;");
+                File.WriteAllText(strayTmp, "half a write");
+                Seed(ScratchBufferStore.EntryFor(kept));
+
+                var window = new MainWindow();
+
+                Assert.True(File.Exists(ScratchBufferStore.BufferPathFor(kept)));
+                Assert.NotNull(Sessions(window).SingleOrDefault(s => s.ScratchBufferId == kept));
+
+                Assert.False(File.Exists(ScratchBufferStore.BufferPathFor(orphan)));
+                Assert.False(File.Exists(strayTmp));
+            }
+            finally
+            {
+                ResetScratchState();
+            }
+        });
+    }
+
+    /// <summary>
+    /// #495's poison invariant, mirrored for buffers: an entry whose buffer cannot load is
+    /// skipped, never re-added (the poison-defense clear already ran, and no session exists
+    /// to re-list it), and its file is removed rather than left to fail at every start. An
+    /// unreadable buffer (a directory squatting on its path) and an empty one (debris the
+    /// writer would never produce) both walk that path; the healthy entry next to them
+    /// restores.
+    /// </summary>
+    [Fact]
+    public void AFailedBufferLoadIsSkippedNotReAddedAndSwept()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var unreadable = Guid.NewGuid();
+            var empty = Guid.NewGuid();
+            var healthy = Guid.NewGuid();
+            var unreadablePath = ScratchBufferStore.BufferPathFor(unreadable);
+            try
+            {
+                // A directory where the buffer file should be: File.ReadAllText throws.
+                Directory.CreateDirectory(unreadablePath);
+                ScratchBufferStore.Write(empty, "");
+                ScratchBufferStore.Write(healthy, "SELECT 1 AS healthy;");
+                Seed(
+                    ScratchBufferStore.EntryFor(unreadable),
+                    ScratchBufferStore.EntryFor(empty),
+                    ScratchBufferStore.EntryFor(healthy));
+
+                var window = new MainWindow();
+
+                Assert.NotNull(Sessions(window).SingleOrDefault(s => s.ScratchBufferId == healthy));
+                Assert.Null(Sessions(window).SingleOrDefault(s => s.ScratchBufferId == unreadable));
+                Assert.Null(Sessions(window).SingleOrDefault(s => s.ScratchBufferId == empty));
+
+                Assert.False(File.Exists(ScratchBufferStore.BufferPathFor(empty)));
+
+                /* Restore rewrote the list on its way out; the poisoned entries must not
+                   have ridden back in. */
+                var persisted = PersistedOpenTabs();
+                Assert.Contains(ScratchBufferStore.EntryFor(healthy), persisted);
+                Assert.DoesNotContain(ScratchBufferStore.EntryFor(unreadable), persisted);
+                Assert.DoesNotContain(ScratchBufferStore.EntryFor(empty), persisted);
+            }
+            finally
+            {
+                ResetScratchState();
+                if (Directory.Exists(unreadablePath))
+                    Directory.Delete(unreadablePath);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The cap: a pathological paste must not put megabytes on the idle writer's two-second
+    /// cadence, so past ~1MB the tab simply behaves pre-#496 — and an already-written
+    /// smaller buffer is removed rather than left to restore a stale fragment of what the
+    /// user actually had. Shrinking back under the cap resumes persistence.
+    /// </summary>
+    [Fact]
+    public void ABufferOverTheSizeCapIsNotPersistedAndAStaleOneIsRemoved()
+    {
+        HeadlessUi.Run(() =>
+        {
+            try
+            {
+                var window = new MainWindow();
+                var session = NewScratchTab(window, "SELECT 1 AS small;");
+                window.FlushPendingScratchPersistForTests();
+
+                var firstId = session.ScratchBufferId!.Value;
+                Assert.True(File.Exists(ScratchBufferStore.BufferPathFor(firstId)));
+
+                // One char past MainWindow.MaxScratchPersistChars (1 MiB).
+                session.QueryEditor.Text = new string('x', (1024 * 1024) + 1);
+                window.FlushPendingScratchPersistForTests();
+
+                Assert.False(File.Exists(ScratchBufferStore.BufferPathFor(firstId)));
+                Assert.Null(session.ScratchBufferId);
+                Assert.Empty(ScratchFiles());
+
+                session.QueryEditor.Text = "SELECT 1 AS small_again;";
+                window.FlushPendingScratchPersistForTests();
+
+                Assert.NotNull(session.ScratchBufferId);
+                Assert.Equal(
+                    "SELECT 1 AS small_again;",
+                    File.ReadAllText(ScratchBufferStore.BufferPathFor(session.ScratchBufferId!.Value)));
+            }
+            finally
+            {
+                ResetScratchState();
+            }
+        });
+    }
+
+    /// <summary>
+    /// A list from before #496 is nothing but plain paths, and a new build treats it
+    /// exactly as #495 did — restored by extension, rewritten as paths, no scratch
+    /// machinery invoked and no scratch files invented. Zero version fields is the whole
+    /// compatibility design, so this pins its new-reading-old half.
+    /// </summary>
+    [Fact]
+    public void AnOldFormatPlainPathListRestoresUnchanged()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1 AS plain_old_path;");
+            try
+            {
+                Seed(path);
+
+                var window = new MainWindow();
+
+                var session = Sessions(window).Single(s => s.SourceFilePath == path);
+                Assert.Equal("SELECT 1 AS plain_old_path;", session.QueryEditor.Text);
+                Assert.Equal(new[] { path }, PersistedOpenTabs());
+                Assert.Empty(ScratchFiles());
+            }
+            finally
+            {
+                ResetScratchState();
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The old-reading-new half, pinned the way #494's activation sentinel taught: as the
+    /// STRING PROPERTY that makes it true. An old build reading a new list guards every
+    /// entry with File.Exists, so a scratch entry is safe to hand it exactly because the
+    /// entry can never name an existing file — the colon is not legal in a Windows file
+    /// name, and the app only ever writes absolute paths to the list, which a scratch entry
+    /// is not on any platform. A File.Exists assertion here would prove nothing on a runner
+    /// whose filesystem allows colons; the prefix's shape is the actual contract, so the
+    /// prefix's shape is what this test holds still.
+    /// </summary>
+    [Fact]
+    public void TheScratchEntryPrefixCanNeverNameAnExistingFile()
+    {
+        Assert.Contains(':', ScratchBufferStore.EntryPrefix);
+        Assert.Equal("scratch:", ScratchBufferStore.EntryPrefix);
+
+        var id = Guid.NewGuid();
+        var entry = ScratchBufferStore.EntryFor(id);
+        Assert.StartsWith(ScratchBufferStore.EntryPrefix, entry, StringComparison.Ordinal);
+
+        // Roundtrip: what the writer emits is what restore routes to a buffer.
+        Assert.True(ScratchBufferStore.TryParseEntry(entry, out var parsed));
+        Assert.Equal(id, parsed);
+
+        /* Everything that is not a well-formed entry routes as a PATH — including a
+           prefixed entry with a mangled tail, and a real file on a colon-tolerant
+           filesystem that happens to be named like one. */
+        Assert.False(ScratchBufferStore.TryParseEntry(null, out _));
+        Assert.False(ScratchBufferStore.TryParseEntry(@"C:\temp\query.sql", out _));
+        Assert.False(ScratchBufferStore.TryParseEntry("scratch:not-a-guid", out _));
+        Assert.False(ScratchBufferStore.TryParseEntry("SCRATCH:" + id.ToString("N"), out _),
+            "the prefix is exact — case-mangled entries fall through to path handling");
+    }
+
+    /// <summary>
+    /// #496's sixth requirement: off the tab strip is not out of the feature. A detached
+    /// scratch window's edits keep flowing to the same buffer (the subscription lives on
+    /// the session, which detach moves and redock reuses), its entry rides the #495
+    /// detached register half of the list — and Don't Save at ITS close prompt kills the
+    /// buffer the same way a docked one's does.
+    /// </summary>
+    [Fact]
+    public void ADetachedScratchWindowPersistsAndItsDontSaveDeletes()
+    {
+        HeadlessUi.Run(() =>
+        {
+            MainWindow? window = null;
+            Window? detached = null;
+            QuerySessionControl? session = null;
+            try
+            {
+                window = new MainWindow();
+                window.Show();
+
+                session = NewScratchTab(window, "SELECT 1 AS docked_first;");
+                window.FlushPendingScratchPersistForTests();
+                var id = session.ScratchBufferId!.Value;
+
+                detached = window.DetachTabToWindow(TabOf(window, session))!;
+                Dispatcher.UIThread.RunJobs();
+
+                session.QueryEditor.Text = "SELECT 2 AS edited_detached;";
+                window.FlushPendingScratchPersistForTests();
+
+                Assert.Equal(
+                    "SELECT 2 AS edited_detached;",
+                    File.ReadAllText(ScratchBufferStore.BufferPathFor(id)));
+                Assert.Contains(ScratchBufferStore.EntryFor(id), PersistedOpenTabs());
+
+                detached.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                var prompt = Assert.Single(detached.OwnedWindows);
+                PromptButton(prompt, "Don't Save").RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.False(detached.IsVisible);
+                Assert.False(File.Exists(ScratchBufferStore.BufferPathFor(id)),
+                    "a chosen buffer dies in a detached window too");
+
+                window.FlushPendingScratchPersistForTests();
+                Assert.DoesNotContain(ScratchBufferStore.EntryFor(id), PersistedOpenTabs());
+            }
+            finally
+            {
+                PutAwayDetached(detached, session);
+                PutAwayMainWindow(window, session);
+                ResetScratchState();
+            }
+        });
+    }
+
+    // ── plumbing ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Opens a fresh scratch tab and types into it — through NewQuery_Click and the editor
+    /// text, so the persistence subscription is exercised the way a user exercises it.
+    /// </summary>
+    private static QuerySessionControl NewScratchTab(MainWindow window, string text)
+    {
+        window.NewQuery_Click(window, new RoutedEventArgs());
+        var session = Sessions(window).Last();
+        session.QueryEditor.Text = text;
+        return session;
+    }
+
+    /// <summary>
+    /// What is actually on disk, read back through the same serializer the app writes with
+    /// — same rationale as SessionPersistenceTests: crash survival is a property of the
+    /// file, so the file is what gets asserted.
+    /// </summary>
+    private static List<string> PersistedOpenTabs()
+    {
+        var json = File.ReadAllText(AppSettingsService.SettingsFilePath);
+        return JsonSerializer.Deserialize<AppSettings>(json)!.OpenTabs;
+    }
+
+    /// <summary>Every file currently in the redirected scratch directory.</summary>
+    private static string[] ScratchFiles() =>
+        Directory.Exists(AppSettingsService.ScratchDirectory)
+            ? Directory.GetFiles(AppSettingsService.ScratchDirectory)
+            : Array.Empty<string>();
+
+    /// <summary>
+    /// Stages entries where the next MainWindow will look — Load returns the process-wide
+    /// cached instance, the very object the window reads (see RestoreQueryTabsTests.Seed).
+    /// </summary>
+    private static void Seed(params string[] entries)
+    {
+        var settings = AppSettingsService.Load();
+        settings.OpenTabs.Clear();
+        settings.OpenTabs.AddRange(entries);
+    }
+
+    /// <summary>
+    /// Leaves nothing for the next test's MainWindow to restore or sweep: the list (cache
+    /// and file, same as SessionPersistenceTests.ResetPersistedState) and every buffer
+    /// file. Buffer hygiene matters doubly here — a leaked scratch entry would restore a
+    /// phantom tab in an unrelated test, and a leaked buffer file would be "swept" by that
+    /// test's window, hiding a real sweep bug or inventing one.
+    /// </summary>
+    private static void ResetScratchState()
+    {
+        var settings = AppSettingsService.Load();
+        settings.OpenTabs.Clear();
+        AppSettingsService.Save(settings);
+
+        foreach (var file in ScratchFiles())
+        {
+            try
+            {
+                File.Delete(file);
+            }
+            catch
+            {
+                // Best-effort — a stuck file will be swept by a later window anyway.
+            }
+        }
+    }
+
+    /// <summary>
+    /// Same job as UpdateRestartGuardTests.PutAway: prompts closed, session settled, window
+    /// shut — from a finally, because the run where it matters is the run where an
+    /// assertion failed and left the window up (#474).
+    /// </summary>
+    private static void PutAwayMainWindow(MainWindow? window, QuerySessionControl? session = null)
+    {
+        if (window == null || !window.IsVisible)
+            return;
+
+        foreach (var prompt in window.OwnedWindows.ToList())
+            prompt.Close();
+
+        session?.MarkClean();
+        Dispatcher.UIThread.RunJobs();
+        window.Close();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    /// <summary>Detached twin of the above, mirroring DetachedUnsavedChangesTests.PutAway.</summary>
+    private static void PutAwayDetached(Window? detached, QuerySessionControl? session)
+    {
+        if (detached == null || !detached.IsVisible)
+            return;
+
+        foreach (var prompt in detached.OwnedWindows.ToList())
+            prompt.Close();
+
+        session?.MarkClean();
+        Dispatcher.UIThread.RunJobs();
+        detached.Close();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static TabItem TabOf(MainWindow window, QuerySessionControl session) =>
+        window.MainTabControl.Items.OfType<TabItem>().Single(t => t.Content == session);
+
+    private static Button CloseButton(TabItem tab) =>
+        ((StackPanel)tab.Header!).Children.OfType<Button>().Single();
+
+    /// <summary>
+    /// Digs the named button out of an UnsavedChangesDialog: content StackPanel, then the
+    /// button row, then the caption. Same shape as OpenInEditorOverwriteTests.PromptButton.
+    /// </summary>
+    private static Button PromptButton(Window prompt, string caption) =>
+        ((StackPanel)prompt.Content!).Children.OfType<StackPanel>().Single()
+            .Children.OfType<Button>().Single(b => (string?)b.Content == caption);
+
+    private static IEnumerable<QuerySessionControl> Sessions(MainWindow window) =>
+        window.MainTabControl.Items.OfType<TabItem>()
+            .Select(t => t.Content).OfType<QuerySessionControl>();
+
+    private static string TempSql(string text)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+        File.WriteAllText(path, text);
+        return path;
+    }
+}

--- a/tests/PlanViewer.Core.Tests/SessionPersistenceTests.cs
+++ b/tests/PlanViewer.Core.Tests/SessionPersistenceTests.cs
@@ -1,0 +1,370 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using PlanViewer.App;
+using PlanViewer.App.Controls;
+using PlanViewer.App.Services;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #490: session restore knew only what a clean close wrote down. The list was written once,
+/// in OnClosed, so a crash, a task kill, or an OS "shut down anyway" restored zero tabs; and
+/// the writer walked MainTabControl alone, so a file detached into its own window was never
+/// written down at all. Membership changes now persist continuously (debounced), and detached
+/// windows are part of the collected set.
+///
+/// <para>Every assertion here reads the settings FILE, not the in-memory list — the whole
+/// point of continuous persistence is what is on disk when the process dies without warning,
+/// so the disk is what gets checked. The file is the redirected per-run one (#451), which is
+/// what makes asserting real writes safe. The debounce is driven through
+/// <see cref="MainWindow.FlushPendingSessionPersistForTests"/> rather than waited out: the
+/// harness shares one dispatcher across the suite, so a real one-second timer would tick
+/// during some unrelated later test — see RequestSessionPersist for the full story.</para>
+///
+/// <para>Tests that leave real paths in the persisted list blank it on the way out
+/// (<see cref="ResetPersistedState"/>, same hygiene as UpdateRestartGuardTests), because the
+/// next MainWindow constructed anywhere in the run restores whatever it finds there.</para>
+/// </summary>
+public class SessionPersistenceTests
+{
+    [Fact]
+    public void OpeningATabIsPersistedWithoutClosingTheApp()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1 AS persisted_live;");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                /* The open armed the debounced writer through the tab watcher; the seam
+                   stands in for the timer's tick. Before #490 nothing short of closing the
+                   app wrote this down. */
+                window.FlushPendingSessionPersistForTests();
+
+                Assert.Contains(path, PersistedOpenTabs());
+            }
+            finally
+            {
+                ResetPersistedState();
+                File.Delete(path);
+            }
+        });
+    }
+
+    [Fact]
+    public void ClosingATabRemovesItFromThePersistedList()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var stays = TempSql("SELECT 1 AS stays;");
+            var goes = TempSql("SELECT 2 AS goes;");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(stays);
+                window.LoadSqlFile(goes);
+                window.FlushPendingSessionPersistForTests();
+                Assert.Contains(goes, PersistedOpenTabs());
+
+                /* Through the real close button, not Items.Remove, so the whole path is the
+                   one a user takes. The session is clean, so no prompt holds the close. */
+                CloseButton(QueryTab(window, goes)).RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                Dispatcher.UIThread.RunJobs();
+
+                window.FlushPendingSessionPersistForTests();
+
+                var persisted = PersistedOpenTabs();
+                Assert.DoesNotContain(goes, persisted);
+                Assert.Contains(stays, persisted);
+            }
+            finally
+            {
+                ResetPersistedState();
+                File.Delete(stays);
+                File.Delete(goes);
+            }
+        });
+    }
+
+    [Fact]
+    public void ADetachedQueryStaysOnThePersistedListAndRedockKeepsIt()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1 AS detached;");
+            Window? detached = null;
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                detached = window.DetachTabToWindow(QueryTab(window, path))!;
+                window.FlushPendingSessionPersistForTests();
+
+                /* The first gap #490 names: off the tab strip is not out of the app. Before
+                   this, detaching a file was indistinguishable from closing it as far as the
+                   next session was concerned. */
+                Assert.Contains(path, PersistedOpenTabs());
+
+                RedockButton(detached).RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                Dispatcher.UIThread.RunJobs();
+                window.FlushPendingSessionPersistForTests();
+
+                /* And exactly once — redock has to move the entry back to the docked half of
+                   the collection, not leave a stale twin on the detached half. */
+                Assert.Single(PersistedOpenTabs(), p => p == path);
+            }
+            finally
+            {
+                PutAway(detached);
+                ResetPersistedState();
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The register #473 built for unsaved-changes prompts is query-sessions-only, because
+    /// only an edit can be lost. Persistence needs every FILE-backed detached window, and a
+    /// detached plan is exactly the read-only case that register ignores — which is why #490
+    /// keeps its own register instead of borrowing that one.
+    /// </summary>
+    [Fact]
+    public void ADetachedPlanIsPersistedToo()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = Path.Combine(System.AppContext.BaseDirectory, "Plans", "row_goal_plan.sqlplan");
+            Window? detached = null;
+            try
+            {
+                var window = new MainWindow();
+                window.LoadPlanFile(path);
+
+                var planTab = window.MainTabControl.Items.OfType<TabItem>()
+                    .Last(t => t.Content is DockPanel);
+                detached = window.DetachTabToWindow(planTab)!;
+                window.FlushPendingSessionPersistForTests();
+
+                Assert.Contains(path, PersistedOpenTabs());
+            }
+            finally
+            {
+                PutAway(detached);
+                ResetPersistedState();
+            }
+        });
+    }
+
+    [Fact]
+    public void ClosingADetachedWindowTakesItsFileOffThePersistedList()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1 AS closed_detached;");
+            Window? detached = null;
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                detached = window.DetachTabToWindow(QueryTab(window, path))!;
+                window.FlushPendingSessionPersistForTests();
+                Assert.Contains(path, PersistedOpenTabs());
+
+                /* A detached window closing changes nothing on the tab strip, so this is the
+                   one leave-the-app path the tab watcher cannot see — the trigger rides on the
+                   detached register instead. Clean session, so the close guard waves it
+                   through on the first pass. */
+                detached.Close();
+                Dispatcher.UIThread.RunJobs();
+                window.FlushPendingSessionPersistForTests();
+
+                Assert.DoesNotContain(path, PersistedOpenTabs());
+            }
+            finally
+            {
+                PutAway(detached);
+                ResetPersistedState();
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// A scratch buffer joins the list the moment it becomes a file. Tab membership never
+    /// changes across a save, so this is the trigger that lives at SaveQueryToPath rather
+    /// than on the watcher.
+    /// </summary>
+    [Fact]
+    public void AScratchGainingAFileJoinsThePersistedList()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var savedAs = Path.Combine(Path.GetTempPath(), $"saved_{Path.GetRandomFileName()}.sql");
+            try
+            {
+                var window = new MainWindow();
+                window.NewQuery_Click(window, new RoutedEventArgs());
+
+                var tab = window.MainTabControl.Items.OfType<TabItem>()
+                    .Last(t => t.Content is QuerySessionControl);
+                var session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 1 AS first_save;";
+
+                window.FlushPendingSessionPersistForTests();
+                Assert.DoesNotContain(savedAs, PersistedOpenTabs());
+
+                Assert.True(window.SaveQueryToPath(tab, session, savedAs));
+                window.FlushPendingSessionPersistForTests();
+
+                Assert.Contains(savedAs, PersistedOpenTabs());
+            }
+            finally
+            {
+                ResetPersistedState();
+                if (File.Exists(savedAs))
+                    File.Delete(savedAs);
+            }
+        });
+    }
+
+    [Fact]
+    public void RestoreWritesTheRestoredTabsBackImmediately()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1 AS restored_and_kept;");
+            try
+            {
+                Seed(path);
+                var window = new MainWindow();
+
+                /* No flush call here, deliberately: RestoreOpenPlans flushes synchronously at
+                   its own end, so that a crash a moment after startup still finds the session
+                   on disk instead of an empty list waiting out a debounce. Reading the file
+                   straight after the constructor IS the assertion. */
+                Assert.Contains(path, PersistedOpenTabs());
+            }
+            finally
+            {
+                ResetPersistedState();
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The crash-loop invariant. Restore clears the saved list before the first open, and only
+    /// a file that actually opened re-enters it — so a file that fails during restore has, by
+    /// construction, not re-added itself. A file that CRASHES the process mid-load is the same
+    /// case with a bigger bang: it dies before its own re-add, so the next start does not retry
+    /// it. (A test cannot crash its own process to prove that literally; failing to open walks
+    /// the identical path — cleared first, never re-added.)
+    /// </summary>
+    [Fact]
+    public void AFileThatFailsToOpenDuringRestoreStaysOffThePersistedList()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var good = TempSql("SELECT 1 AS survivor;");
+            var poison = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sqlplan");
+            /* Exists (so restore attempts it) but is not a plan, so the open fails and no tab
+               is created. The startup error dialog it raises is ownerless and left behind, the
+               same way ShowErrorBeforeVisibleTests leaves theirs. */
+            File.WriteAllText(poison, "<NotAPlan/>");
+            try
+            {
+                Seed(good, poison);
+                var window = new MainWindow();
+
+                var persisted = PersistedOpenTabs();
+                Assert.Contains(good, persisted);
+                Assert.DoesNotContain(poison, persisted);
+            }
+            finally
+            {
+                ResetPersistedState();
+                File.Delete(good);
+                File.Delete(poison);
+            }
+        });
+    }
+
+    // ── plumbing ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// What is actually on disk, read back through the same serializer the app writes with.
+    /// The redirected file (#451) makes this safe to hit for real.
+    /// </summary>
+    private static List<string> PersistedOpenTabs()
+    {
+        var json = File.ReadAllText(AppSettingsService.SettingsFilePath);
+        return JsonSerializer.Deserialize<AppSettings>(json)!.OpenTabs;
+    }
+
+    /// <summary>
+    /// Stages paths where the next MainWindow will look for the previous session's tabs —
+    /// same mechanism as RestoreQueryTabsTests.Seed: Load returns the process-wide cached
+    /// instance, which is the very object the window reads.
+    /// </summary>
+    private static void Seed(params string[] paths)
+    {
+        var settings = AppSettingsService.Load();
+        settings.OpenTabs.Clear();
+        settings.OpenTabs.AddRange(paths);
+    }
+
+    /// <summary>
+    /// Leaves nothing persisted for the next test's MainWindow to restore. Cache and file
+    /// both, since restore reads the former and these tests assert the latter.
+    /// </summary>
+    private static void ResetPersistedState()
+    {
+        var settings = AppSettingsService.Load();
+        settings.OpenTabs.Clear();
+        AppSettingsService.Save(settings);
+    }
+
+    /// <summary>
+    /// Same job as DetachedUnsavedChangesTests.PutAway: a leaked window outlives its test and
+    /// poisons the shared session (#474), so closure lives in a finally. Sessions here are
+    /// clean, so no prompt ever holds the close.
+    /// </summary>
+    private static void PutAway(Window? detached)
+    {
+        if (detached == null)
+            return;
+
+        foreach (var prompt in detached.OwnedWindows.ToList())
+            prompt.Close();
+
+        detached.Close();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static TabItem QueryTab(MainWindow window, string path) =>
+        window.MainTabControl.Items.OfType<TabItem>()
+            .Single(t => t.Content is QuerySessionControl s && s.SourceFilePath == path);
+
+    private static Button CloseButton(TabItem tab) =>
+        ((StackPanel)tab.Header!).Children.OfType<Button>().Single();
+
+    private static Button RedockButton(Window detached) =>
+        ((DockPanel)detached.Content!).Children.OfType<StackPanel>().Single()
+            .Children.OfType<Button>().Single();
+
+    private static string TempSql(string text)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+        File.WriteAllText(path, text);
+        return path;
+    }
+}

--- a/tests/PlanViewer.Core.Tests/ShowPlanParserLimitsTests.cs
+++ b/tests/PlanViewer.Core.Tests/ShowPlanParserLimitsTests.cs
@@ -1,0 +1,111 @@
+using System.Text;
+using PlanViewer.Core.Models;
+using PlanViewer.Core.Services;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #456's stored-procedure descent called ParseStatementAndChildren without passing the depth
+/// argument, so the parser's recursion depth silently reset to zero at every StoredProc/UDF
+/// boundary. The MaxParseDepth guard — which exists precisely so a maliciously deep plan throws
+/// a catchable error instead of an uncatchable StackOverflowException — could therefore never
+/// fire across procedure nesting, and roughly sixty bytes of XML per level bought an attacker
+/// one more stack frame pair on every plan-open route that feeds the parser.
+///
+/// <para>These tests pin both parser input ceilings: recursion depth across procedure bodies,
+/// and the synchronous Parse path's document-size cap. ParseAsync always had the cap through
+/// XmlReaderSettings.MaxCharactersInDocument; Parse — the path used by the app's
+/// PlanViewerControl, the web viewer, and the analysis pipeline — had none.</para>
+///
+/// <para>The plan XML here is generated rather than loaded from a fixture: a depth bomb is the
+/// same three elements repeated a thousand-odd times, and a loop states that more honestly than
+/// a 70KB fixture file could.</para>
+/// </summary>
+public sealed class ShowPlanParserLimitsTests
+{
+    /// <summary>
+    /// Nesting chosen to fail safely in both directions. With the guard carrying through, it
+    /// fires at depth 1,001 — about two thousand frames, nowhere near exhaustion. If the depth
+    /// reset ever regresses, this nesting is shallow enough to parse to completion on the
+    /// big-stack thread below, so the test fails on the ParseError assert (it stays null)
+    /// instead of killing the test host — verified by running it against the unfixed parser.
+    /// </summary>
+    private const int BombDepth = ShowPlanParser.MaxParseDepth + 100;
+
+    [Fact]
+    public void ProcedureNestingPastTheDepthLimitFailsWithACatchableError()
+    {
+        var xml = NestedProcedurePlan(BombDepth);
+
+        /* A dedicated thread with a deliberately generous stack, so the test's two outcomes
+           stay deterministic regardless of build config or future frame-size drift: guard
+           working -> depth error long before the stack matters; guard regressed -> the parse
+           COMPLETES in the headroom (instead of gambling on where overflow lands) and the
+           assert below reports the miss. */
+        ParsedPlan? plan = null;
+        var thread = new Thread(() => plan = ShowPlanParser.Parse(xml), 8 * 1024 * 1024);
+        thread.Start();
+        thread.Join();
+
+        Assert.NotNull(plan);
+        Assert.NotNull(plan!.ParseError);
+        Assert.Contains("depth limit", plan.ParseError);
+    }
+
+    /// <summary>
+    /// The other direction: carrying depth through procedure bodies must not reject legitimate
+    /// nesting. Every level below the limit still parses, in order, all the way down.
+    /// </summary>
+    [Fact]
+    public void ProcedureNestingBelowTheDepthLimitStillParsesEveryLevel()
+    {
+        const int depth = 50;
+
+        var plan = ShowPlanParser.Parse(NestedProcedurePlan(depth));
+
+        Assert.Null(plan.ParseError);
+        var stmt = Assert.Single(Assert.Single(plan.Batches).Statements);
+        var levels = 0;
+        while (stmt.StoredProcPlan is not null)
+        {
+            stmt = Assert.Single(stmt.StoredProcPlan.Statements);
+            levels++;
+        }
+        Assert.Equal(depth, levels);
+    }
+
+    [Fact]
+    public void SynchronousParseRejectsOversizedInput()
+    {
+        /* Well-formed XML on purpose: if the size cap regressed, this input would parse
+           cleanly and ParseError would stay null, so the test fails on the assert instead of
+           passing by accident on a syntax error. Whitespace inside the root pads it just past
+           the limit; the cap is in characters, matching MaxCharactersInDocument's unit on the
+           async path. */
+        var xml = "<ShowPlanXML>"
+            + new string(' ', ShowPlanParser.MaxParseCharacters)
+            + "</ShowPlanXML>";
+
+        var plan = ShowPlanParser.Parse(xml);
+
+        Assert.NotNull(plan.ParseError);
+        Assert.Contains("size limit", plan.ParseError);
+    }
+
+    /// <summary>
+    /// StmtSimple > StoredProc > Statements repeated <paramref name="levels"/> times around one
+    /// innermost bare statement — the exact shape whose depth #456's descent stopped counting.
+    /// </summary>
+    private static string NestedProcedurePlan(int levels)
+    {
+        var xml = new StringBuilder(
+            "<ShowPlanXML xmlns=\"http://schemas.microsoft.com/sqlserver/2004/07/showplan\"><BatchSequence><Batch><Statements>");
+        for (var level = 0; level < levels; level++)
+            xml.Append("<StmtSimple StatementText=\"EXEC p\"><StoredProc ProcName=\"p\"><Statements>");
+        xml.Append("<StmtSimple StatementText=\"SELECT 1\" />");
+        for (var level = 0; level < levels; level++)
+            xml.Append("</Statements></StoredProc></StmtSimple>");
+        xml.Append("</Statements></Batch></BatchSequence></ShowPlanXML>");
+        return xml.ToString();
+    }
+}

--- a/tests/PlanViewer.Core.Tests/ShowPlanParserLimitsTests.cs
+++ b/tests/PlanViewer.Core.Tests/ShowPlanParserLimitsTests.cs
@@ -74,6 +74,68 @@ public sealed class ShowPlanParserLimitsTests
         Assert.Equal(depth, levels);
     }
 
+    /// <summary>
+    /// #491 gave the cursor branch the same StoredProc/UDF descent as every other statement
+    /// shape, which is a NEW descent path — and #484 is the proof that a new descent path is
+    /// where the depth reset comes back. A plan alternating cursor and procedure shapes
+    /// (StmtCursor &gt; CursorPlan &gt; Operation &gt; UDF wrapping StmtSimple &gt; StoredProc,
+    /// repeated) must hit the same catchable depth error as pure procedure nesting; if the
+    /// cursor-side descent ever forgets to pass depth, the guard can never fire across a cursor
+    /// boundary and this parse runs to completion instead — failing on the assert, safely, per
+    /// the big-stack reasoning on <see cref="BombDepth"/>.
+    /// </summary>
+    [Fact]
+    public void CursorProcedureNestingPastTheDepthLimitFailsWithACatchableError()
+    {
+        var xml = NestedCursorProcedurePlan(BombDepth);
+
+        ParsedPlan? plan = null;
+        var thread = new Thread(() => plan = ShowPlanParser.Parse(xml), 8 * 1024 * 1024);
+        thread.Start();
+        thread.Join();
+
+        Assert.NotNull(plan);
+        Assert.NotNull(plan!.ParseError);
+        Assert.Contains("depth limit", plan.ParseError);
+    }
+
+    /// <summary>
+    /// And the same in reverse for the cursor shape: carrying depth through cursor operation
+    /// bodies must not overcount and reject legitimate nesting. Every alternating level below
+    /// the limit still parses, attached to the right container, all the way down.
+    /// </summary>
+    [Fact]
+    public void CursorProcedureNestingBelowTheDepthLimitStillParsesEveryLevel()
+    {
+        const int depth = 50;
+
+        var plan = ShowPlanParser.Parse(NestedCursorProcedurePlan(depth));
+
+        Assert.Null(plan.ParseError);
+        var stmt = Assert.Single(Assert.Single(plan.Batches).Statements);
+        var cursorLevels = 0;
+        var procLevels = 0;
+        while (true)
+        {
+            if (stmt.UdfPlans.Count == 1)
+            {
+                cursorLevels++;
+                stmt = Assert.Single(stmt.UdfPlans[0].Statements);
+            }
+            else if (stmt.StoredProcPlan is not null)
+            {
+                procLevels++;
+                stmt = Assert.Single(stmt.StoredProcPlan.Statements);
+            }
+            else
+            {
+                break;
+            }
+        }
+        Assert.Equal(depth / 2, cursorLevels);
+        Assert.Equal(depth / 2, procLevels);
+    }
+
     [Fact]
     public void SynchronousParseRejectsOversizedInput()
     {
@@ -105,6 +167,37 @@ public sealed class ShowPlanParserLimitsTests
         xml.Append("<StmtSimple StatementText=\"SELECT 1\" />");
         for (var level = 0; level < levels; level++)
             xml.Append("</Statements></StoredProc></StmtSimple>");
+        xml.Append("</Statements></Batch></BatchSequence></ShowPlanXML>");
+        return xml.ToString();
+    }
+
+    /// <summary>
+    /// Alternating levels of StmtCursor &gt; CursorPlan &gt; Operation &gt; UDF &gt; Statements
+    /// and StmtSimple &gt; StoredProc &gt; Statements around one innermost bare statement, so the
+    /// depth counter has to survive a hand-off between the cursor branch's descent (#491) and
+    /// ParseStatement's (#456/#484) at every second boundary. Each cursor Operation carries the
+    /// QueryPlan the schema requires — the branch only builds a statement (the sub-plan's attach
+    /// point) for an operation that has one.
+    /// </summary>
+    private static string NestedCursorProcedurePlan(int levels)
+    {
+        var xml = new StringBuilder(
+            "<ShowPlanXML xmlns=\"http://schemas.microsoft.com/sqlserver/2004/07/showplan\"><BatchSequence><Batch><Statements>");
+        for (var level = 0; level < levels; level++)
+        {
+            if (level % 2 == 0)
+                xml.Append("<StmtCursor StatementText=\"DECLARE c CURSOR\"><CursorPlan CursorName=\"c\"><Operation OperationType=\"FetchQuery\"><QueryPlan><RelOp NodeId=\"0\" /></QueryPlan><UDF ProcName=\"f\"><Statements>");
+            else
+                xml.Append("<StmtSimple StatementText=\"EXEC p\"><StoredProc ProcName=\"p\"><Statements>");
+        }
+        xml.Append("<StmtSimple StatementText=\"SELECT 1\" />");
+        for (var level = levels - 1; level >= 0; level--)
+        {
+            if (level % 2 == 0)
+                xml.Append("</Statements></UDF></Operation></CursorPlan></StmtCursor>");
+            else
+                xml.Append("</Statements></StoredProc></StmtSimple>");
+        }
         xml.Append("</Statements></Batch></BatchSequence></ShowPlanXML>");
         return xml.ToString();
     }

--- a/tests/PlanViewer.Core.Tests/SingleInstanceTests.cs
+++ b/tests/PlanViewer.Core.Tests/SingleInstanceTests.cs
@@ -1,0 +1,216 @@
+using System.IO;
+using System.Linq;
+using Avalonia.Controls;
+using PlanViewer.App;
+using PlanViewer.App.Controls;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #489: two Studio instances each hold a whole-file AppSettings snapshot and Save writes
+/// the whole file, so the instance that exits second silently clobbers the other's
+/// open_tabs and every other setting. The fix makes a bare second launch hand a
+/// "surface yourself" sentinel to the running instance over the existing OpenFile pipe
+/// (with-file launches already forwarded), with <c>--new-instance</c> as the deliberate
+/// escape hatch.
+///
+/// <para>The process-level halves — the named mutex in Program.Main and the exit of the
+/// non-owning launch — cannot run under this harness, which boots App directly and never
+/// enters Main; they are verified by inspection and commented in Program.cs. What CAN be
+/// pinned, and is here, are the two seams everything else leans on: the receiver's message
+/// grammar (sentinel vs file path vs garbage, including the property that makes the
+/// sentinel safe to send to a pre-#489 receiver) and the argv scrubbing that keeps the
+/// flag from shadowing a real file argument.</para>
+/// </summary>
+public class SingleInstanceTests
+{
+    /* ---- Classify: the receiver's message grammar ---------------------------------- */
+
+    [Fact]
+    public void TheActivationSentinelClassifiesAsActivate()
+    {
+        Assert.Equal(
+            SingleInstance.PipeMessage.Activate,
+            SingleInstance.Classify(SingleInstance.ActivateSentinel));
+    }
+
+    [Fact]
+    public void AnExistingFileClassifiesAsOpenFile()
+    {
+        var path = TempSql("SELECT 1;");
+        try
+        {
+            Assert.Equal(SingleInstance.PipeMessage.OpenFile, SingleInstance.Classify(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// A path that stopped existing between send and receive was dropped silently before
+    /// #489 and must still be — the receiver has no way to open it and no business
+    /// guessing.
+    /// </summary>
+    [Fact]
+    public void AMissingPathClassifiesAsIgnore()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), "never_written.sqlplan");
+        Assert.Equal(SingleInstance.PipeMessage.Ignore, SingleInstance.Classify(missing));
+    }
+
+    [Fact]
+    public void BlankLinesClassifyAsIgnore()
+    {
+        Assert.Equal(SingleInstance.PipeMessage.Ignore, SingleInstance.Classify(null));
+        Assert.Equal(SingleInstance.PipeMessage.Ignore, SingleInstance.Classify(string.Empty));
+        Assert.Equal(SingleInstance.PipeMessage.Ignore, SingleInstance.Classify("   "));
+    }
+
+    /// <summary>
+    /// The entire backward-compatibility story of the sentinel, pinned: a pre-#489
+    /// receiver's only guard is <c>File.Exists(line)</c>, so the sentinel is safe to send
+    /// to an old running build exactly as long as it can never name an existing file. The
+    /// double-colons are illegal in Windows file names by design; if someone ever
+    /// "tidies" the token into something path-representable, this fails and points here.
+    /// </summary>
+    [Fact]
+    public void TheSentinelCanNeverBeMistakenForAFileByAnOldReceiver()
+    {
+        Assert.False(
+            File.Exists(SingleInstance.ActivateSentinel),
+            "an old receiver File.Exists-guards every pipe line, so the sentinel must never resolve to a real file");
+    }
+
+    /* ---- StripNewInstanceFlag: argv scrubbing -------------------------------------- */
+
+    /// <summary>
+    /// "PerformanceStudio.exe --new-instance file.sqlplan" must still open the file: the
+    /// flag disappears and the path keeps its place as the first real argument, because
+    /// OpenFromStartupArgs only ever looks at args[1].
+    /// </summary>
+    [Fact]
+    public void TheNewInstanceFlagIsRemovedAndTheFileArgSurvives()
+    {
+        var raw = new[] { "PerformanceStudio.exe", "--new-instance", @"C:\plans\slow.sqlplan" };
+
+        var scrubbed = SingleInstance.StripNewInstanceFlag(raw);
+
+        Assert.Equal(new[] { "PerformanceStudio.exe", @"C:\plans\slow.sqlplan" }, scrubbed);
+        Assert.True(SingleInstance.NewInstanceRequested(raw));
+    }
+
+    [Fact]
+    public void TheFlagIsRecognizedInAnyCase()
+    {
+        var raw = new[] { "PerformanceStudio.exe", "--NEW-INSTANCE" };
+
+        Assert.True(SingleInstance.NewInstanceRequested(raw));
+        Assert.Equal(new[] { "PerformanceStudio.exe" }, SingleInstance.StripNewInstanceFlag(raw));
+    }
+
+    /// <summary>
+    /// The overwhelmingly common argv has no flag in it, and scrubbing must be invisible
+    /// there — same contents, same order, nothing else filtered.
+    /// </summary>
+    [Fact]
+    public void ArgvWithoutTheFlagPassesThroughUntouched()
+    {
+        var raw = new[] { "PerformanceStudio.exe", @"C:\plans\slow.sqlplan" };
+
+        Assert.Equal(raw, SingleInstance.StripNewInstanceFlag(raw));
+        Assert.False(SingleInstance.NewInstanceRequested(raw));
+    }
+
+    /* ---- The window-side dispatch -------------------------------------------------- */
+
+    /// <summary>
+    /// What a bare second launch's sentinel actually buys the user: the running window
+    /// comes back from minimized. Activate() is also called but has nothing observable
+    /// headlessly; the state restore is the part that can silently regress.
+    /// </summary>
+    [Fact]
+    public void ASentinelDispatchRestoresAMinimizedWindow()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var window = new MainWindow();
+            window.WindowState = WindowState.Minimized;
+
+            window.DispatchPipeMessage(
+                SingleInstance.PipeMessage.Activate, SingleInstance.ActivateSentinel);
+
+            Assert.Equal(WindowState.Normal, window.WindowState);
+        });
+    }
+
+    /// <summary>
+    /// The path every existing sender relies on — the SSMS extension and a second launch
+    /// handing over its file — still lands the file in a tab, and now also surfaces a
+    /// minimized window instead of loading into one that stays in the taskbar.
+    /// </summary>
+    [Fact]
+    public void AFileDispatchOpensTheFileAndRestoresAMinimizedWindow()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1 AS from_pipe;");
+            try
+            {
+                var window = new MainWindow();
+                window.WindowState = WindowState.Minimized;
+                var queryTabsBefore = QueryTabs(window).Count();
+
+                window.DispatchPipeMessage(SingleInstance.PipeMessage.OpenFile, path);
+
+                Assert.Equal(queryTabsBefore + 1, QueryTabs(window).Count());
+                Assert.Equal(path, ((QuerySessionControl)QueryTabs(window).Last().Content!).SourceFilePath);
+                Assert.Equal(WindowState.Normal, window.WindowState);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The end-to-end argv property, through the real startup router: the constructor
+    /// consumes raw <c>Environment.GetCommandLineArgs()</c>, so OpenFromStartupArgs must
+    /// scrub the flag itself — Program.Main's scrubbed copy never reaches it. With the
+    /// flag sitting where the file used to be, the file behind it still opens.
+    /// </summary>
+    [Fact]
+    public void OpenFromStartupArgsOpensTheFileBehindTheNewInstanceFlag()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1 AS behind_the_flag;");
+            try
+            {
+                var window = new MainWindow();
+                var queryTabsBefore = QueryTabs(window).Count();
+
+                window.OpenFromStartupArgs(new[] { "PerformanceStudio.exe", "--new-instance", path });
+
+                Assert.Equal(queryTabsBefore + 1, QueryTabs(window).Count());
+                Assert.Equal(path, ((QuerySessionControl)QueryTabs(window).Last().Content!).SourceFilePath);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    private static string TempSql(string text)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+        File.WriteAllText(path, text);
+        return path;
+    }
+
+    private static System.Collections.Generic.IEnumerable<TabItem> QueryTabs(MainWindow window) =>
+        window.MainTabControl.Items.OfType<TabItem>().Where(t => t.Content is QuerySessionControl);
+}

--- a/tests/PlanViewer.Core.Tests/SingleInstanceTests.cs
+++ b/tests/PlanViewer.Core.Tests/SingleInstanceTests.cs
@@ -71,16 +71,33 @@ public class SingleInstanceTests
     /// <summary>
     /// The entire backward-compatibility story of the sentinel, pinned: a pre-#489
     /// receiver's only guard is <c>File.Exists(line)</c>, so the sentinel is safe to send
-    /// to an old running build exactly as long as it can never name an existing file. The
-    /// double-colons are illegal in Windows file names by design; if someone ever
-    /// "tidies" the token into something path-representable, this fails and points here.
+    /// to an old running build exactly as long as it can never name an existing file.
+    ///
+    /// <para>Pinned as a STRING property, not with File.Exists — the gate review caught
+    /// that a File.Exists assertion is vacuous on the ubuntu CI runner, where ':' is a
+    /// legal filename character and the check only proves no such file sits in the test
+    /// CWD. What actually guarantees old-Windows-receiver safety is the colon, which
+    /// Windows rejects in file names; asserting the characters directly means "tidying"
+    /// the token into a path-representable word fails this test on every platform. An old
+    /// LINUX receiver next to an adversarially created "::activate::" file remains the
+    /// accepted floor (new receivers classify the sentinel before File.Exists, so only
+    /// pre-#489 builds are exposed, and only until they restart).</para>
     /// </summary>
     [Fact]
-    public void TheSentinelCanNeverBeMistakenForAFileByAnOldReceiver()
+    public void TheSentinelCanNeverBeMistakenForAFileByAnOldWindowsReceiver()
     {
-        Assert.False(
-            File.Exists(SingleInstance.ActivateSentinel),
-            "an old receiver File.Exists-guards every pipe line, so the sentinel must never resolve to a real file");
+        Assert.Contains(':', SingleInstance.ActivateSentinel);
+        Assert.StartsWith("::", SingleInstance.ActivateSentinel, StringComparison.Ordinal);
+        Assert.EndsWith("::", SingleInstance.ActivateSentinel, StringComparison.Ordinal);
+
+        /* Belt and braces for the platform where the guarantee lives: on Windows the
+           token must actually be rejected by the file-name rules, not just assumed to be. */
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Contains(
+                SingleInstance.ActivateSentinel,
+                c => Path.GetInvalidFileNameChars().Contains(c));
+        }
     }
 
     /* ---- StripNewInstanceFlag: argv scrubbing -------------------------------------- */

--- a/tests/PlanViewer.Core.Tests/SingleInstanceTests.cs
+++ b/tests/PlanViewer.Core.Tests/SingleInstanceTests.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.IO;
 using System.Linq;
 using Avalonia.Controls;
@@ -219,6 +220,34 @@ public class SingleInstanceTests
                 File.Delete(path);
             }
         });
+    }
+
+    /// <summary>
+    /// The named-mutex machinery itself, exercised on whatever platform the suite runs on.
+    ///
+    /// <para>The gate review's point: Program.Main's catch-all degrades a throwing mutex to
+    /// "run fully" — the right call, but if named mutexes ever break wholesale on a platform
+    /// (the Unix shim backs them with files under /tmp, and PlatformNotSupportedException is
+    /// the classic wholesale failure), single-instancing would silently no-op there and the
+    /// #489 clobber would be back with no symptom. This runs on the ubuntu CI runner on every
+    /// push, so a platform where creating or re-opening a named mutex throws fails HERE,
+    /// loudly, instead of degrading invisibly in the field. In-process rather than
+    /// cross-process (the harness cannot spawn app instances), which still traverses the
+    /// named create and second-open paths the shim has to serve; macOS has no CI leg, so the
+    /// one-time bare-double-launch smoke there is a release-checklist item, not a test.</para>
+    /// </summary>
+    [Fact]
+    public void NamedMutexMachineryWorksOnThisPlatform()
+    {
+        // A unique name per run: colliding with a real Studio instance on a dev machine
+        // (or a parallel test run) would turn this into a flake about unrelated state.
+        var name = $"{SingleInstance.MutexName}_selftest_{Guid.NewGuid():N}";
+
+        using var first = new Mutex(initiallyOwned: true, name, out var createdFirst);
+        Assert.True(createdFirst, "a fresh name must be created, not found");
+
+        using var second = new Mutex(initiallyOwned: true, name, out var createdSecond);
+        Assert.False(createdSecond, "a second open of the same name must see the existing mutex");
     }
 
     private static string TempSql(string text)

--- a/tests/PlanViewer.Core.Tests/StoredProcedurePlanTests.cs
+++ b/tests/PlanViewer.Core.Tests/StoredProcedurePlanTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using PlanViewer.Core.Models;
 using PlanViewer.Core.Output;
 using PlanViewer.Core.Services;
 
@@ -102,5 +103,130 @@ public class StoredProcedurePlanTests
         Assert.Equal(
             plan.Batches.SelectMany(b => b.Statements).Count(),
             PlanStatements.EnumerateAll(plan).Count());
+    }
+
+    /// <summary>
+    /// The half of #456 the review caught: the ANALYZER descended into the body, the SCORER did
+    /// not, so body warnings existed with MaxBenefitPercent forever null. The UI sorts
+    /// unquantified warnings below quantified ones, which buried every finding of an EXEC plan —
+    /// present in the list, missing its "up to X%", ranked last.
+    ///
+    /// <para>Non-SARGable Predicate is the probe because on an estimated plan it is scored
+    /// unconditionally (operator cost percent fallback), so the same warning on an outer
+    /// statement always carries a value — null on a body statement can only mean the scorer
+    /// never got there.</para>
+    /// </summary>
+    [Fact]
+    public void ProcedureBodyWarningsAreBenefitScored()
+    {
+        var plan = PlanTestHelper.LoadAndAnalyze("exec_stored_procedure_plan.sqlplan");
+
+        var bodyWarnings = PlanStatements.EnumerateAll(plan)
+            .Skip(1) // everything after the EXEC lives inside the procedure body
+            .SelectMany(PlanTestHelper.AllNodeWarnings)
+            .Where(w => w.WarningType == "Non-SARGable Predicate")
+            .ToList();
+
+        Assert.NotEmpty(bodyWarnings);
+        Assert.All(bodyWarnings, w => Assert.NotNull(w.MaxBenefitPercent));
+    }
+
+    /// <summary>
+    /// The wait-stats half of the same scorer gap, on a synthetic plan because the fixture is an
+    /// estimated plan and carries no wait stats: a body statement's waits were never scored and
+    /// never emitted as "Wait:" warnings, so an actual EXEC plan lost its wait analysis entirely.
+    /// Serial statement, 400ms of PAGEIOLATCH against 1000ms elapsed — the simple-ratio path —
+    /// so the expected 40% is arithmetic, not a golden value.
+    /// </summary>
+    [Fact]
+    public void ProcedureBodyWaitStatsAreScoredAndSurfaced()
+    {
+        var body = new PlanStatement
+        {
+            StatementText = "SELECT o.Id FROM dbo.Orders AS o;",
+            QueryTimeStats = new QueryTimeInfo { CpuTimeMs = 100, ElapsedTimeMs = 1_000 },
+            WaitStats = { new WaitStatInfo { WaitType = "PAGEIOLATCH_SH", WaitTimeMs = 400, WaitCount = 10 } }
+        };
+        var plan = new ParsedPlan
+        {
+            Batches =
+            {
+                new PlanBatch
+                {
+                    Statements =
+                    {
+                        new PlanStatement
+                        {
+                            StatementText = "EXEC dbo.Waits;",
+                            StoredProcPlan = new FunctionPlanInfo
+                            {
+                                ProcName = "dbo.Waits",
+                                Statements = { body }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        BenefitScorer.Score(plan);
+
+        var waitWarning = Assert.Single(body.PlanWarnings, w => w.WarningType == "Wait: PAGEIOLATCH_SH");
+        Assert.NotNull(waitWarning.MaxBenefitPercent);
+        Assert.Equal(40.0, waitWarning.MaxBenefitPercent!.Value, 1);
+    }
+
+    /// <summary>
+    /// The other pass the review caught walking batch.Statements: a user's severity override
+    /// applied to a warning on the outer batch and silently did not apply to the identical
+    /// warning inside the body. Rule 12 is Non-SARGable Predicate, which the body carries; its
+    /// default severity is asserted first so the Critical below can only have come from the
+    /// override being applied, not from the rule itself.
+    /// </summary>
+    [Fact]
+    public void SeverityOverridesReachProcedureBodyStatements()
+    {
+        static List<PlanWarning> BodyNonSargable(ParsedPlan plan) =>
+            PlanStatements.EnumerateAll(plan)
+                .Skip(1)
+                .SelectMany(PlanTestHelper.AllNodeWarnings)
+                .Where(w => w.WarningType == "Non-SARGable Predicate")
+                .ToList();
+
+        var byDefault = BodyNonSargable(PlanTestHelper.LoadAndAnalyze("exec_stored_procedure_plan.sqlplan"));
+        Assert.NotEmpty(byDefault);
+        Assert.All(byDefault, w => Assert.Equal(PlanWarningSeverity.Warning, w.Severity));
+
+        var config = new AnalyzerConfig
+        {
+            Rules = new RulesConfig { SeverityOverrides = { [12] = "Critical" } }
+        };
+        var overridden = BodyNonSargable(
+            PlanTestHelper.LoadAndAnalyzeWithConfig("exec_stored_procedure_plan.sqlplan", config));
+
+        Assert.NotEmpty(overridden);
+        Assert.All(overridden, w => Assert.Equal(PlanWarningSeverity.Critical, w.Severity));
+    }
+
+    /// <summary>
+    /// The context-carrying enumeration exists for UIs that list body statements to a person:
+    /// a row has to say which module its statement came from. It must be the SAME walk as
+    /// EnumerateAll — same statements, same order — because two traversals that must agree is
+    /// the arrangement that produced #455 in the first place.
+    /// </summary>
+    [Fact]
+    public void BodyStatementsKnowTheirContainingModule()
+    {
+        var plan = PlanTestHelper.LoadAndAnalyze("exec_stored_procedure_plan.sqlplan");
+
+        var entries = PlanStatements.EnumerateAllWithContainer(plan).ToList();
+
+        Assert.True(entries.Count > 1);
+        Assert.Null(entries[0].ContainerPath); // the EXEC itself lives in the outer batch
+        Assert.All(entries.Skip(1), e => Assert.Equal("dbo.ReproProc", e.ContainerPath));
+
+        Assert.Equal(
+            PlanStatements.EnumerateAll(plan),
+            entries.Select(e => e.Statement));
     }
 }

--- a/tests/PlanViewer.Core.Tests/TestHostIsolationTests.cs
+++ b/tests/PlanViewer.Core.Tests/TestHostIsolationTests.cs
@@ -1,0 +1,85 @@
+using PlanViewer.App;
+using PlanViewer.App.Services;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #451: the headless harness boots the REAL App, and before these seams existed the real
+/// startup side effects ran inside the test host — every local <c>dotnet test</c> rewrote
+/// HKCU's .sqlplan association to point at the test runner, restored and then destroyed the
+/// developer's saved open-tab list, evicted real Recent Plans entries with fixture paths,
+/// held the app's single named-pipe slot, and hit GitHub with an update check per
+/// constructed window. All confirmed live on a dev machine.
+///
+/// These tests pin the two seams that stop that — the settings redirection and the
+/// <see cref="AppRuntimeMode.IsTestHost"/> gate — so the next person's MainWindow test
+/// cannot silently reach back into the machine.
+/// </summary>
+public class TestHostIsolationTests
+{
+    /// <summary>
+    /// The guard against a test wiping real user state: with the harness active, the
+    /// effective settings path is under the run-scoped temp root, never the real profile,
+    /// and a save lands there.
+    ///
+    /// <para>Runs on the UI thread even though it shows nothing, because every other
+    /// mutation of the shared cached <see cref="AppSettings"/> happens there — serializing
+    /// it off-thread could race a seeding test's list mutation mid-write.</para>
+    /// </summary>
+    [Fact]
+    public void SettingsReadsAndWritesLandInTheRunScopedTempDirectory()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var realProfileDir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "PerformanceStudio");
+
+            Assert.NotEqual(string.Empty, HeadlessUi.SettingsRedirectRoot);
+            Assert.StartsWith(
+                HeadlessUi.SettingsRedirectRoot,
+                AppSettingsService.SettingsFilePath,
+                StringComparison.OrdinalIgnoreCase);
+            Assert.False(
+                AppSettingsService.SettingsFilePath.StartsWith(realProfileDir, StringComparison.OrdinalIgnoreCase),
+                "the test host must never read or write the real appsettings.json");
+
+            /* Save(Load()) rather than Save(new AppSettings()): Save caches the instance it
+               is given, and swapping in a fresh one would yank state out from under a test
+               that had just seeded the shared cached instance. This is the write that used
+               to land in the developer's real profile. */
+            AppSettingsService.Save(AppSettingsService.Load());
+            Assert.True(
+                File.Exists(AppSettingsService.SettingsFilePath),
+                "a save under the harness must land in the redirected file");
+        });
+    }
+
+    /// <summary>
+    /// A MainWindow built under the harness launches none of the process-external startup
+    /// services. The flags are set by the launch methods themselves, not by the gate, so
+    /// this fails honestly if a future change starts one of them through a new path.
+    /// </summary>
+    [Fact]
+    public void AWindowBuiltUnderTheHarnessLaunchesNoStartupServices()
+    {
+        HeadlessUi.Run(() =>
+        {
+            // Pins the ordering the whole design leans on: the module initializer flipped
+            // the gate before the first App (and this window) booted.
+            Assert.True(AppRuntimeMode.IsTestHost);
+
+            var window = new MainWindow();
+
+            Assert.False(
+                window.PipeServerStarted,
+                "the pipe server would hold the machine-wide SQLPerformanceStudio_OpenFile slot and never release it");
+            Assert.False(
+                window.StartupUpdateCheckStarted,
+                "the update check would hit GitHub once per constructed window");
+            Assert.False(
+                window.McpServerStartAttempted,
+                "starting MCP would read the user's real ~/.planview settings and could bind a real port");
+        });
+    }
+}

--- a/tests/PlanViewer.Core.Tests/TestHostIsolationTests.cs
+++ b/tests/PlanViewer.Core.Tests/TestHostIsolationTests.cs
@@ -44,6 +44,19 @@ public class TestHostIsolationTests
                 AppSettingsService.SettingsFilePath.StartsWith(realProfileDir, StringComparison.OrdinalIgnoreCase),
                 "the test host must never read or write the real appsettings.json");
 
+            /* #496: the scratch buffer directory rides the same redirection, and the stakes
+               are higher than the settings file's — the persistence tests write real buffer
+               FILES and the startup sweep DELETES unreferenced ones, so a scratch directory
+               that escaped the redirect would have every MainWindow test collecting the
+               developer's real crash-protected queries as orphans. */
+            Assert.StartsWith(
+                HeadlessUi.SettingsRedirectRoot,
+                AppSettingsService.ScratchDirectory,
+                StringComparison.OrdinalIgnoreCase);
+            Assert.False(
+                AppSettingsService.ScratchDirectory.StartsWith(realProfileDir, StringComparison.OrdinalIgnoreCase),
+                "the test host must never touch the real scratch buffers — the orphan sweep deletes files there");
+
             /* Save(Load()) rather than Save(new AppSettings()): Save caches the instance it
                is given, and swapping in a fresh one would yank state out from under a test
                that had just seeded the shared cached instance. This is the write that used

--- a/tests/PlanViewer.Core.Tests/UpdateRestartGuardTests.cs
+++ b/tests/PlanViewer.Core.Tests/UpdateRestartGuardTests.cs
@@ -1,0 +1,154 @@
+using System.IO;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using PlanViewer.App;
+using PlanViewer.App.Controls;
+using PlanViewer.App.Services;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// The About window's Velopack "Restart Now" calls ApplyUpdatesAndRestart, which exits the
+/// process without ever raising Closing — so the unsaved-changes walk (#462/#473) never ran
+/// on that route and dirty edits were discarded without a question, and OnClosed's session
+/// save never ran either, so the relaunched app restored nothing (RestoreOpenPlans had
+/// already cleared the saved list at startup). The fix reuses the close path's walk,
+/// <see cref="MainWindow.ConfirmAllUnsavedWorkAsync"/>, and persists the open tabs before
+/// the restart.
+///
+/// <para>Same testing shape as UnsavedQueryChangesTests: nothing headless can click a
+/// dialog's buttons, so what is pinned is the walk itself — a clean window answers yes
+/// without raising anything, and a dirty one stops, asks, and takes a dismissal as no.</para>
+/// </summary>
+public class UpdateRestartGuardTests
+{
+    [Fact]
+    public void ACleanWindowConfirmsImmediatelyWithoutRaisingAPrompt()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                var task = window.ConfirmAllUnsavedWorkAsync();
+
+                /* Nothing dirty means the walk has nobody to ask, so the task must finish on
+                   the spot. A prompt would leave it pending forever headlessly — completing
+                   at all is the proof that no dialog went up. */
+                Assert.True(task.IsCompletedSuccessfully, "a clean window has nothing to ask about");
+                Assert.True(task.Result);
+                Assert.Empty(window.OwnedWindows);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        });
+    }
+
+    [Fact]
+    public void ADirtyTabHoldsTheRestartAndADismissedPromptRefusesIt()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            MainWindow? window = null;
+            QuerySessionControl? session = null;
+            try
+            {
+                window = new MainWindow();
+                window.Show(); // the prompt's ShowDialog needs a visible owner, headless or not
+                window.LoadSqlFile(path);
+
+                var tab = window.MainTabControl.Items.OfType<TabItem>()
+                    .Last(t => t.Content is QuerySessionControl);
+                session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 2; -- unsaved work";
+
+                var task = window.ConfirmAllUnsavedWorkAsync();
+                Dispatcher.UIThread.RunJobs();
+
+                /* The restart cannot go ahead while the question is open. */
+                Assert.False(task.IsCompleted);
+                var prompt = Assert.Single(window.OwnedWindows);
+
+                /* Dismissing the prompt is Cancel, and Cancel has to refuse the restart with
+                   everything intact: no save, no close, and no latch set behind the caller's
+                   back — the About window aborts and the app carries on as it was. */
+                prompt.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.True(task.IsCompleted, "the refused answer still has to arrive");
+                Assert.False(task.Result);
+                Assert.True(session.IsDirty, "nothing was written and nothing was discarded");
+                Assert.True(window.IsVisible, "the walk must not close anything on its own");
+                Assert.Contains(tab, window.MainTabControl.Items.OfType<TabItem>());
+            }
+            finally
+            {
+                PutAway(window, session);
+                File.Delete(path);
+            }
+        });
+    }
+
+    [Fact]
+    public void PersistSessionForRestartWritesTheOpenTabsDown()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            var settings = AppSettingsService.Load();
+            try
+            {
+                var window = new MainWindow();
+                window.LoadSqlFile(path);
+
+                /* OnClosed does this on an ordinary shutdown; ApplyUpdatesAndRestart exits
+                   without one, and RestoreOpenPlans cleared the list at startup — so the
+                   restart path has to write the tabs down itself or the updated app comes
+                   back empty-handed. Load returns the process-wide cached instance, the same
+                   object the window writes through (see RestoreQueryTabsTests.Seed). */
+                window.PersistSessionForRestart();
+
+                Assert.Contains(path, settings.OpenTabs);
+            }
+            finally
+            {
+                /* Leave nothing seeded for the next test's MainWindow to restore. */
+                settings.OpenTabs.Clear();
+                AppSettingsService.Save(settings);
+                File.Delete(path);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Same job as DetachedUnsavedChangesTests.PutAway, for the main window: prompts closed,
+    /// session settled, window shut — from a finally, because the run where it matters is the
+    /// run where an assertion above it failed (#474).
+    /// </summary>
+    private static void PutAway(MainWindow? window, QuerySessionControl? session)
+    {
+        if (window == null)
+            return;
+
+        foreach (var prompt in window.OwnedWindows.ToList())
+            prompt.Close();
+
+        session?.MarkClean();
+        window.Close();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static string TempSql(string text)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+        File.WriteAllText(path, text);
+        return path;
+    }
+}

--- a/tests/PlanViewer.Core.Tests/WarningSourceTests.cs
+++ b/tests/PlanViewer.Core.Tests/WarningSourceTests.cs
@@ -80,6 +80,59 @@ public class WarningSourceTests
         Assert.DoesNotContain("Non-SARGable Predicate [SQL Server]", text);
     }
 
+    /// <summary>
+    /// The [legacy] badge exists to mark OUR rules that predate the benefit-scoring framework
+    /// (#215) — a migration status for inferences of ours. "Implicit Conversion" is rule 29's
+    /// entry on that list AND the type the parser stamps on the engine's own PlanAffectingConvert
+    /// record, and the legacy pass matched by type name alone — so the engine's statement of fact
+    /// rendered "[SQL Server] [legacy]", as if the engine's record were an un-migrated rule
+    /// awaiting rework. Legacy status is a fact about our rules; nothing the engine said can
+    /// have it.
+    /// </summary>
+    [Fact]
+    public void TheEnginesWarningsAreNeverMarkedLegacy()
+    {
+        var plan = PlanTestHelper.LoadAndAnalyze("convert_implicit_plan.sqlplan");
+
+        var engineWarnings = PlanTestHelper.AllWarnings(plan)
+            .Where(w => w.Source == PlanWarningSource.SqlServer)
+            .ToList();
+
+        Assert.NotEmpty(engineWarnings);
+        Assert.All(engineWarnings, w => Assert.False(w.IsLegacy,
+            $"\"{w.WarningType}\" is the engine's record, not an un-migrated rule of ours"));
+    }
+
+    /// <summary>
+    /// The same name collision, other pass: TryOverrideSeverity finds rule numbers by type-name
+    /// matching, so a user's rule 29 override re-badged the ENGINE's conversion record — and the
+    /// Contains matching spread it further (every engine Spill variant matched rule 7, "Memory
+    /// Grant" rule 9). A rule severity override is an opinion about our inference; what the engine
+    /// recorded keeps the severity the parser gave it.
+    /// </summary>
+    [Fact]
+    public void ASeverityOverrideForRule29DoesNotRebadgeTheEnginesWarnings()
+    {
+        var untouched = PlanTestHelper.LoadAndAnalyze("convert_implicit_plan.sqlplan");
+        var overridden = PlanTestHelper.LoadAndAnalyzeWithConfig(
+            "convert_implicit_plan.sqlplan",
+            new AnalyzerConfig
+            {
+                /* Info: the parser only ever gives these Warning or Critical, so a pre-fix
+                   misroute is a visible severity change whichever kind the fixture carries. */
+                Rules = new RulesConfig { SeverityOverrides = { [29] = "Info" } }
+            });
+
+        var engineBefore = PlanTestHelper.WarningsOfType(untouched, "Implicit Conversion");
+        var engineAfter = PlanTestHelper.WarningsOfType(overridden, "Implicit Conversion");
+
+        Assert.NotEmpty(engineAfter);
+        Assert.All(engineAfter, w => Assert.Equal(PlanWarningSource.SqlServer, w.Source));
+        Assert.Equal(
+            engineBefore.Select(w => w.Severity),
+            engineAfter.Select(w => w.Severity));
+    }
+
     /// <summary>The JSON and MCP consumers get it as a field rather than having to parse the tag out.</summary>
     [Fact]
     public void TheJsonOutputCarriesTheSource()

--- a/tests/PlanViewer.Core.Tests/WindowCloseReentryTests.cs
+++ b/tests/PlanViewer.Core.Tests/WindowCloseReentryTests.cs
@@ -14,6 +14,12 @@ namespace PlanViewer.Core.Tests;
 /// used to start a second concurrent walk: duplicate prompts about the same tab, and a Cancel
 /// answered to one walk that the other never heard. Same reentrancy class as the About
 /// window's update link (#485 review), and the same walk-in-progress latch closes it.
+///
+/// <para><b>Both guards, not one.</b> <c>DetachedWindowHelper</c> carries its own copy of the
+/// latch for its own copy of the gap, and the two are separate code with separate state. Only
+/// the MainWindow half was pinned when the latch landed: deleting the detached
+/// <c>closeGuardPending</c> check outright left this class green, which is how a latch gets
+/// tidied away by someone who reasonably believes the tests are watching it.</para>
 /// </summary>
 public class WindowCloseReentryTests
 {
@@ -72,6 +78,80 @@ public class WindowCloseReentryTests
                     session?.MarkClean();
                     Dispatcher.UIThread.RunJobs();
                     window.Close(); // nothing dirty now, so this one goes through
+                    Dispatcher.UIThread.RunJobs();
+                }
+
+                File.Delete(path);
+            }
+        });
+    }
+
+    [Fact]
+    public void ASecondCloseOfADetachedWindowDoesNotStackASecondPrompt()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            MainWindow? window = null;
+            Window? detached = null;
+            QuerySessionControl? session = null;
+            try
+            {
+                window = new MainWindow();
+                window.Show();
+                window.LoadSqlFile(path);
+
+                var tab = window.MainTabControl.Items.OfType<TabItem>()
+                    .Last(t => t.Content is QuerySessionControl);
+                session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 2; -- unsaved work";
+
+                detached = window.DetachTabToWindow(tab)!;
+                Dispatcher.UIThread.RunJobs();
+
+                detached.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.True(detached.IsVisible, "the close is held while the question is up");
+                Assert.Single(detached.OwnedWindows);
+
+                /* The second X. The guard's prompt is modal to the detached window, but a Save As
+                   raised from that prompt is not, so this is reachable in the real app. */
+                detached.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.Single(detached.OwnedWindows);
+                Assert.True(detached.IsVisible);
+
+                /* Dismissing is Cancel: the window stays, and the latch has to clear with it or
+                   the X is dead for the rest of that window's life. */
+                detached.OwnedWindows.Single().Close();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.True(detached.IsVisible);
+                Assert.Empty(detached.OwnedWindows);
+
+                detached.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.Single(detached.OwnedWindows); // a fresh close starts a fresh question
+            }
+            finally
+            {
+                if (detached != null)
+                {
+                    foreach (var prompt in detached.OwnedWindows.ToList())
+                        prompt.Close();
+                    session?.MarkClean();
+                    Dispatcher.UIThread.RunJobs();
+                    detached.Close();
+                    Dispatcher.UIThread.RunJobs();
+                }
+
+                if (window != null)
+                {
+                    session?.MarkClean();
+                    window.Close();
                     Dispatcher.UIThread.RunJobs();
                 }
 

--- a/tests/PlanViewer.Core.Tests/WindowCloseReentryTests.cs
+++ b/tests/PlanViewer.Core.Tests/WindowCloseReentryTests.cs
@@ -1,0 +1,89 @@
+using System.IO;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using PlanViewer.App;
+using PlanViewer.App.Controls;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// MainWindow.OnClosing cancels the close and runs the unsaved-work walk asynchronously, and
+/// _closeConfirmed only latches once that walk says yes — so a second close request arriving
+/// WHILE the walk was still asking (a double-clicked X, an Alt+F4 behind a Save As picker)
+/// used to start a second concurrent walk: duplicate prompts about the same tab, and a Cancel
+/// answered to one walk that the other never heard. Same reentrancy class as the About
+/// window's update link (#485 review), and the same walk-in-progress latch closes it.
+/// </summary>
+public class WindowCloseReentryTests
+{
+    [Fact]
+    public void ASecondCloseDuringTheWalkDoesNotStartASecondWalk()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var path = TempSql("SELECT 1;");
+            MainWindow? window = null;
+            QuerySessionControl? session = null;
+            try
+            {
+                window = new MainWindow();
+                window.Show(); // the prompt's ShowDialog needs a visible owner, headless or not
+                window.LoadSqlFile(path);
+
+                var tab = window.MainTabControl.Items.OfType<TabItem>()
+                    .Last(t => t.Content is QuerySessionControl);
+                session = (QuerySessionControl)tab.Content!;
+                session.QueryEditor.Text = "SELECT 2; -- unsaved work";
+
+                window.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.True(window.IsVisible, "the close is held while the question is up");
+                Assert.Single(window.OwnedWindows);
+
+                /* The double-clicked X. Programmatic Close is the same entry: modality only
+                   blocks input, not the API, so OnClosing runs again mid-walk. */
+                window.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.Single(window.OwnedWindows);
+                Assert.True(window.IsVisible);
+
+                /* Dismissing the prompt is Cancel: the walk ends refused, the window stays —
+                   and the latch has to clear with it, or the X is dead for good. */
+                window.OwnedWindows.Single().Close();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.True(window.IsVisible);
+                Assert.Empty(window.OwnedWindows);
+
+                window.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.Single(window.OwnedWindows); // a fresh close starts a fresh walk
+            }
+            finally
+            {
+                if (window != null)
+                {
+                    foreach (var prompt in window.OwnedWindows.ToList())
+                        prompt.Close();
+                    session?.MarkClean();
+                    Dispatcher.UIThread.RunJobs();
+                    window.Close(); // nothing dirty now, so this one goes through
+                    Dispatcher.UIThread.RunJobs();
+                }
+
+                File.Delete(path);
+            }
+        });
+    }
+
+    private static string TempSql(string text)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.sql");
+        File.WriteAllText(path, text);
+        return path;
+    }
+}


### PR DESCRIPTION
Promotes dev to main for the v1.24.0 release: the September hardening line. Fifteen merges since v1.23.0 — the crafted-plan crash fix (#484, live in v1.22/v1.23), the data-loss cluster (#485, #494, #495, #498: update-restart guard, atomic saves, single-instance, continuous session persistence, scratch-buffer survival), proc/cursor-body analysis integration (#486, #493), the web share depth fix completing end to end via the Pages deploy, the minor-findings sweep (#488), test-host isolation (#487), and the version bump (#499).

On merge: release.yml cuts the tag and assets, deploy-web ships the viewer to plans.erikdarling.com, and deploy-planshare re-deploys the API from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvAv72Pwb8czsjDWsCCk7n