### PR TITLE
Fix #503: let a selection cover a section of Human Advice, not just one line

### DIFF
--- a/src/PlanViewer.App/Services/AdviceContentBuilder.NodeLinks.cs
+++ b/src/PlanViewer.App/Services/AdviceContentBuilder.NodeLinks.cs
@@ -196,39 +196,25 @@ internal static partial class AdviceContentBuilder
             var hit = stb.TextLayout.HitTestPoint(point);
             if (!hit.IsInside) return;
 
-            var charIndex = hit.TextPosition;
+            var run = RunAtCharIndex(stb, hit.TextPosition);
+            if (run?.Text == null
+                || run.TextDecorations != Avalonia.Media.TextDecorations.Underline
+                || run.Foreground != LinkBrush)
+                return;
 
-            // Walk through inlines to find which Run the charIndex falls in
-            int runStart = 0;
-            foreach (var inline in stb.Inlines!)
-            {
-                if (inline is Run run && run.Text != null)
-                {
-                    var runEnd = runStart + run.Text.Length;
-                    if (charIndex >= runStart && charIndex < runEnd)
-                    {
-                        if (run.TextDecorations == Avalonia.Media.TextDecorations.Underline
-                            && run.Foreground == LinkBrush)
-                        {
-                            var m = NodeRefRegex.Match(run.Text);
-                            if (m.Success && int.TryParse(m.Groups[1].Value, out var nodeId))
-                            {
-                                e.Handled = true;
+            var m = NodeRefRegex.Match(run.Text);
+            if (!m.Success || !int.TryParse(m.Groups[1].Value, out var nodeId))
+                return;
 
-                                // Clear any text selection and release pointer capture
-                                // to prevent SelectableTextBlock from starting a selection drag
-                                stb.SelectionStart = 0;
-                                stb.SelectionEnd = 0;
-                                e.Pointer.Capture(null);
+            e.Handled = true;
 
-                                onNodeClick(nodeId);
-                            }
-                        }
-                        return;
-                    }
-                    runStart = runEnd;
-                }
-            }
+            // Clear any text selection and release pointer capture
+            // to prevent SelectableTextBlock from starting a selection drag
+            stb.SelectionStart = 0;
+            stb.SelectionEnd = 0;
+            e.Pointer.Capture(null);
+
+            onNodeClick(nodeId);
         }, Avalonia.Interactivity.RoutingStrategies.Tunnel);
 
         // Change cursor on hover over link runs
@@ -242,25 +228,68 @@ internal static partial class AdviceContentBuilder
                 return;
             }
 
-            var charIndex = hit.TextPosition;
-            int runStart = 0;
-            foreach (var inline in stb.Inlines!)
-            {
-                if (inline is Run run && run.Text != null)
-                {
-                    var runEnd = runStart + run.Text.Length;
-                    if (charIndex >= runStart && charIndex < runEnd)
-                    {
-                        stb.Cursor = run.TextDecorations == Avalonia.Media.TextDecorations.Underline
-                            && run.Foreground == LinkBrush
-                            ? HandCursor
-                            : Avalonia.Input.Cursor.Default;
-                        return;
-                    }
-                    runStart = runEnd;
-                }
-            }
-            stb.Cursor = Avalonia.Input.Cursor.Default;
+            var run = RunAtCharIndex(stb, hit.TextPosition);
+            stb.Cursor = run != null
+                && run.TextDecorations == Avalonia.Media.TextDecorations.Underline
+                && run.Foreground == LinkBrush
+                ? HandCursor
+                : Avalonia.Input.Cursor.Default;
         };
+    }
+
+    /// <summary>
+    /// The <see cref="Run"/> covering <paramref name="charIndex"/> in the block's laid-out text, or
+    /// null when the index falls outside every Run.
+    ///
+    /// <para>Walking Runs alone was correct while every block held one line. #503 merges a section's
+    /// lines into a single block separated by LineBreaks, and a LineBreak takes up a position in the
+    /// laid-out text while exposing no Text of its own — so skipping it slides every later Run's
+    /// offset backwards, and a click on a "Node N" past the first line resolves to the wrong run or
+    /// to none.</para>
+    ///
+    /// <para>How much a non-Run inline contributes is derived from the collection's own text rather
+    /// than hardcoded, so this cannot drift if the framework changes what it writes for one.</para>
+    ///
+    /// <para>Internal so a test can check the offset math directly: driving it through a real click
+    /// would mean placing a pointer at a laid-out coordinate, which tests the font more than the
+    /// arithmetic that was wrong.</para>
+    /// </summary>
+    internal static Run? RunAtCharIndex(SelectableTextBlock stb, int charIndex)
+    {
+        var inlines = stb.Inlines;
+        if (inlines == null)
+            return null;
+
+        var runChars = 0;
+        var nonRuns = 0;
+        foreach (var inline in inlines)
+        {
+            if (inline is Run r)
+                runChars += r.Text?.Length ?? 0;
+            else
+                nonRuns++;
+        }
+
+        var perNonRun = nonRuns > 0
+            ? Math.Max(0, (inlines.Text?.Length ?? runChars) - runChars) / nonRuns
+            : 0;
+
+        var start = 0;
+        foreach (var inline in inlines)
+        {
+            if (inline is Run run && run.Text != null)
+            {
+                var end = start + run.Text.Length;
+                if (charIndex >= start && charIndex < end)
+                    return run;
+                start = end;
+            }
+            else
+            {
+                start += perNonRun;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/PlanViewer.App/Services/AdviceContentBuilder.NodeLinks.cs
+++ b/src/PlanViewer.App/Services/AdviceContentBuilder.NodeLinks.cs
@@ -247,8 +247,13 @@ internal static partial class AdviceContentBuilder
     /// offset backwards, and a click on a "Node N" past the first line resolves to the wrong run or
     /// to none.</para>
     ///
-    /// <para>How much a non-Run inline contributes is derived from the collection's own text rather
-    /// than hardcoded, so this cannot drift if the framework changes what it writes for one.</para>
+    /// <para>Rather than assume what a non-Run inline contributes, each Run is located in the text
+    /// the collection actually laid out, searching forward from the end of the previous one. That is
+    /// exact for any interleaving — a LineBreak today, an InlineUIContainer tomorrow — where
+    /// distributing the leftover characters evenly across non-Runs would only hold while they are all
+    /// the same kind, and would go quietly wrong rather than loudly the day they are not. Scanning
+    /// forward rather than from zero is also what keeps repeated text (two runs both reading
+    /// "Node 4") landing on the right one.</para>
     ///
     /// <para>Internal so a test can check the offset math directly: driving it through a real click
     /// would mean placing a pointer at a laid-out coordinate, which tests the font more than the
@@ -260,34 +265,23 @@ internal static partial class AdviceContentBuilder
         if (inlines == null)
             return null;
 
-        var runChars = 0;
-        var nonRuns = 0;
+        var text = inlines.Text ?? "";
+        var cursor = 0;
+
         foreach (var inline in inlines)
         {
-            if (inline is Run r)
-                runChars += r.Text?.Length ?? 0;
-            else
-                nonRuns++;
-        }
+            if (inline is not Run run || string.IsNullOrEmpty(run.Text))
+                continue;
 
-        var perNonRun = nonRuns > 0
-            ? Math.Max(0, (inlines.Text?.Length ?? runChars) - runChars) / nonRuns
-            : 0;
+            var start = text.IndexOf(run.Text, cursor, StringComparison.Ordinal);
+            if (start < 0)
+                return null;
 
-        var start = 0;
-        foreach (var inline in inlines)
-        {
-            if (inline is Run run && run.Text != null)
-            {
-                var end = start + run.Text.Length;
-                if (charIndex >= start && charIndex < end)
-                    return run;
-                start = end;
-            }
-            else
-            {
-                start += perNonRun;
-            }
+            var end = start + run.Text.Length;
+            if (charIndex >= start && charIndex < end)
+                return run;
+
+            cursor = end;
         }
 
         return null;

--- a/src/PlanViewer.App/Services/AdviceContentBuilder.Selection.cs
+++ b/src/PlanViewer.App/Services/AdviceContentBuilder.Selection.cs
@@ -1,0 +1,115 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Media;
+
+namespace PlanViewer.App.Services;
+
+internal static partial class AdviceContentBuilder
+{
+    /// <summary>
+    /// Collects consecutive body lines into a single <see cref="SelectableTextBlock"/> (#503).
+    ///
+    /// <para>Avalonia gives each SelectableTextBlock its own selection and nothing coordinates a drag
+    /// that starts in one and ends in another — the whole API is SelectionStart/SelectionEnd/Copy on
+    /// the individual control. The advice pane used to add one control per line, so a selection could
+    /// never be longer than a line: the reporter could grab a query (one line, one control) but not
+    /// Server Context, Parameters, or Missing indexes, which are several lines each. Copy-all into
+    /// Notepad was the only way to get a piece of it.</para>
+    ///
+    /// <para>Merging the lines of a section into one control makes a drag across those lines a normal
+    /// selection. Structural elements — headers, warning blocks, operator groups, wait-stat bars,
+    /// cards — still flush and stand alone, because they are not text runs and cannot join a text
+    /// block. So selection now spans a section's body rather than the entire window; that is the
+    /// limit of what the framework will do without a selection manager of our own.</para>
+    ///
+    /// <para>Indentation moves from control margins to leading spaces. The pane is monospace
+    /// throughout, so a space is a reliable unit here in a way it would not be in a proportional
+    /// font.</para>
+    /// </summary>
+    private sealed class BodyTextAccumulator
+    {
+        private readonly List<Inline> _pending = new();
+        private bool _hasLine;
+
+        /// <summary>Roughly one monospace character at the pane's 12px body size.</summary>
+        private const double PixelsPerSpace = 6.0;
+
+        public void AddLine(double indentPixels, params Inline[] runs)
+        {
+            if (_hasLine)
+                _pending.Add(new LineBreak());
+            _hasLine = true;
+
+            var spaces = (int)(indentPixels / PixelsPerSpace);
+            if (spaces > 0)
+                _pending.Add(new Run(new string(' ', spaces)));
+
+            _pending.AddRange(runs);
+        }
+
+        public void AddLine(double indentPixels, string text, IBrush? foreground) =>
+            AddLine(indentPixels, new Run(text) { Foreground = foreground });
+
+        /// <summary>
+        /// Folds in the runs a helper already built for a single line — SQL keyword highlighting, the
+        /// SNIFFING marker — instead of letting that line stand alone as its own block.
+        /// </summary>
+        public void AddLine(double indentPixels, SelectableTextBlock built)
+        {
+            if (built.Inlines is { Count: > 0 })
+            {
+                // Moved rather than shared: an Inline belongs to one block at a time.
+                var taken = built.Inlines.ToArray();
+                built.Inlines.Clear();
+                AddLine(indentPixels, taken);
+            }
+            else
+            {
+                AddLine(indentPixels, built.Text ?? "", built.Foreground);
+            }
+        }
+
+        /// <summary>
+        /// A blank line inside a section stays inside the same block, so a selection can run straight
+        /// through it. Only a structural element breaks the block.
+        /// </summary>
+        public void AddBlankLine()
+        {
+            if (_hasLine)
+                _pending.Add(new LineBreak());
+        }
+
+        /// <summary>
+        /// Emits everything collected so far as one selectable block, and resets. Safe to call when
+        /// nothing is pending — callers flush before every structural element rather than tracking
+        /// whether they need to.
+        /// </summary>
+        public void Flush(Panel panel)
+        {
+            if (!_hasLine)
+            {
+                _pending.Clear();
+                return;
+            }
+
+            var block = new SelectableTextBlock
+            {
+                FontFamily = MonoFont,
+                FontSize = 12,
+                Foreground = ValueBrush,
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Avalonia.Thickness(0, 1)
+            };
+
+            foreach (var inline in _pending)
+                block.Inlines!.Add(inline);
+
+            panel.Children.Add(block);
+
+            _pending.Clear();
+            _hasLine = false;
+        }
+    }
+}

--- a/src/PlanViewer.App/Services/AdviceContentBuilder.Selection.cs
+++ b/src/PlanViewer.App/Services/AdviceContentBuilder.Selection.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Controls.Documents;

--- a/src/PlanViewer.App/Services/AdviceContentBuilder.Selection.cs
+++ b/src/PlanViewer.App/Services/AdviceContentBuilder.Selection.cs
@@ -53,11 +53,17 @@ internal static partial class AdviceContentBuilder
             AddLine(indentPixels, new Run(text) { Foreground = foreground });
 
         /// <summary>
-        /// Folds in the runs a helper already built for a single line — SQL keyword highlighting, the
-        /// SNIFFING marker — instead of letting that line stand alone as its own block.
+        /// Folds in the runs a helper already built for a single line — SQL keyword highlighting —
+        /// instead of letting that line stand alone as its own block.
+        ///
+        /// <para>The indent comes from the block the helper built, not from the caller. The helper
+        /// expressed it as a Margin, and a Margin is exactly what is lost when its runs move into a
+        /// shared block; making the caller restate the number is how the SQL indent got dropped on
+        /// the first cut of this.</para>
         /// </summary>
-        public void AddLine(double indentPixels, SelectableTextBlock built)
+        public void AddLine(SelectableTextBlock built)
         {
+            var indentPixels = built.Margin.Left;
             if (built.Inlines is { Count: > 0 })
             {
                 // Moved rather than shared: an Inline belongs to one block at a time.

--- a/src/PlanViewer.App/Services/AdviceContentBuilder.cs
+++ b/src/PlanViewer.App/Services/AdviceContentBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/src/PlanViewer.App/Services/AdviceContentBuilder.cs
+++ b/src/PlanViewer.App/Services/AdviceContentBuilder.cs
@@ -174,7 +174,7 @@ internal static partial class AdviceContentBuilder
             // Statement text (SQL) — highlight keywords
             if (isStatementText)
             {
-                body.AddLine(0, BuildSqlHighlightedLine(line));
+                body.AddLine(BuildSqlHighlightedLine(line));
                 continue;
             }
 

--- a/src/PlanViewer.App/Services/AdviceContentBuilder.cs
+++ b/src/PlanViewer.App/Services/AdviceContentBuilder.cs
@@ -214,13 +214,6 @@ internal static partial class AdviceContentBuilder
             // SNIFFING marker
             if (line.Contains("[SNIFFING]"))
             {
-                var tb = new SelectableTextBlock
-                {
-                    FontFamily = MonoFont,
-                    FontSize = 12,
-                    TextWrapping = TextWrapping.Wrap,
-                    Margin = new Avalonia.Thickness(12, 1, 0, 1)
-                };
                 var sniffIdx = line.IndexOf("[SNIFFING]");
                 body.AddLine(
                     12,

--- a/src/PlanViewer.App/Services/AdviceContentBuilder.cs
+++ b/src/PlanViewer.App/Services/AdviceContentBuilder.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -87,6 +87,8 @@ internal static partial class AdviceContentBuilder
     {
         var panel = new StackPanel { Margin = new Avalonia.Thickness(4, 0) };
         var lines = content.Split('\n');
+        // #503: consecutive body lines go into one selectable block instead of one per line.
+        var body = new BodyTextAccumulator();
         var inCodeBlock = false;
         var codeBlockIndent = 0;
         var isStatementText = false;
@@ -107,11 +109,17 @@ internal static partial class AdviceContentBuilder
                 {
                     var card = CreateTriageSummaryCard(analysis.Statements[statementIndex]);
                     if (card != null)
+                    {
+                        body.Flush(panel);
                         panel.Children.Add(card);
+                    }
                     needsTriageCard = false;
                 }
 
-                panel.Children.Add(new Border { Height = 8 });
+                // Kept inside the current block: a blank line between a section's lines belongs to
+                // that section, and breaking here would drop a selection boundary in the middle of
+                // what the user is dragging across.
+                body.AddBlankLine();
                 inCodeBlock = false;
                 isStatementText = false;
                 inSubSection = false;
@@ -124,6 +132,8 @@ internal static partial class AdviceContentBuilder
                 inCodeBlock = false;
                 isStatementText = false;
                 inSubSection = false;
+
+                body.Flush(panel);
 
                 // Strip === markers, just show the text
                 var headerText = line.Trim('=', ' ');
@@ -164,23 +174,26 @@ internal static partial class AdviceContentBuilder
             // Statement text (SQL) — highlight keywords
             if (isStatementText)
             {
-                panel.Children.Add(BuildSqlHighlightedLine(line));
+                body.AddLine(0, BuildSqlHighlightedLine(line));
                 continue;
             }
 
             // Warning lines: [Critical], [Warning], [Info] — with left accent border
             if (line.Contains("[Critical]"))
             {
+                body.Flush(panel);
                 panel.Children.Add(CreateWarningBlock(line, CriticalBrush));
                 continue;
             }
             if (line.Contains("[Warning]"))
             {
+                body.Flush(panel);
                 panel.Children.Add(CreateWarningBlock(line, WarningBrush));
                 continue;
             }
             if (line.Contains("[Info]"))
             {
+                body.Flush(panel);
                 panel.Children.Add(CreateWarningBlock(line, InfoBrush));
                 continue;
             }
@@ -190,15 +203,10 @@ internal static partial class AdviceContentBuilder
             // Grouped explanation line: "  -> The overestimate may have..."
             if (trimmed.StartsWith("-> "))
             {
-                panel.Children.Add(new SelectableTextBlock
+                body.AddLine(20, new Run(trimmed[3..])
                 {
-                    Text = trimmed[3..],
-                    FontFamily = MonoFont,
-                    FontSize = 12,
                     FontStyle = Avalonia.Media.FontStyle.Italic,
-                    Foreground = MutedBrush,
-                    Margin = new Avalonia.Thickness(20, 2, 0, 4),
-                    TextWrapping = TextWrapping.Wrap
+                    Foreground = MutedBrush
                 });
                 continue;
             }
@@ -214,16 +222,17 @@ internal static partial class AdviceContentBuilder
                     Margin = new Avalonia.Thickness(12, 1, 0, 1)
                 };
                 var sniffIdx = line.IndexOf("[SNIFFING]");
-                tb.Inlines!.Add(new Run(line[..sniffIdx].TrimStart()) { Foreground = ValueBrush });
-                tb.Inlines.Add(new Run("[SNIFFING]")
-                    { Foreground = CriticalBrush, FontWeight = FontWeight.SemiBold });
-                panel.Children.Add(tb);
+                body.AddLine(
+                    12,
+                    new Run(line[..sniffIdx].TrimStart()) { Foreground = ValueBrush },
+                    new Run("[SNIFFING]") { Foreground = CriticalBrush, FontWeight = FontWeight.SemiBold });
                 continue;
             }
 
             // Missing index impact line: "dbo.Posts (impact: 95%)"
             if (trimmed.Contains("(impact:") && trimmed.EndsWith("%)"))
             {
+                body.Flush(panel);
                 panel.Children.Add(CreateMissingIndexImpactLine(trimmed));
                 continue;
             }
@@ -252,15 +261,7 @@ internal static partial class AdviceContentBuilder
                     ? new string(' ', codeBlockIndent) + trimmed
                     : line;
 
-                panel.Children.Add(new SelectableTextBlock
-                {
-                    Text = displayLine,
-                    FontFamily = MonoFont,
-                    FontSize = 12,
-                    Foreground = CodeBrush,
-                    TextWrapping = TextWrapping.Wrap,
-                    Margin = new Avalonia.Thickness(12, 1, 0, 1)
-                });
+                body.AddLine(12, displayLine, CodeBrush);
                 continue;
             }
 
@@ -295,6 +296,7 @@ internal static partial class AdviceContentBuilder
                     }
                 }
                 i = peekIdx - 1; // skip consumed lines
+                body.Flush(panel);
                 panel.Children.Add(CreateOperatorGroup(line, timingLine, statsLine));
                 continue;
             }
@@ -303,6 +305,7 @@ internal static partial class AdviceContentBuilder
             if ((trimmed.Contains("ms CPU") || trimmed.Contains("ms elapsed"))
                 && trimmed.Length > 0 && char.IsDigit(trimmed[0]))
             {
+                body.Flush(panel);
                 panel.Children.Add(CreateOperatorTimingLine(trimmed));
                 continue;
             }
@@ -312,15 +315,11 @@ internal static partial class AdviceContentBuilder
             if (IsSubSectionLabel(trimmed))
             {
                 inSubSection = true;
-                panel.Children.Add(new SelectableTextBlock
+                body.AddLine(8, new Run(trimmed)
                 {
-                    Text = trimmed,
-                    FontFamily = MonoFont,
                     FontSize = 13,
                     FontWeight = FontWeight.SemiBold,
-                    Foreground = LabelBrush,
-                    Margin = new Avalonia.Thickness(8, 6, 0, 4),
-                    TextWrapping = TextWrapping.Wrap
+                    Foreground = LabelBrush
                 });
                 continue;
             }
@@ -328,15 +327,7 @@ internal static partial class AdviceContentBuilder
             // Bullet lines: "   * ..."
             if (trimmed.StartsWith("* "))
             {
-                panel.Children.Add(new SelectableTextBlock
-                {
-                    Text = line,
-                    FontFamily = MonoFont,
-                    FontSize = 12,
-                    Foreground = MutedBrush,
-                    Margin = new Avalonia.Thickness(12, 1, 0, 1),
-                    TextWrapping = TextWrapping.Wrap
-                });
+                body.AddLine(12, line, MutedBrush);
                 continue;
             }
 
@@ -380,6 +371,7 @@ internal static partial class AdviceContentBuilder
                         }
 
                         // Render all lines with consistent scaling
+                        body.Flush(panel);
                         foreach (var (name, val) in waitGroup)
                             panel.Children.Add(CreateWaitStatLine(name, val, maxWaitMs));
 
@@ -396,31 +388,19 @@ internal static partial class AdviceContentBuilder
                 if (labelPart.Length < 40 && !labelPart.Contains('(') && !labelPart.Contains('='))
                 {
                     var indent = inSubSection ? 12.0 : 8.0;
-                    var tb = new SelectableTextBlock
-                    {
-                        FontFamily = MonoFont,
-                        FontSize = 12,
-                        TextWrapping = TextWrapping.Wrap,
-                        Margin = new Avalonia.Thickness(indent, 1, 0, 1)
-                    };
-                    tb.Inlines!.Add(new Run(labelPart + ":") { Foreground = LabelBrush });
-                    tb.Inlines.Add(new Run(line[(colonIdx + 1)..]) { Foreground = ValueBrush });
-                    panel.Children.Add(tb);
+                    body.AddLine(
+                        indent,
+                        new Run(labelPart + ":") { Foreground = LabelBrush },
+                        new Run(line[(colonIdx + 1)..]) { Foreground = ValueBrush });
                     continue;
                 }
             }
 
             // Default: regular text
-            panel.Children.Add(new SelectableTextBlock
-            {
-                Text = line,
-                FontFamily = MonoFont,
-                FontSize = 12,
-                Foreground = ValueBrush,
-                TextWrapping = TextWrapping.Wrap,
-                Margin = new Avalonia.Thickness(0, 1)
-            });
+            body.AddLine(0, line, ValueBrush);
         }
+
+        body.Flush(panel);
 
         // Post-process: make "Node N" references clickable
         if (onNodeClick != null)

--- a/tests/PlanViewer.Core.Tests/AdviceSelectionTests.cs
+++ b/tests/PlanViewer.Core.Tests/AdviceSelectionTests.cs
@@ -90,6 +90,25 @@ public class AdviceSelectionTests
         });
     }
 
+    /// <summary>
+    /// A helper that builds a line expresses its indent as a Margin, and a Margin is precisely what
+    /// is lost when the runs move into a shared block. The first cut of this dropped the SQL indent
+    /// that way, so the indent is pinned here rather than trusted.
+    /// </summary>
+    [Fact]
+    public void StatementSqlKeepsItsIndentAfterMerging()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var body = BodyBlocks("=== Statement 1 ===\nSELECT p.Id\nFROM dbo.Posts AS p\n").Single();
+
+            body.SelectAll();
+
+            // 8px of Margin becomes a leading space at the pane's monospace body size.
+            Assert.StartsWith(" SELECT", body.SelectedText);
+        });
+    }
+
     [Fact]
     public void TheSectionHeaderIsStillItsOwnBlock()
     {

--- a/tests/PlanViewer.Core.Tests/AdviceSelectionTests.cs
+++ b/tests/PlanViewer.Core.Tests/AdviceSelectionTests.cs
@@ -158,6 +158,30 @@ public class AdviceSelectionTests
         });
     }
 
+    /// <summary>
+    /// Two runs can carry the same text — the same node referenced on two lines. Locating each run by
+    /// searching forward from the previous one has to land on the second occurrence for the second
+    /// run, not re-find the first.
+    /// </summary>
+    [Fact]
+    public void RepeatedRunTextResolvesToTheRightOccurrence()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var first = new Run("Node 4");
+            var second = new Run("Node 4");
+            var block = new SelectableTextBlock();
+            block.Inlines!.Add(first);
+            block.Inlines.Add(new LineBreak());
+            block.Inlines.Add(second);
+
+            var secondIndex = block.Inlines.Text!.LastIndexOf("Node 4", System.StringComparison.Ordinal);
+
+            Assert.Same(first, AdviceContentBuilder.RunAtCharIndex(block, 0));
+            Assert.Same(second, AdviceContentBuilder.RunAtCharIndex(block, secondIndex));
+        });
+    }
+
     // ---------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------

--- a/tests/PlanViewer.Core.Tests/AdviceSelectionTests.cs
+++ b/tests/PlanViewer.Core.Tests/AdviceSelectionTests.cs
@@ -1,0 +1,132 @@
+using Avalonia.Controls;
+using PlanViewer.App.Services;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #503: the advice pane put every line in its own <see cref="SelectableTextBlock"/>, and Avalonia
+/// gives each one its own selection with nothing coordinating a drag between them. So a selection
+/// could never be longer than a single line — the reporter could grab a one-line query but not
+/// Server Context, Parameters, or Missing indexes, which are several lines each. Copying everything
+/// into Notepad was the only way to get a piece of it.
+///
+/// <para>These assert on selection rather than on the control tree, because "one block per section"
+/// is the mechanism and "a drag covers more than one line" is the thing that was broken.</para>
+/// </summary>
+public class AdviceSelectionTests
+{
+    private const string ServerContext =
+        "=== Server Context ===\n"
+        + "SQL Server: 16.0.1000\n"
+        + "Edition: Developer\n"
+        + "Cores: 8\n"
+        + "Max server memory: 32768 MB\n";
+
+    [Fact]
+    public void ASectionsBodyIsOneSelectionCoveringEveryLineInIt()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var body = BodyBlocks(ServerContext).Single();
+
+            body.SelectAll();
+
+            // The whole point: one drag reaches the first value and the last one.
+            Assert.Contains("16.0.1000", body.SelectedText);
+            Assert.Contains("Developer", body.SelectedText);
+            Assert.Contains("32768 MB", body.SelectedText);
+        });
+    }
+
+    [Fact]
+    public void ABlankLineInsideASectionDoesNotSplitTheSelection()
+    {
+        HeadlessUi.Run(() =>
+        {
+            // A blank line is a paragraph break in the text, not a section break, so a drag has to
+            // run straight through it.
+            var body = BodyBlocks("=== Server Context ===\nEdition: Developer\n\nCores: 8\n").Single();
+
+            body.SelectAll();
+
+            Assert.Contains("Developer", body.SelectedText);
+            Assert.Contains("Cores", body.SelectedText);
+        });
+    }
+
+    [Fact]
+    public void AMultiLineQueryIsOneSelection()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var body = BodyBlocks(
+                "=== Statement 1 ===\nSELECT p.Id\nFROM dbo.Posts AS p\nWHERE p.Score > 10;\n").Single();
+
+            body.SelectAll();
+
+            Assert.Contains("SELECT", body.SelectedText);
+            Assert.Contains("FROM", body.SelectedText);
+            Assert.Contains("WHERE", body.SelectedText);
+        });
+    }
+
+    /// <summary>
+    /// Warning blocks are Bordered cards, not text runs, so they cannot join a text block. They still
+    /// break the body either side of them — that is the ceiling on what merging can do here, and it
+    /// is worth pinning so a later change does not quietly assume the whole pane is one selection.
+    /// </summary>
+    [Fact]
+    public void AWarningCardStillStandsOnItsOwnAndSplitsTheBodyEitherSide()
+    {
+        HeadlessUi.Run(() =>
+        {
+            // Deliberately not a "Statement" header: that sets isStatementText, and every line after
+            // it takes the SQL path without ever reaching the severity checks.
+            var panel = Build(
+                "=== Warnings ===\nEdition: Developer\n[Critical] Something is wrong\nCores: 8\n");
+
+            Assert.Single(panel.Children.OfType<Border>());
+            Assert.Equal(2, BodyBlocks(panel).Count);
+        });
+    }
+
+    [Fact]
+    public void TheSectionHeaderIsStillItsOwnBlock()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var panel = Build(ServerContext);
+
+            // Header block + one body block. The header keeps its own size and weight, which a Run
+            // inside the body could carry but which would let a drag start mid-title.
+            Assert.Equal(2, panel.Children.OfType<SelectableTextBlock>().Count());
+            Assert.Equal("Server Context", FirstBlock(panel).Text);
+        });
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private static StackPanel Build(string content)
+    {
+        var panel = AdviceContentBuilder.Build(content);
+
+        // Selection needs a laid-out control attached to a TopLevel.
+        var window = new Window { Content = panel, Width = 1000, Height = 700 };
+        window.Show();
+        window.UpdateLayout();
+
+        return panel;
+    }
+
+    private static SelectableTextBlock FirstBlock(StackPanel panel) =>
+        panel.Children.OfType<SelectableTextBlock>().First();
+
+    /// <summary>The body blocks: every selectable block except the section header.</summary>
+    private static System.Collections.Generic.List<SelectableTextBlock> BodyBlocks(StackPanel panel) =>
+        panel.Children.OfType<SelectableTextBlock>().Skip(1).ToList();
+
+    private static System.Collections.Generic.List<SelectableTextBlock> BodyBlocks(string content) =>
+        BodyBlocks(Build(content));
+}

--- a/tests/PlanViewer.Core.Tests/AdviceSelectionTests.cs
+++ b/tests/PlanViewer.Core.Tests/AdviceSelectionTests.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
 using Avalonia.Controls.Documents;
 using PlanViewer.App.Services;
 

--- a/tests/PlanViewer.Core.Tests/AdviceSelectionTests.cs
+++ b/tests/PlanViewer.Core.Tests/AdviceSelectionTests.cs
@@ -1,4 +1,5 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
+using Avalonia.Controls.Documents;
 using PlanViewer.App.Services;
 
 namespace PlanViewer.Core.Tests;
@@ -120,6 +121,40 @@ public class AdviceSelectionTests
             // inside the body could carry but which would let a drag start mid-title.
             Assert.Equal(2, panel.Children.OfType<SelectableTextBlock>().Count());
             Assert.Equal("Server Context", FirstBlock(panel).Text);
+        });
+    }
+
+    /// <summary>
+    /// Merging lines put LineBreaks between them, and a LineBreak occupies a position in the
+    /// laid-out text while exposing no Text of its own. The Node-link hit test walked Runs only, so
+    /// every offset past the first line slid backwards and a "Node N" on a later line resolved to
+    /// the wrong run. Checks the arithmetic directly rather than through a laid-out click, which
+    /// would be testing the font.
+    /// </summary>
+    [Fact]
+    public void NodeLinkHitTestingSurvivesTheLineBreaksBetweenMergedLines()
+    {
+        HeadlessUi.Run(() =>
+        {
+            var link = new Run("Node 42")
+            {
+                TextDecorations = Avalonia.Media.TextDecorations.Underline
+            };
+            var block = new SelectableTextBlock();
+            block.Inlines!.Add(new Run("first line, Node 1"));
+            block.Inlines.Add(new LineBreak());
+            block.Inlines.Add(new Run("second line, "));
+            block.Inlines.Add(link);
+
+            // The index the layout would report for the link's own text.
+            var index = block.Inlines.Text!.IndexOf("Node 42", System.StringComparison.Ordinal);
+            Assert.True(index > 0, "fixture should place the link after the break");
+
+            Assert.Same(link, AdviceContentBuilder.RunAtCharIndex(block, index));
+            Assert.Same(link, AdviceContentBuilder.RunAtCharIndex(block, index + 3));
+
+            // And the run before the break still resolves to itself.
+            Assert.Equal("first line, Node 1", AdviceContentBuilder.RunAtCharIndex(block, 0)!.Text);
         });
     }
 


### PR DESCRIPTION
Fixes #503.

## The cause

Not a missing `SelectableTextBlock` — every text element in the advice pane already was one (15 across the four builder files, zero plain `TextBlock`). The problem is structural.

`AdviceContentBuilder.Build` added **one control per line**. Avalonia gives each `SelectableTextBlock` its own selection — the entire API is `SelectionStart`/`SelectionEnd`/`SelectedText`/`SelectAll`/`Copy` on the individual control — and nothing coordinates a drag that starts in one and ends in another.

So a selection could never be longer than a single line. The reporter could grab a one-line query; Server Context, Parameters and Missing indexes are several lines each, so dragging over them yielded nothing usable. His copy-all-into-Notepad workaround is the exact shape of that limitation.

## The fix

`BodyTextAccumulator` collects consecutive body lines into a single `SelectableTextBlock` built from `Inlines`, so a drag across those lines is an ordinary selection. Every text path in `Build` routes through it — statement SQL, key/value pairs, bullets, code blocks, `->` explanations, the `[SNIFFING]` marker, sub-section labels, plain text — and flushes before anything structural.

Two consequences worth calling out:

- **Blank lines no longer break the block.** They used to emit an 8px spacer `Border`, which would have split every section at its first paragraph break. They're now a `LineBreak` inside the same block, so a drag runs straight through.
- **Indentation moved from control margins to leading spaces.** Only safe because the pane is monospace throughout; in a proportional font this wouldn't hold.

## The ceiling

Selection now spans a **section body**, not the whole window. Warning blocks, operator groups, wait-stat bars and the triage card are `Border`-wrapped composites, not text runs, so they can't join a text block and still interrupt a drag. Getting past that needs a cross-control selection manager, which the framework gives no help with.

`AWarningCardStillStandsOnItsOwnAndSplitsTheBodyEitherSide` pins this deliberately, so a later change doesn't quietly assume the whole pane is one selection.

## Worth eyeballing before merge

Line spacing inside section bodies. Each line previously carried `Margin(…, 1, 0, 1)`; they're now line breaks within one block, and the 8px blank-line spacer is gone. Functionally correct and tested, but it's a small visual delta I have no way to verify from a headless run.

## Tests

Five new, full suite green at 514 (513 passed, 1 pre-existing skip, 0 failed). They assert on `SelectAll()` + `SelectedText` rather than on the control tree, because "a drag covers more than one line" is what was broken.

- a section's body is one selection reaching its first and last values
- a blank line inside a section doesn't split it
- a multi-line query is one selection
- a warning card still stands alone and splits the body either side
- the section header is still its own block

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nD83xZyWPzKWhs7Gg9Vyq