### PR TITLE
Say why a custom time range was rejected instead of quietly changing it

### DIFF
--- a/src/PlanViewer.App/Controls/TimeRangeSlicerControl.axaml
+++ b/src/PlanViewer.App/Controls/TimeRangeSlicerControl.axaml
@@ -75,6 +75,12 @@
                                                 MinuteIncrement="15"/>
                                 </StackPanel>
                             </StackPanel>
+                            <!-- Says what is wrong instead of quietly moving the end time (#507) -->
+                            <TextBlock x:Name="RangeValidationMessage"
+                                       IsVisible="False"
+                                       FontSize="11"
+                                       TextWrapping="Wrap"
+                                       Foreground="{DynamicResource SlicerValidationBrush}"/>
                             <!-- Action buttons -->
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8"
                                         Margin="0,4,0,0">

--- a/src/PlanViewer.App/Controls/TimeRangeSlicerControl.axaml.cs
+++ b/src/PlanViewer.App/Controls/TimeRangeSlicerControl.axaml.cs
@@ -160,6 +160,7 @@ public partial class TimeRangeSlicerControl : UserControl
     private void CustomFilter_Click(object? sender, RoutedEventArgs e)
     {
         PopulatePickersFromSelection();
+        ClearRangeValidation();
         DateTimePopup.IsOpen = true;
     }
 
@@ -172,19 +173,28 @@ public partial class TimeRangeSlicerControl : UserControl
         var endDate = EndDatePicker.SelectedDate;
         var endTime = EndTimePicker.SelectedTime;
 
-        if (!startDate.HasValue || !endDate.HasValue) { DateTimePopup.IsOpen = false; return; }
+        // Convert display time back to UTC. Null until both halves of a bound are present.
+        DateTime? startUtc = startDate.HasValue
+            ? ConvertFromDisplay(startDate.Value.Date + (startTime ?? TimeSpan.Zero))
+            : null;
+        DateTime? endUtc = endDate.HasValue
+            ? ConvertFromDisplay(endDate.Value.Date + (endTime ?? TimeSpan.Zero))
+            : null;
 
-        var startDt = startDate.Value.Date + (startTime ?? TimeSpan.Zero);
-        var endDt = endDate.Value.Date + (endTime ?? TimeSpan.Zero);
+        /* #507: this used to close the popup on a missing date and quietly rewrite an end that
+           landed before the start, both of which read as the picker ignoring what you typed. Say
+           what is wrong and stay open on the entered values so they can be seen and corrected. */
+        var problem = DescribeRangeProblem(startUtc, endUtc);
+        if (problem != null)
+        {
+            ShowRangeValidation(problem);
+            return;
+        }
 
-        // Convert display time back to UTC
-        var startUtc = ConvertFromDisplay(startDt);
-        var endUtc = ConvertFromDisplay(endDt);
+        ClearRangeValidation();
 
-        if (endUtc <= startUtc) endUtc = startUtc.AddHours(1);
-
-        _rangeStart = GetNormFromDateTime(startUtc);
-        _rangeEnd = GetNormFromDateTime(endUtc);
+        _rangeStart = GetNormFromDateTime(startUtc!.Value);
+        _rangeEnd = GetNormFromDateTime(endUtc!.Value);
 
         // Enforce minimum interval
         if (_rangeEnd - _rangeStart < MinNormInterval)
@@ -248,6 +258,47 @@ public partial class TimeRangeSlicerControl : UserControl
             }
         }
     }
+
+    /// <summary>
+    /// What is wrong with an entered custom range, or null when it can be applied (#507).
+    ///
+    /// <para>Separate from the click handler and static so the rule can be tested without standing up
+    /// a popup and driving two CalendarDatePickers, and so that adding a rule later means changing
+    /// one method rather than the middle of an event handler.</para>
+    /// </summary>
+    internal static string? DescribeRangeProblem(DateTime? startUtc, DateTime? endUtc)
+    {
+        if (!startUtc.HasValue || !endUtc.HasValue)
+            return "Pick both a start and an end date.";
+
+        if (endUtc.Value == startUtc.Value)
+            return "Start and end are the same. The end has to be after the start.";
+
+        if (endUtc.Value < startUtc.Value)
+            return "The end is before the start. Swap them, or move the end later.";
+
+        return null;
+    }
+
+    /// <summary>
+    /// Shows why the entered range was not applied, leaving the popup open on the values that caused
+    /// it. Internal so a test can read the message a given pair of inputs produces (#507).
+    /// </summary>
+    internal void ShowRangeValidation(string message)
+    {
+        RangeValidationMessage.Text = message;
+        RangeValidationMessage.IsVisible = true;
+    }
+
+    internal void ClearRangeValidation()
+    {
+        RangeValidationMessage.Text = "";
+        RangeValidationMessage.IsVisible = false;
+    }
+
+    /// <summary>The validation text currently shown, or null when the popup is not complaining.</summary>
+    internal string? CurrentRangeValidation =>
+        RangeValidationMessage.IsVisible ? RangeValidationMessage.Text : null;
 
     private void PopulatePickersFromSelection()
     {

--- a/src/PlanViewer.App/Themes/DarkTheme.axaml
+++ b/src/PlanViewer.App/Themes/DarkTheme.axaml
@@ -71,6 +71,8 @@
     <SolidColorBrush x:Key="SlicerBorderBrush" Color="#3A3D45"/>
     <SolidColorBrush x:Key="SlicerLabelBrush" Color="#E4E6EB"/>
     <SolidColorBrush x:Key="SlicerToggleBrush" Color="#E4E6EB"/>
+    <!-- Custom range validation text. Same red the advice pane uses for Critical. -->
+    <SolidColorBrush x:Key="SlicerValidationBrush" Color="#E57373"/>
 
     <!-- Wait Stats category colors (fixed per category) -->
     <SolidColorBrush x:Key="WaitCategory.Unknown"            Color="#8E8E93"/>

--- a/tests/PlanViewer.Core.Tests/CustomTimeRangeValidationTests.cs
+++ b/tests/PlanViewer.Core.Tests/CustomTimeRangeValidationTests.cs
@@ -1,0 +1,66 @@
+using PlanViewer.App.Controls;
+
+namespace PlanViewer.Core.Tests;
+
+/// <summary>
+/// #507: the custom range popup used to close itself when a date was missing, and quietly move the
+/// end to an hour after the start when the end landed first. Both read as the picker ignoring what
+/// was typed, which is what the reporter concluded.
+/// </summary>
+public class CustomTimeRangeValidationTests
+{
+    private static readonly System.DateTime Noon = new(2026, 9, 4, 12, 0, 0, System.DateTimeKind.Utc);
+
+    [Fact]
+    public void AnOrderedRangeIsAccepted()
+    {
+        Assert.Null(TimeRangeSlicerControl.DescribeRangeProblem(Noon, Noon.AddHours(3)));
+    }
+
+    [Fact]
+    public void AnEndBeforeTheStartIsRefusedInsteadOfMoved()
+    {
+        var problem = TimeRangeSlicerControl.DescribeRangeProblem(Noon, Noon.AddHours(-3));
+
+        Assert.NotNull(problem);
+        Assert.Contains("before the start", problem);
+    }
+
+    /// <summary>
+    /// Equal bounds are their own message: "before the start" would be wrong, and the old code turned
+    /// this into a silent one-hour range.
+    /// </summary>
+    [Fact]
+    public void EqualStartAndEndSaysSoOnItsOwnTerms()
+    {
+        var problem = TimeRangeSlicerControl.DescribeRangeProblem(Noon, Noon);
+
+        Assert.NotNull(problem);
+        Assert.Contains("same", problem);
+        Assert.DoesNotContain("before the start", problem);
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public void AMissingDateIsReportedRatherThanClosingThePopup(bool hasStart, bool hasEnd)
+    {
+        var problem = TimeRangeSlicerControl.DescribeRangeProblem(
+            hasStart ? Noon : null,
+            hasEnd ? Noon.AddHours(1) : null);
+
+        Assert.NotNull(problem);
+        Assert.Contains("both", problem);
+    }
+
+    /// <summary>
+    /// A minute apart is a legitimate range to enter. The slicer widens it to one hourly bucket when
+    /// it applies, which is a property of Query Store's aggregation, not a reason to refuse the input.
+    /// </summary>
+    [Fact]
+    public void AVeryShortRangeIsStillAValidEntry()
+    {
+        Assert.Null(TimeRangeSlicerControl.DescribeRangeProblem(Noon, Noon.AddMinutes(1)));
+    }
+}


### PR DESCRIPTION
Part of #507.

## Two silent failures

The custom range popup had two, and both read as the picker ignoring what you typed — which is the conclusion the reporter reached:

- an end at or before the start was rewritten to an hour after the start (`endUtc = startUtc.AddHours(1)`) and applied
- a missing date just closed the popup

Neither said anything. Both now refuse, name the problem, and leave the popup open on the entered values so they can be seen and corrected.

Equal bounds get their own message. "The end is before the start" isn't true there, and equal bounds are exactly the case the old code turned into a silent one-hour range.

## Shape

The rule is a static `DescribeRangeProblem(startUtc, endUtc)` rather than more branches inside the click handler: testable without standing up a popup and driving two `CalendarDatePicker`s, and the next rule is one method to change instead of surgery in an event handler.

`DarkTheme.axaml` had no error colour, so `SlicerValidationBrush` is added beside the other slicer brushes, reusing the `#E57373` the advice pane already uses for Critical.

## Deliberately unchanged

A sub-hour range still widens to one hourly bucket when applied. That's Query Store's aggregation interval (`INTERVAL_LENGTH_MINUTES`, default 60), not bad input, and the range label already shows what was applied. A test pins a one-minute range as *valid input* so this doesn't later get "fixed" into an error.

## The other half of the issue doesn't exist

I'd told the reporter the pickers were limited to the currently loaded range and that he'd need to click 7d/30d to load more. That was wrong, and I've corrected it on the issue.

`QuickFilter_Click` only moves the selection inside data that is already loaded — `OnTimeRangeChanged` refetches plans, never slicer data. `_data` holds the full `QueryStoreSlicerDays` window (default 30), so the calendar always spans that whole window regardless of which quick filter is active. Nothing to fix.

## Tests

Seven new; suite green at 525 (524 passed, 1 pre-existing skip, 0 failed).

Ordered range accepted; end-before-start refused; equal bounds get their own wording; each of the three missing-date combinations reported; a one-minute range still valid input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nD83xZyWPzKWhs7Gg9Vyq