### PR TITLE
Drop the BOMs #504 added to three files

### DIFF
--- a/src/PlanViewer.App/Controls/PlanViewerControl.Statements.cs
+++ b/src/PlanViewer.App/Controls/PlanViewerControl.Statements.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Avalonia;

--- a/src/PlanViewer.Core/Models/PlanModels.cs
+++ b/src/PlanViewer.Core/Models/PlanModels.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace PlanViewer.Core.Models;

--- a/src/PlanViewer.Core/Services/PlanAnalyzer.Statement.cs
+++ b/src/PlanViewer.Core/Services/PlanAnalyzer.Statement.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;


### PR DESCRIPTION
Follow-up to #504, flagged by the review on #505.

The scripted edits behind #504 read files with `utf-8-sig` and wrote them back with `utf-8-sig` — which strips a BOM on the way in and adds one on the way out. Three files that had no BOM before came out with one:

- `src/PlanViewer.Core/Models/PlanModels.cs`
- `src/PlanViewer.Core/Services/PlanAnalyzer.Statement.cs`
- `src/PlanViewer.App/Controls/PlanViewerControl.Statements.cs`

Their neighbours in the same projects still have none, so this is inconsistent as well as unintended.

No behavior change — the compiler doesn't care. What it costs is the first line of every future diff of these files showing as changed. #505 stripped the equivalent BOMs from its own files before merging; this catches the ones that landed first.

`dotnet build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nD83xZyWPzKWhs7Gg9Vyq